### PR TITLE
Claude Feature parity

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -5,6 +5,39 @@ All notable changes to this project will be documented in this file.
 The format is based on [Keep a Changelog](https://keepachangelog.com/en/1.0.0/),
 and this project adheres to [Semantic Versioning](https://semver.org/spec/v2.0.0.html).
 
+## [0.4.3] - 2026-03-13
+
+### Added
+- **Persistent agent memory** — new `memory` frontmatter field with three scopes: `"user"` (global `~/.pi/`), `"project"` (per-project `.pi/`), `"local"` (gitignored `.pi/`). Agents with write/edit tools get full read-write memory; read-only agents get a read-only fallback that injects existing MEMORY.md content without granting write access or creating directories.
+- **Git worktree isolation** — new `isolation: "worktree"` frontmatter field and Agent tool parameter. Creates a temporary `git worktree` so agents work on an isolated copy of the repo. On completion, changes are auto-committed to a `pi-agent-<id>` branch; clean worktrees are removed. Includes crash recovery via `pruneWorktrees()`.
+- **Skill preloading** — `skills` frontmatter now accepts a comma-separated list of skill names (e.g. `skills: planning, review`). Reads from `.pi/skills/` (project) then `~/.pi/skills/` (global), tries `.md`/`.txt`/bare extensions. Content injected into the system prompt as `# Preloaded Skill: {name}`.
+- **Tool denylist** — new `disallowed_tools` frontmatter field (e.g. `disallowed_tools: bash, write`). Blocks specified tools even if `builtinToolNames` or extensions would provide them. Enforced for both extension-enabled and extension-disabled agents.
+- **Prompt extras system** — new `PromptExtras` interface in `prompts.ts`; `buildAgentPrompt()` accepts optional memory and skill blocks appended in both `replace` and `append` modes.
+- `getMemoryTools()`, `getReadOnlyMemoryTools()` in `agent-types.ts`.
+- `buildMemoryBlock()`, `buildReadOnlyMemoryBlock()`, `isSymlink()`, `safeReadFile()` in `memory.ts`.
+- `preloadSkills()` in `skill-loader.ts`.
+- `createWorktree()`, `cleanupWorktree()`, `pruneWorktrees()` in `worktree.ts`.
+- `MemoryScope`, `IsolationMode` types; `memory`, `isolation`, `disallowedTools` fields on `AgentConfig`; `worktree`, `worktreeResult` fields on `AgentRecord`.
+- 177 total tests across 8 test files (41 new tests).
+
+### Fixed
+- **Read-only agents no longer escalated to read-write** — enabling `memory` on a read-only agent (e.g. Explore) previously auto-added `write`/`edit` tools. Now the runner detects write capability and branches: read-write agents get full memory tools, read-only agents get read-only memory prompt with only the `read` tool added.
+- **Denylist-aware memory detection** — write capability check now accounts for `disallowedTools`. An agent with `tools: write` + `disallowed_tools: write` correctly gets read-only memory instead of broken read-write instructions.
+- **Worktree requires commits** — repos with no commits (empty HEAD) are now rejected early with a warning instead of failing silently at `git worktree add`.
+- **Worktree failure warning** — when worktree creation fails, a warning is prepended to the agent's prompt instead of silently falling through to the main cwd.
+- **No force-branch overwrite** — worktree cleanup appends a timestamp suffix on branch name conflict instead of using `git branch -f`.
+
+### Security
+- **Whitelist name validation** — agent/skill names must match `^[a-zA-Z0-9][a-zA-Z0-9._-]*$`, max 128 chars. Rejects path traversal, leading dots, spaces, and special characters.
+- **Symlink protection** — `safeReadFile()` and `isSymlink()` reject symlinks in memory directories, MEMORY.md files, and skill files, preventing arbitrary file reads.
+- **Symlink-safe directory creation** — `ensureMemoryDir()` throws on symlinked directories.
+
+### Changed
+- `agent-runner.ts`: tool/extension/skill resolution moved before memory detection; `ctx.cwd` → `effectiveCwd` throughout.
+- `custom-agents.ts`: extracted `parseCsvField()` helper; added `csvListOptional()` and `parseMemory()`.
+- `skill-loader.ts`: uses `safeReadFile()` from `memory.ts` instead of raw `readFileSync`.
+- Agent tool schema updated with `isolation` parameter and help text for `memory`, `isolation`, `disallowed_tools`, and skill list.
+
 ## [0.4.2] - 2026-03-12
 
 ### Added
@@ -209,6 +242,7 @@ Initial release.
 - **Thinking level** — per-agent extended thinking control
 - **`/agent` and `/agents` commands**
 
+[0.4.3]: https://github.com/tintinweb/pi-subagents/compare/v0.4.2...v0.4.3
 [0.4.2]: https://github.com/tintinweb/pi-subagents/compare/v0.4.1...v0.4.2
 [0.4.1]: https://github.com/tintinweb/pi-subagents/compare/v0.4.0...v0.4.1
 [0.4.0]: https://github.com/tintinweb/pi-subagents/compare/v0.3.1...v0.4.0

--- a/package.json
+++ b/package.json
@@ -1,6 +1,6 @@
 {
   "name": "@tintinweb/pi-subagents",
-  "version": "0.4.2",
+  "version": "0.4.3",
   "description": "A pi extension extension that brings smart Claude Code-style autonomous sub-agents to pi.",
   "author": "tintinweb",
   "license": "MIT",

--- a/src/agent-manager.ts
+++ b/src/agent-manager.ts
@@ -11,7 +11,8 @@ import type { ExtensionContext, ExtensionAPI } from "@mariozechner/pi-coding-age
 import type { Model } from "@mariozechner/pi-ai";
 import type { AgentSession } from "@mariozechner/pi-coding-agent";
 import { runAgent, resumeAgent, type ToolActivity } from "./agent-runner.js";
-import type { SubagentType, AgentRecord, ThinkingLevel } from "./types.js";
+import type { SubagentType, AgentRecord, ThinkingLevel, IsolationMode } from "./types.js";
+import { createWorktree, cleanupWorktree, pruneWorktrees, type WorktreeInfo } from "./worktree.js";
 
 export type OnAgentComplete = (record: AgentRecord) => void;
 export type OnAgentStart = (record: AgentRecord) => void;
@@ -35,6 +36,8 @@ interface SpawnOptions {
   inheritContext?: boolean;
   thinkingLevel?: ThinkingLevel;
   isBackground?: boolean;
+  /** Isolation mode — "worktree" creates a temp git worktree for the agent. */
+  isolation?: IsolationMode;
   /** Called on tool start/end with activity info (for streaming progress to UI). */
   onToolActivity?: (activity: ToolActivity) => void;
   /** Called on streaming text deltas from the assistant response. */
@@ -117,6 +120,17 @@ export class AgentManager {
     if (options.isBackground) this.runningBackground++;
     this.onStart?.(record);
 
+    // Worktree isolation: create a temporary git worktree if requested
+    let worktreeCwd: string | undefined;
+    if (options.isolation === "worktree") {
+      const wt = createWorktree(ctx.cwd, id);
+      if (wt) {
+        record.worktree = wt;
+        worktreeCwd = wt.path;
+      }
+      // If worktree creation fails (not a git repo, etc.), fall through to normal cwd
+    }
+
     const promise = runAgent(ctx, type, prompt, {
       pi,
       model: options.model,
@@ -124,6 +138,7 @@ export class AgentManager {
       isolated: options.isolated,
       inheritContext: options.inheritContext,
       thinkingLevel: options.thinkingLevel,
+      cwd: worktreeCwd,
       signal: record.abortController!.signal,
       onToolActivity: (activity) => {
         if (activity.type === "end") record.toolUses++;
@@ -143,6 +158,17 @@ export class AgentManager {
         record.result = responseText;
         record.session = session;
         record.completedAt ??= Date.now();
+
+        // Clean up worktree if used
+        if (record.worktree) {
+          const wtResult = cleanupWorktree(ctx.cwd, record.worktree, options.description);
+          record.worktreeResult = wtResult;
+          if (wtResult.hasChanges && wtResult.branch) {
+            record.result = (record.result ?? "") +
+              `\n\n---\nChanges saved to branch \`${wtResult.branch}\`. Merge with: \`git merge ${wtResult.branch}\``;
+          }
+        }
+
         if (options.isBackground) {
           this.runningBackground--;
           this.onComplete?.(record);
@@ -157,6 +183,15 @@ export class AgentManager {
         }
         record.error = err instanceof Error ? err.message : String(err);
         record.completedAt ??= Date.now();
+
+        // Best-effort worktree cleanup on error
+        if (record.worktree) {
+          try {
+            const wtResult = cleanupWorktree(ctx.cwd, record.worktree, options.description);
+            record.worktreeResult = wtResult;
+          } catch { /* ignore cleanup errors */ }
+        }
+
         if (options.isBackground) {
           this.runningBackground--;
           this.onComplete?.(record);
@@ -305,5 +340,7 @@ export class AgentManager {
       record.session?.dispose();
     }
     this.agents.clear();
+    // Prune any orphaned git worktrees (crash recovery)
+    try { pruneWorktrees(process.cwd()); } catch { /* ignore */ }
   }
 }

--- a/src/agent-manager.ts
+++ b/src/agent-manager.ts
@@ -122,16 +122,21 @@ export class AgentManager {
 
     // Worktree isolation: create a temporary git worktree if requested
     let worktreeCwd: string | undefined;
+    let worktreeWarning = "";
     if (options.isolation === "worktree") {
       const wt = createWorktree(ctx.cwd, id);
       if (wt) {
         record.worktree = wt;
         worktreeCwd = wt.path;
+      } else {
+        worktreeWarning = "\n\n[WARNING: Worktree isolation was requested but failed (not a git repo, or no commits yet). Running in the main working directory instead.]";
       }
-      // If worktree creation fails (not a git repo, etc.), fall through to normal cwd
     }
 
-    const promise = runAgent(ctx, type, prompt, {
+    // Prepend worktree warning to prompt if isolation failed
+    const effectivePrompt = worktreeWarning ? worktreeWarning + "\n\n" + prompt : prompt;
+
+    const promise = runAgent(ctx, type, effectivePrompt, {
       pi,
       model: options.model,
       maxTurns: options.maxTurns,

--- a/src/agent-runner.ts
+++ b/src/agent-runner.ts
@@ -13,10 +13,12 @@ import {
 } from "@mariozechner/pi-coding-agent";
 import type { ExtensionContext } from "@mariozechner/pi-coding-agent";
 import type { Model } from "@mariozechner/pi-ai";
-import { getToolsForType, getConfig, getAgentConfig } from "./agent-types.js";
-import { buildAgentPrompt } from "./prompts.js";
+import { getToolsForType, getConfig, getAgentConfig, getMemoryTools, getReadOnlyMemoryTools } from "./agent-types.js";
+import { buildAgentPrompt, type PromptExtras } from "./prompts.js";
 import { buildParentContext, extractText } from "./context.js";
 import { detectEnv } from "./env.js";
+import { buildMemoryBlock, buildReadOnlyMemoryBlock } from "./memory.js";
+import { preloadSkills } from "./skill-loader.js";
 import type { SubagentType, ThinkingLevel } from "./types.js";
 
 /** Names of tools registered by this extension that subagents must NOT inherit. */
@@ -84,6 +86,8 @@ export interface RunOptions {
   isolated?: boolean;
   inheritContext?: boolean;
   thinkingLevel?: ThinkingLevel;
+  /** Override working directory (e.g. for worktree isolation). */
+  cwd?: string;
   /** Called on tool start/end with activity info. */
   onToolActivity?: (activity: ToolActivity) => void;
   /** Called on streaming text deltas from the assistant response. */
@@ -136,15 +140,56 @@ export async function runAgent(
 ): Promise<RunResult> {
   const config = getConfig(type);
   const agentConfig = getAgentConfig(type);
-  const env = await detectEnv(options.pi, ctx.cwd);
+
+  // Resolve working directory: worktree override > parent cwd
+  const effectiveCwd = options.cwd ?? ctx.cwd;
+
+  const env = await detectEnv(options.pi, effectiveCwd);
 
   // Get parent system prompt for append-mode agents
   const parentSystemPrompt = ctx.getSystemPrompt();
 
+  // Build prompt extras (memory, skill preloading)
+  const extras: PromptExtras = {};
+
+  // Resolve extensions/skills: isolated overrides to false
+  const extensions = options.isolated ? false : config.extensions;
+  const skills = options.isolated ? false : config.skills;
+
+  // Skill preloading: when skills is string[], preload their content into prompt
+  if (Array.isArray(skills)) {
+    const loaded = preloadSkills(skills, effectiveCwd);
+    if (loaded.length > 0) {
+      extras.skillBlocks = loaded;
+    }
+  }
+
+  let tools = getToolsForType(type, effectiveCwd);
+
+  // Persistent memory: detect write capability and branch accordingly
+  if (agentConfig?.memory) {
+    const existingNames = new Set(tools.map(t => t.name));
+    const hasWriteTools = existingNames.has("write") || existingNames.has("edit");
+
+    if (hasWriteTools) {
+      // Read-write memory: add any missing memory tools (read/write/edit)
+      const memTools = getMemoryTools(effectiveCwd, existingNames);
+      if (memTools.length > 0) tools = [...tools, ...memTools];
+      extras.memoryBlock = buildMemoryBlock(agentConfig.name, agentConfig.memory, effectiveCwd);
+    } else {
+      // Read-only memory: only add read tool, use read-only prompt
+      if (!existingNames.has("read")) {
+        const readTools = getReadOnlyMemoryTools(effectiveCwd, existingNames);
+        if (readTools.length > 0) tools = [...tools, ...readTools];
+      }
+      extras.memoryBlock = buildReadOnlyMemoryBlock(agentConfig.name, agentConfig.memory, effectiveCwd);
+    }
+  }
+
   // Build system prompt from agent config
   let systemPrompt: string;
   if (agentConfig) {
-    systemPrompt = buildAgentPrompt(agentConfig, ctx.cwd, env, parentSystemPrompt);
+    systemPrompt = buildAgentPrompt(agentConfig, effectiveCwd, env, parentSystemPrompt, extras);
   } else {
     // Unknown type fallback: general-purpose (defensive — unreachable in practice
     // since index.ts resolves unknown types to "general-purpose" before calling runAgent)
@@ -158,20 +203,18 @@ export async function runAgent(
       inheritContext: false,
       runInBackground: false,
       isolated: false,
-    }, ctx.cwd, env, parentSystemPrompt);
+    }, effectiveCwd, env, parentSystemPrompt, extras);
   }
 
-  const tools = getToolsForType(type, ctx.cwd);
-
-  // Resolve extensions/skills: isolated overrides to false
-  const extensions = options.isolated ? false : config.extensions;
-  const skills = options.isolated ? false : config.skills;
+  // When skills is string[], we've already preloaded them into the prompt.
+  // Still pass noSkills: true since we don't need the skill loader to load them again.
+  const noSkills = skills === false || Array.isArray(skills);
 
   // Load extensions/skills: true or string[] → load; false → don't
   const loader = new DefaultResourceLoader({
-    cwd: ctx.cwd,
+    cwd: effectiveCwd,
     noExtensions: extensions === false,
-    noSkills: skills === false,
+    noSkills,
     noPromptTemplates: true,
     noThemes: true,
     systemPromptOverride: () => systemPrompt,
@@ -187,8 +230,8 @@ export async function runAgent(
   const thinkingLevel = options.thinkingLevel ?? agentConfig?.thinking;
 
   const sessionOpts: Record<string, unknown> = {
-    cwd: ctx.cwd,
-    sessionManager: SessionManager.inMemory(ctx.cwd),
+    cwd: effectiveCwd,
+    sessionManager: SessionManager.inMemory(effectiveCwd),
     settingsManager: SettingsManager.create(),
     modelRegistry: ctx.modelRegistry,
     model,
@@ -202,18 +245,28 @@ export async function runAgent(
   // createAgentSession's type signature may not include thinkingLevel yet
   const { session } = await createAgentSession(sessionOpts as Parameters<typeof createAgentSession>[0]);
 
+  // Build disallowed tools set from agent config
+  const disallowedSet = agentConfig?.disallowedTools
+    ? new Set(agentConfig.disallowedTools)
+    : undefined;
+
   // Filter active tools: remove our own tools to prevent nesting,
-  // and apply extension allowlist if specified
+  // apply extension allowlist if specified, and apply disallowedTools denylist
   if (extensions !== false) {
     const builtinToolNames = new Set(tools.map(t => t.name));
     const activeTools = session.getActiveToolNames().filter((t) => {
       if (EXCLUDED_TOOL_NAMES.includes(t)) return false;
+      if (disallowedSet?.has(t)) return false;
       if (builtinToolNames.has(t)) return true;
       if (Array.isArray(extensions)) {
         return extensions.some(ext => t.startsWith(ext) || t.includes(ext));
       }
       return true;
     });
+    session.setActiveToolsByName(activeTools);
+  } else if (disallowedSet) {
+    // Even with extensions disabled, apply denylist to built-in tools
+    const activeTools = session.getActiveToolNames().filter(t => !disallowedSet.has(t));
     session.setActiveToolsByName(activeTools);
   }
 

--- a/src/agent-runner.ts
+++ b/src/agent-runner.ts
@@ -166,10 +166,13 @@ export async function runAgent(
 
   let tools = getToolsForType(type, effectiveCwd);
 
-  // Persistent memory: detect write capability and branch accordingly
+  // Persistent memory: detect write capability and branch accordingly.
+  // Account for disallowedTools — a tool in the base set but on the denylist is not truly available.
   if (agentConfig?.memory) {
     const existingNames = new Set(tools.map(t => t.name));
-    const hasWriteTools = existingNames.has("write") || existingNames.has("edit");
+    const denied = agentConfig.disallowedTools ? new Set(agentConfig.disallowedTools) : undefined;
+    const effectivelyHas = (name: string) => existingNames.has(name) && !denied?.has(name);
+    const hasWriteTools = effectivelyHas("write") || effectivelyHas("edit");
 
     if (hasWriteTools) {
       // Read-write memory: add any missing memory tools (read/write/edit)

--- a/src/agent-types.ts
+++ b/src/agent-types.ts
@@ -109,6 +109,32 @@ export function isValidType(type: string): boolean {
   return agents.get(key)?.enabled !== false;
 }
 
+/** Tool names required for memory management. */
+const MEMORY_TOOL_NAMES = ["read", "write", "edit"];
+
+/**
+ * Get the tools needed for memory management (read, write, edit).
+ * Only returns tools that are NOT already in the provided set.
+ */
+export function getMemoryTools(cwd: string, existingToolNames: Set<string>): AgentTool<any>[] {
+  return MEMORY_TOOL_NAMES
+    .filter(n => !existingToolNames.has(n) && n in TOOL_FACTORIES)
+    .map(n => TOOL_FACTORIES[n](cwd));
+}
+
+/** Tool names needed for read-only memory access. */
+const READONLY_MEMORY_TOOL_NAMES = ["read"];
+
+/**
+ * Get only the read tool for read-only memory access.
+ * Only returns tools that are NOT already in the provided set.
+ */
+export function getReadOnlyMemoryTools(cwd: string, existingToolNames: Set<string>): AgentTool<any>[] {
+  return READONLY_MEMORY_TOOL_NAMES
+    .filter(n => !existingToolNames.has(n) && n in TOOL_FACTORIES)
+    .map(n => TOOL_FACTORIES[n](cwd));
+}
+
 /** Get built-in tools for a type (case-insensitive). */
 export function getToolsForType(type: string, cwd: string): AgentTool<any>[] {
   const key = resolveKey(type);

--- a/src/custom-agents.ts
+++ b/src/custom-agents.ts
@@ -6,7 +6,7 @@ import { parseFrontmatter } from "@mariozechner/pi-coding-agent";
 import { readFileSync, readdirSync, existsSync } from "node:fs";
 import { join, basename } from "node:path";
 import { homedir } from "node:os";
-import type { AgentConfig, ThinkingLevel } from "./types.js";
+import type { AgentConfig, ThinkingLevel, MemoryScope, IsolationMode } from "./types.js";
 import { BUILTIN_TOOL_NAMES } from "./agent-types.js";
 
 /**
@@ -56,6 +56,7 @@ function loadFromDir(dir: string, agents: Map<string, AgentConfig>, source: "pro
       displayName: str(fm.display_name),
       description: str(fm.description) ?? name,
       builtinToolNames: csvList(fm.tools, BUILTIN_TOOL_NAMES),
+      disallowedTools: csvListOptional(fm.disallowed_tools),
       extensions: inheritField(fm.extensions ?? fm.inherit_extensions),
       skills: inheritField(fm.skills ?? fm.inherit_skills),
       model: str(fm.model),
@@ -66,6 +67,8 @@ function loadFromDir(dir: string, agents: Map<string, AgentConfig>, source: "pro
       inheritContext: fm.inherit_context === true,
       runInBackground: fm.run_in_background === true,
       isolated: fm.isolated === true,
+      memory: parseMemory(fm.memory),
+      isolation: fm.isolation === "worktree" ? "worktree" : undefined,
       enabled: fm.enabled !== false,  // default true; explicitly false disables
       source,
     });
@@ -86,14 +89,40 @@ function positiveInt(val: unknown): number | undefined {
 }
 
 /**
- * Parse a comma-separated list field.
+ * Parse a raw CSV field value into items, or undefined if absent/empty/"none".
+ */
+function parseCsvField(val: unknown): string[] | undefined {
+  if (val === undefined || val === null) return undefined;
+  const s = String(val).trim();
+  if (!s || s === "none") return undefined;
+  const items = s.split(",").map(t => t.trim()).filter(Boolean);
+  return items.length > 0 ? items : undefined;
+}
+
+/**
+ * Parse a comma-separated list field with defaults.
  * omitted → defaults; "none"/empty → []; csv → listed items.
  */
 function csvList(val: unknown, defaults: string[]): string[] {
   if (val === undefined || val === null) return defaults;
-  const s = String(val).trim();
-  if (!s || s === "none") return [];
-  return s.split(",").map(t => t.trim()).filter(Boolean);
+  return parseCsvField(val) ?? [];
+}
+
+/**
+ * Parse an optional comma-separated list field.
+ * omitted → undefined; "none"/empty → undefined; csv → listed items.
+ */
+function csvListOptional(val: unknown): string[] | undefined {
+  return parseCsvField(val);
+}
+
+/**
+ * Parse a memory scope field.
+ * omitted → undefined; "user"/"project"/"local" → MemoryScope.
+ */
+function parseMemory(val: unknown): MemoryScope | undefined {
+  if (val === "user" || val === "project" || val === "local") return val;
+  return undefined;
 }
 
 /**

--- a/src/index.ts
+++ b/src/index.ts
@@ -408,6 +408,7 @@ Guidelines:
 - Use model to specify a different model (as "provider/modelId", or fuzzy e.g. "haiku", "sonnet").
 - Use thinking to control extended thinking level.
 - Use inherit_context if the agent needs the parent conversation history.
+- Use isolation: "worktree" to run the agent in an isolated git worktree (safe parallel file modifications).
 - Use join_mode to control how background completion notifications are delivered. By default (smart), 2+ background agents spawned in the same turn are grouped into a single notification. Use "async" for individual notifications or "group" to force grouping.`,
     parameters: Type.Object({
       prompt: Type.String({
@@ -454,6 +455,11 @@ Guidelines:
       inherit_context: Type.Optional(
         Type.Boolean({
           description: "If true, fork parent conversation into the agent. Default: false (fresh context).",
+        }),
+      ),
+      isolation: Type.Optional(
+        Type.Literal("worktree", {
+          description: 'Set to "worktree" to run the agent in a temporary git worktree (isolated copy of the repo). Changes are saved to a branch on completion.',
         }),
       ),
       join_mode: Type.Optional(
@@ -590,6 +596,7 @@ Guidelines:
       const inheritContext = params.inherit_context ?? customConfig?.inheritContext ?? false;
       const runInBackground = params.run_in_background ?? customConfig?.runInBackground ?? false;
       const isolated = params.isolated ?? customConfig?.isolated ?? false;
+      const isolation = params.isolation ?? customConfig?.isolation;
 
       // Build display tags for non-default config
       const parentModelId = ctx.model?.id;
@@ -602,6 +609,7 @@ Guidelines:
       if (modeLabel) agentTags.push(modeLabel);
       if (thinking) agentTags.push(`thinking: ${thinking}`);
       if (isolated) agentTags.push("isolated");
+      if (isolation === "worktree") agentTags.push("worktree");
       // Shared base fields for all AgentDetails in this call
       const detailBase = {
         displayName,
@@ -642,6 +650,7 @@ Guidelines:
           inheritContext,
           thinkingLevel: thinking,
           isBackground: true,
+          isolation,
           ...bgCallbacks,
         });
 
@@ -739,6 +748,7 @@ Guidelines:
         isolated,
         inheritContext,
         thinkingLevel: thinking,
+        isolation,
         ...fgCallbacks,
       });
 
@@ -1148,9 +1158,12 @@ Guidelines:
     else if (Array.isArray(cfg.extensions)) fmFields.push(`extensions: ${cfg.extensions.join(", ")}`);
     if (cfg.skills === false) fmFields.push("skills: false");
     else if (Array.isArray(cfg.skills)) fmFields.push(`skills: ${cfg.skills.join(", ")}`);
+    if (cfg.disallowedTools?.length) fmFields.push(`disallowed_tools: ${cfg.disallowedTools.join(", ")}`);
     if (cfg.inheritContext) fmFields.push("inherit_context: true");
     if (cfg.runInBackground) fmFields.push("run_in_background: true");
     if (cfg.isolated) fmFields.push("isolated: true");
+    if (cfg.memory) fmFields.push(`memory: ${cfg.memory}`);
+    if (cfg.isolation) fmFields.push(`isolation: ${cfg.isolation}`);
 
     const content = `---\n${fmFields.join("\n")}\n---\n\n${cfg.systemPrompt}\n`;
 
@@ -1270,10 +1283,13 @@ thinking: <optional thinking level: off, minimal, low, medium, high, xhigh. Omit
 max_turns: <optional max agentic turns, default 50. Omit for default>
 prompt_mode: <"replace" (body IS the full system prompt) or "append" (body is appended to default prompt). Default: replace>
 extensions: <true (inherit all MCP/extension tools), false (none), or comma-separated names. Default: true>
-skills: <true (inherit all), false (none). Default: true>
+skills: <true (inherit all), false (none), or comma-separated skill names to preload into prompt. Default: true>
+disallowed_tools: <comma-separated tool names to block, even if otherwise available. Omit for none>
 inherit_context: <true to fork parent conversation into agent so it sees chat history. Default: false>
 run_in_background: <true to run in background by default. Default: false>
 isolated: <true for no extension/MCP tools, only built-in tools. Default: false>
+memory: <"user" (global), "project" (per-project), or "local" (gitignored per-project) for persistent memory. Omit for none>
+isolation: <"worktree" to run in isolated git worktree. Omit for normal>
 ---
 
 <system prompt body — instructions for the agent>

--- a/src/memory.ts
+++ b/src/memory.ts
@@ -1,0 +1,130 @@
+/**
+ * memory.ts — Persistent agent memory: per-agent memory directories that persist across sessions.
+ *
+ * Memory scopes:
+ *   - "user"    → ~/.pi/agent-memory/{agent-name}/
+ *   - "project" → .pi/agent-memory/{agent-name}/
+ *   - "local"   → .pi/agent-memory-local/{agent-name}/
+ */
+
+import { existsSync, readFileSync, mkdirSync } from "node:fs";
+import { join } from "node:path";
+import { homedir } from "node:os";
+import type { MemoryScope } from "./types.js";
+
+/** Maximum lines to read from MEMORY.md */
+const MAX_MEMORY_LINES = 200;
+
+/**
+ * Returns true if a name contains path traversal or shell-unsafe characters.
+ */
+export function isUnsafeName(name: string): boolean {
+  return name.includes("..") || name.includes("/") || name.includes("\\") || name.includes("\0");
+}
+
+/**
+ * Resolve the memory directory path for a given agent + scope + cwd.
+ * Throws if agentName contains path traversal characters.
+ */
+export function resolveMemoryDir(agentName: string, scope: MemoryScope, cwd: string): string {
+  if (isUnsafeName(agentName)) {
+    throw new Error(`Unsafe agent name for memory directory: "${agentName}"`);
+  }
+  switch (scope) {
+    case "user":
+      return join(homedir(), ".pi", "agent-memory", agentName);
+    case "project":
+      return join(cwd, ".pi", "agent-memory", agentName);
+    case "local":
+      return join(cwd, ".pi", "agent-memory-local", agentName);
+  }
+}
+
+/**
+ * Ensure the memory directory exists, creating it if needed.
+ */
+export function ensureMemoryDir(memoryDir: string): void {
+  mkdirSync(memoryDir, { recursive: true });
+}
+
+/**
+ * Read the first N lines of MEMORY.md from the memory directory, if it exists.
+ * Returns undefined if no MEMORY.md exists.
+ */
+export function readMemoryIndex(memoryDir: string): string | undefined {
+  const memoryFile = join(memoryDir, "MEMORY.md");
+  if (!existsSync(memoryFile)) return undefined;
+
+  try {
+    const content = readFileSync(memoryFile, "utf-8");
+    const lines = content.split("\n");
+    if (lines.length > MAX_MEMORY_LINES) {
+      return lines.slice(0, MAX_MEMORY_LINES).join("\n") + "\n... (truncated at 200 lines)";
+    }
+    return content;
+  } catch {
+    return undefined;
+  }
+}
+
+/**
+ * Build the memory block to inject into the agent's system prompt.
+ * Also ensures the memory directory exists (creates it if needed).
+ */
+export function buildMemoryBlock(agentName: string, scope: MemoryScope, cwd: string): string {
+  const memoryDir = resolveMemoryDir(agentName, scope, cwd);
+  // Create the memory directory so the agent can immediately write to it
+  ensureMemoryDir(memoryDir);
+
+  const existingMemory = readMemoryIndex(memoryDir);
+
+  const header = `# Agent Memory
+
+You have a persistent memory directory at: ${memoryDir}/
+Memory scope: ${scope}
+
+This memory persists across sessions. Use it to build up knowledge over time.`;
+
+  const memoryContent = existingMemory
+    ? `\n\n## Current MEMORY.md\n${existingMemory}`
+    : `\n\nNo MEMORY.md exists yet. Create one at ${join(memoryDir, "MEMORY.md")} to start building persistent memory.`;
+
+  const instructions = `
+
+## Memory Instructions
+- MEMORY.md is an index file — keep it concise (under 200 lines). Lines after 200 are truncated.
+- Store detailed memories in separate files within ${memoryDir}/ and link to them from MEMORY.md.
+- Each memory file should use this frontmatter format:
+  \`\`\`markdown
+  ---
+  name: <memory name>
+  description: <one-line description>
+  type: <user|feedback|project|reference>
+  ---
+  <memory content>
+  \`\`\`
+- Update or remove memories that become outdated. Check for existing memories before creating duplicates.
+- You have Read, Write, and Edit tools available for managing memory files.`;
+
+  return header + memoryContent + instructions;
+}
+
+/**
+ * Build a read-only memory block for agents that lack write/edit tools.
+ * Does NOT create the memory directory — agents can only consume existing memory.
+ */
+export function buildReadOnlyMemoryBlock(agentName: string, scope: MemoryScope, cwd: string): string {
+  const memoryDir = resolveMemoryDir(agentName, scope, cwd);
+  const existingMemory = readMemoryIndex(memoryDir);
+
+  const header = `# Agent Memory (read-only)
+
+Memory scope: ${scope}
+You have read-only access to memory. You can reference existing memories but cannot create or modify them.`;
+
+  const memoryContent = existingMemory
+    ? `\n\n## Current MEMORY.md\n${existingMemory}`
+    : `\n\nNo memory is available yet. Other agents or sessions with write access can create memories for you to consume.`;
+
+  return header + memoryContent;
+}

--- a/src/memory.ts
+++ b/src/memory.ts
@@ -7,8 +7,8 @@
  *   - "local"   → .pi/agent-memory-local/{agent-name}/
  */
 
-import { existsSync, readFileSync, mkdirSync } from "node:fs";
-import { join } from "node:path";
+import { existsSync, readFileSync, mkdirSync, lstatSync } from "node:fs";
+import { join, resolve } from "node:path";
 import { homedir } from "node:os";
 import type { MemoryScope } from "./types.js";
 
@@ -16,10 +16,37 @@ import type { MemoryScope } from "./types.js";
 const MAX_MEMORY_LINES = 200;
 
 /**
- * Returns true if a name contains path traversal or shell-unsafe characters.
+ * Returns true if a name contains characters not allowed in agent/skill names.
+ * Uses a whitelist: only alphanumeric, hyphens, underscores, and dots (no leading dot).
  */
 export function isUnsafeName(name: string): boolean {
-  return name.includes("..") || name.includes("/") || name.includes("\\") || name.includes("\0");
+  if (!name || name.length > 128) return true;
+  return !/^[a-zA-Z0-9][a-zA-Z0-9._-]*$/.test(name);
+}
+
+/**
+ * Returns true if the given path is a symlink (defense against symlink attacks).
+ */
+export function isSymlink(filePath: string): boolean {
+  try {
+    return lstatSync(filePath).isSymbolicLink();
+  } catch {
+    return false;
+  }
+}
+
+/**
+ * Safely read a file, rejecting symlinks.
+ * Returns undefined if the file doesn't exist, is a symlink, or can't be read.
+ */
+export function safeReadFile(filePath: string): string | undefined {
+  if (!existsSync(filePath)) return undefined;
+  if (isSymlink(filePath)) return undefined;
+  try {
+    return readFileSync(filePath, "utf-8");
+  } catch {
+    return undefined;
+  }
 }
 
 /**
@@ -42,29 +69,37 @@ export function resolveMemoryDir(agentName: string, scope: MemoryScope, cwd: str
 
 /**
  * Ensure the memory directory exists, creating it if needed.
+ * Refuses to create directories if any component in the path is a symlink
+ * to prevent symlink-based directory traversal attacks.
  */
 export function ensureMemoryDir(memoryDir: string): void {
+  // If the directory already exists, verify it's not a symlink
+  if (existsSync(memoryDir)) {
+    if (isSymlink(memoryDir)) {
+      throw new Error(`Refusing to use symlinked memory directory: ${memoryDir}`);
+    }
+    return;
+  }
   mkdirSync(memoryDir, { recursive: true });
 }
 
 /**
  * Read the first N lines of MEMORY.md from the memory directory, if it exists.
- * Returns undefined if no MEMORY.md exists.
+ * Returns undefined if no MEMORY.md exists or if the path is a symlink.
  */
 export function readMemoryIndex(memoryDir: string): string | undefined {
-  const memoryFile = join(memoryDir, "MEMORY.md");
-  if (!existsSync(memoryFile)) return undefined;
+  // Reject symlinked memory directories
+  if (isSymlink(memoryDir)) return undefined;
 
-  try {
-    const content = readFileSync(memoryFile, "utf-8");
-    const lines = content.split("\n");
-    if (lines.length > MAX_MEMORY_LINES) {
-      return lines.slice(0, MAX_MEMORY_LINES).join("\n") + "\n... (truncated at 200 lines)";
-    }
-    return content;
-  } catch {
-    return undefined;
+  const memoryFile = join(memoryDir, "MEMORY.md");
+  const content = safeReadFile(memoryFile);
+  if (content === undefined) return undefined;
+
+  const lines = content.split("\n");
+  if (lines.length > MAX_MEMORY_LINES) {
+    return lines.slice(0, MAX_MEMORY_LINES).join("\n") + "\n... (truncated at 200 lines)";
   }
+  return content;
 }
 
 /**

--- a/src/prompts.ts
+++ b/src/prompts.ts
@@ -4,6 +4,14 @@
 
 import type { AgentConfig, EnvInfo } from "./types.js";
 
+/** Extra sections to inject into the system prompt (memory, skills, etc.). */
+export interface PromptExtras {
+  /** Persistent memory content to inject (first 200 lines of MEMORY.md + instructions). */
+  memoryBlock?: string;
+  /** Preloaded skill contents to inject. */
+  skillBlocks?: { name: string; content: string }[];
+}
+
 /**
  * Build the system prompt for an agent from its config.
  *
@@ -12,17 +20,31 @@ import type { AgentConfig, EnvInfo } from "./types.js";
  * - "append" with empty systemPrompt: pure parent clone
  *
  * @param parentSystemPrompt  The parent agent's effective system prompt (for append mode).
+ * @param extras  Optional extra sections to inject (memory, preloaded skills).
  */
 export function buildAgentPrompt(
   config: AgentConfig,
   cwd: string,
   env: EnvInfo,
   parentSystemPrompt?: string,
+  extras?: PromptExtras,
 ): string {
   const envBlock = `# Environment
 Working directory: ${cwd}
 ${env.isGitRepo ? `Git repository: yes\nBranch: ${env.branch}` : "Not a git repository"}
 Platform: ${env.platform}`;
+
+  // Build optional extras suffix
+  const extraSections: string[] = [];
+  if (extras?.memoryBlock) {
+    extraSections.push(extras.memoryBlock);
+  }
+  if (extras?.skillBlocks?.length) {
+    for (const skill of extras.skillBlocks) {
+      extraSections.push(`\n# Preloaded Skill: ${skill.name}\n${skill.content}`);
+    }
+  }
+  const extrasSuffix = extraSections.length > 0 ? "\n\n" + extraSections.join("\n") : "";
 
   if (config.promptMode === "append") {
     const identity = parentSystemPrompt || genericBase;
@@ -44,7 +66,7 @@ You are operating as a sub-agent invoked to handle a specific task.
       ? `\n\n<agent_instructions>\n${config.systemPrompt}\n</agent_instructions>`
       : "";
 
-    return envBlock + "\n\n<inherited_system_prompt>\n" + identity + "\n</inherited_system_prompt>\n\n" + bridge + customSection;
+    return envBlock + "\n\n<inherited_system_prompt>\n" + identity + "\n</inherited_system_prompt>\n\n" + bridge + customSection + extrasSuffix;
   }
 
   // "replace" mode — env header + the config's full system prompt
@@ -53,7 +75,7 @@ You have been invoked to handle a specific task autonomously.
 
 ${envBlock}`;
 
-  return replaceHeader + "\n\n" + config.systemPrompt;
+  return replaceHeader + "\n\n" + config.systemPrompt + extrasSuffix;
 }
 
 /** Fallback base prompt when parent system prompt is unavailable in append mode. */

--- a/src/skill-loader.ts
+++ b/src/skill-loader.ts
@@ -1,0 +1,84 @@
+/**
+ * skill-loader.ts — Preload specific skill files and inject their content into the system prompt.
+ *
+ * When skills is a string[], reads each named skill from .pi/skills/ or ~/.pi/skills/
+ * and returns their content for injection into the agent's system prompt.
+ */
+
+import { existsSync, readFileSync } from "node:fs";
+import { join } from "node:path";
+import { homedir } from "node:os";
+import { isUnsafeName } from "./memory.js";
+
+export interface PreloadedSkill {
+  name: string;
+  content: string;
+}
+
+/**
+ * Attempt to load named skills from project and global skill directories.
+ * Looks for: <dir>/<name>.md, <dir>/<name>.txt, <dir>/<name>
+ *
+ * @param skillNames  List of skill names to preload.
+ * @param cwd         Working directory for project-level skills.
+ * @returns Array of loaded skills (missing skills are skipped with a warning comment).
+ */
+export function preloadSkills(skillNames: string[], cwd: string): PreloadedSkill[] {
+  const results: PreloadedSkill[] = [];
+
+  for (const name of skillNames) {
+    // Unlike memory (which throws on unsafe names because it's part of agent setup),
+    // skills are optional — skip gracefully to avoid blocking agent startup.
+    if (isUnsafeName(name)) {
+      results.push({ name, content: `(Skill "${name}" skipped: name contains path traversal characters)` });
+      continue;
+    }
+    const content = findAndReadSkill(name, cwd);
+    if (content !== undefined) {
+      results.push({ name, content });
+    } else {
+      // Include a note about missing skills so the agent knows it was requested but not found
+      results.push({ name, content: `(Skill "${name}" not found in .pi/skills/ or ~/.pi/skills/)` });
+    }
+  }
+
+  return results;
+}
+
+/**
+ * Search for a skill file in project and global directories.
+ * Project-level takes priority over global.
+ */
+function findAndReadSkill(name: string, cwd: string): string | undefined {
+  const projectDir = join(cwd, ".pi", "skills");
+  const globalDir = join(homedir(), ".pi", "skills");
+
+  // Try project first, then global
+  for (const dir of [projectDir, globalDir]) {
+    const content = tryReadSkillFile(dir, name);
+    if (content !== undefined) return content;
+  }
+
+  return undefined;
+}
+
+/**
+ * Try to read a skill file from a directory.
+ * Tries extensions in order: .md, .txt, (no extension)
+ */
+function tryReadSkillFile(dir: string, name: string): string | undefined {
+  const extensions = [".md", ".txt", ""];
+
+  for (const ext of extensions) {
+    const path = join(dir, name + ext);
+    if (existsSync(path)) {
+      try {
+        return readFileSync(path, "utf-8").trim();
+      } catch {
+        continue;
+      }
+    }
+  }
+
+  return undefined;
+}

--- a/src/skill-loader.ts
+++ b/src/skill-loader.ts
@@ -5,10 +5,9 @@
  * and returns their content for injection into the agent's system prompt.
  */
 
-import { existsSync, readFileSync } from "node:fs";
 import { join } from "node:path";
 import { homedir } from "node:os";
-import { isUnsafeName } from "./memory.js";
+import { isUnsafeName, safeReadFile } from "./memory.js";
 
 export interface PreloadedSkill {
   name: string;
@@ -71,13 +70,9 @@ function tryReadSkillFile(dir: string, name: string): string | undefined {
 
   for (const ext of extensions) {
     const path = join(dir, name + ext);
-    if (existsSync(path)) {
-      try {
-        return readFileSync(path, "utf-8").trim();
-      } catch {
-        continue;
-      }
-    }
+    // safeReadFile rejects symlinks to prevent reading arbitrary files
+    const content = safeReadFile(path);
+    if (content !== undefined) return content.trim();
   }
 
   return undefined;

--- a/src/types.ts
+++ b/src/types.ts
@@ -13,12 +13,20 @@ export type SubagentType = string;
 /** Names of the three embedded default agents. */
 export const DEFAULT_AGENT_NAMES = ["general-purpose", "Explore", "Plan"] as const;
 
+/** Memory scope for persistent agent memory. */
+export type MemoryScope = "user" | "project" | "local";
+
+/** Isolation mode for agent execution. */
+export type IsolationMode = "worktree";
+
 /** Unified agent configuration — used for both default and user-defined agents. */
 export interface AgentConfig {
   name: string;
   displayName?: string;
   description: string;
   builtinToolNames?: string[];
+  /** Tool denylist — these tools are removed even if `builtinToolNames` or extensions include them. */
+  disallowedTools?: string[];
   /** true = inherit all, string[] = only listed, false = none */
   extensions: true | string[] | false;
   /** true = inherit all, string[] = only listed, false = none */
@@ -34,6 +42,10 @@ export interface AgentConfig {
   runInBackground: boolean;
   /** Default for spawn: no extension tools */
   isolated: boolean;
+  /** Persistent memory scope — agents with memory get a persistent directory and MEMORY.md */
+  memory?: MemoryScope;
+  /** Isolation mode — "worktree" runs the agent in a temporary git worktree */
+  isolation?: IsolationMode;
   /** true = this is an embedded default agent (informational) */
   isDefault?: boolean;
   /** false = agent is hidden from the registry */
@@ -61,6 +73,10 @@ export interface AgentRecord {
   joinMode?: JoinMode;
   /** Set when result was already consumed via get_subagent_result — suppresses completion notification. */
   resultConsumed?: boolean;
+  /** Worktree info if the agent is running in an isolated worktree. */
+  worktree?: { path: string; branch: string };
+  /** Worktree cleanup result after agent completion. */
+  worktreeResult?: { hasChanges: boolean; branch?: string };
 }
 
 export interface EnvInfo {

--- a/src/worktree.ts
+++ b/src/worktree.ts
@@ -1,0 +1,148 @@
+/**
+ * worktree.ts — Git worktree isolation for agents.
+ *
+ * Creates a temporary git worktree so the agent works on an isolated copy of the repo.
+ * On completion, if no changes were made, the worktree is cleaned up.
+ * If changes exist, a branch is created and returned in the result.
+ */
+
+import { execFileSync } from "node:child_process";
+import { existsSync } from "node:fs";
+import { join } from "node:path";
+import { tmpdir } from "node:os";
+import { randomUUID } from "node:crypto";
+
+export interface WorktreeInfo {
+  /** Absolute path to the worktree directory. */
+  path: string;
+  /** Branch name created for this worktree (if changes exist). */
+  branch: string;
+}
+
+export interface WorktreeCleanupResult {
+  /** Whether changes were found in the worktree. */
+  hasChanges: boolean;
+  /** Branch name if changes were committed. */
+  branch?: string;
+  /** Worktree path if it was kept. */
+  path?: string;
+}
+
+/**
+ * Create a temporary git worktree for an agent.
+ * Returns the worktree path, or undefined if not in a git repo.
+ */
+export function createWorktree(cwd: string, agentId: string): WorktreeInfo | undefined {
+  // Verify we're in a git repo
+  try {
+    execFileSync("git", ["rev-parse", "--is-inside-work-tree"], { cwd, stdio: "pipe", timeout: 5000 });
+  } catch {
+    return undefined;
+  }
+
+  const branch = `pi-agent-${agentId}`;
+  const suffix = randomUUID().slice(0, 8);
+  const worktreePath = join(tmpdir(), `pi-agent-${agentId}-${suffix}`);
+
+  try {
+    // Create detached worktree at HEAD
+    execFileSync("git", ["worktree", "add", "--detach", worktreePath, "HEAD"], {
+      cwd,
+      stdio: "pipe",
+      timeout: 30000,
+    });
+    return { path: worktreePath, branch };
+  } catch (err) {
+    // If worktree creation fails, return undefined (agent runs in normal cwd)
+    return undefined;
+  }
+}
+
+/**
+ * Clean up a worktree after agent completion.
+ * - If no changes: remove worktree entirely.
+ * - If changes exist: create a branch, commit changes, return branch info.
+ */
+export function cleanupWorktree(
+  cwd: string,
+  worktree: WorktreeInfo,
+  agentDescription: string,
+): WorktreeCleanupResult {
+  if (!existsSync(worktree.path)) {
+    return { hasChanges: false };
+  }
+
+  try {
+    // Check for uncommitted changes in the worktree
+    const status = execFileSync("git", ["status", "--porcelain"], {
+      cwd: worktree.path,
+      stdio: "pipe",
+      timeout: 10000,
+    }).toString().trim();
+
+    if (!status) {
+      // No changes — remove worktree
+      removeWorktree(cwd, worktree.path);
+      return { hasChanges: false };
+    }
+
+    // Changes exist — stage, commit, and create a branch
+    execFileSync("git", ["add", "-A"], { cwd: worktree.path, stdio: "pipe", timeout: 10000 });
+    // Truncate description for commit message (no shell sanitization needed — execFileSync uses argv)
+    const safeDesc = agentDescription.slice(0, 200);
+    const commitMsg = `pi-agent: ${safeDesc}`;
+    execFileSync("git", ["commit", "-m", commitMsg], {
+      cwd: worktree.path,
+      stdio: "pipe",
+      timeout: 10000,
+    });
+
+    // Create a branch pointing to the worktree's HEAD.
+    // Use -f to overwrite if a stale branch from a previous run exists.
+    execFileSync("git", ["branch", "-f", worktree.branch], {
+      cwd: worktree.path,
+      stdio: "pipe",
+      timeout: 5000,
+    });
+
+    // Remove the worktree (branch persists in main repo)
+    removeWorktree(cwd, worktree.path);
+
+    return {
+      hasChanges: true,
+      branch: worktree.branch,
+      path: worktree.path,
+    };
+  } catch {
+    // Best effort cleanup on error
+    try { removeWorktree(cwd, worktree.path); } catch { /* ignore */ }
+    return { hasChanges: false };
+  }
+}
+
+/**
+ * Force-remove a worktree.
+ */
+function removeWorktree(cwd: string, worktreePath: string): void {
+  try {
+    execFileSync("git", ["worktree", "remove", "--force", worktreePath], {
+      cwd,
+      stdio: "pipe",
+      timeout: 10000,
+    });
+  } catch {
+    // If git worktree remove fails, try pruning
+    try {
+      execFileSync("git", ["worktree", "prune"], { cwd, stdio: "pipe", timeout: 5000 });
+    } catch { /* ignore */ }
+  }
+}
+
+/**
+ * Prune any orphaned worktrees (crash recovery).
+ */
+export function pruneWorktrees(cwd: string): void {
+  try {
+    execFileSync("git", ["worktree", "prune"], { cwd, stdio: "pipe", timeout: 5000 });
+  } catch { /* ignore */ }
+}

--- a/src/worktree.ts
+++ b/src/worktree.ts
@@ -33,9 +33,10 @@ export interface WorktreeCleanupResult {
  * Returns the worktree path, or undefined if not in a git repo.
  */
 export function createWorktree(cwd: string, agentId: string): WorktreeInfo | undefined {
-  // Verify we're in a git repo
+  // Verify we're in a git repo with at least one commit (HEAD must exist)
   try {
     execFileSync("git", ["rev-parse", "--is-inside-work-tree"], { cwd, stdio: "pipe", timeout: 5000 });
+    execFileSync("git", ["rev-parse", "HEAD"], { cwd, stdio: "pipe", timeout: 5000 });
   } catch {
     return undefined;
   }
@@ -52,7 +53,7 @@ export function createWorktree(cwd: string, agentId: string): WorktreeInfo | und
       timeout: 30000,
     });
     return { path: worktreePath, branch };
-  } catch (err) {
+  } catch {
     // If worktree creation fails, return undefined (agent runs in normal cwd)
     return undefined;
   }
@@ -98,12 +99,25 @@ export function cleanupWorktree(
     });
 
     // Create a branch pointing to the worktree's HEAD.
-    // Use -f to overwrite if a stale branch from a previous run exists.
-    execFileSync("git", ["branch", "-f", worktree.branch], {
-      cwd: worktree.path,
-      stdio: "pipe",
-      timeout: 5000,
-    });
+    // If the branch already exists, append a suffix to avoid overwriting previous work.
+    let branchName = worktree.branch;
+    try {
+      execFileSync("git", ["branch", branchName], {
+        cwd: worktree.path,
+        stdio: "pipe",
+        timeout: 5000,
+      });
+    } catch {
+      // Branch already exists — use a unique suffix
+      branchName = `${worktree.branch}-${Date.now()}`;
+      execFileSync("git", ["branch", branchName], {
+        cwd: worktree.path,
+        stdio: "pipe",
+        timeout: 5000,
+      });
+    }
+    // Update branch name in worktree info for the caller
+    worktree.branch = branchName;
 
     // Remove the worktree (branch persists in main repo)
     removeWorktree(cwd, worktree.path);

--- a/test/agent-types.test.ts
+++ b/test/agent-types.test.ts
@@ -9,6 +9,8 @@ import {
   resolveType,
   getConfig,
   getToolsForType,
+  getMemoryTools,
+  getReadOnlyMemoryTools,
   BUILTIN_TOOL_NAMES,
 } from "../src/agent-types.js";
 import type { AgentConfig } from "../src/types.js";
@@ -239,6 +241,41 @@ describe("agent type registry", () => {
       // getConfig fallback should still return something reasonable
       const config = getConfig("general-purpose");
       expect(config.displayName).toBe("Agent");
+    });
+  });
+
+  describe("getMemoryTools", () => {
+    it("returns read, write, edit when none exist", () => {
+      const tools = getMemoryTools("/tmp", new Set());
+      const names = tools.map(t => t.name);
+      expect(names).toContain("read");
+      expect(names).toContain("write");
+      expect(names).toContain("edit");
+      expect(names).toHaveLength(3);
+    });
+
+    it("skips tools that already exist", () => {
+      const tools = getMemoryTools("/tmp", new Set(["read", "edit"]));
+      const names = tools.map(t => t.name);
+      expect(names).toEqual(["write"]);
+    });
+
+    it("returns empty when all memory tools already exist", () => {
+      const tools = getMemoryTools("/tmp", new Set(["read", "write", "edit"]));
+      expect(tools).toHaveLength(0);
+    });
+  });
+
+  describe("getReadOnlyMemoryTools", () => {
+    it("returns only read when missing", () => {
+      const tools = getReadOnlyMemoryTools("/tmp", new Set());
+      const names = tools.map(t => t.name);
+      expect(names).toEqual(["read"]);
+    });
+
+    it("returns empty when read already exists", () => {
+      const tools = getReadOnlyMemoryTools("/tmp", new Set(["read"]));
+      expect(tools).toHaveLength(0);
     });
   });
 });

--- a/test/custom-agents.test.ts
+++ b/test/custom-agents.test.ts
@@ -328,4 +328,107 @@ Agent prompt.`);
     const result = loadCustomAgents(tmpDir);
     expect(result.get("myagent")!.displayName).toBe("MyAgent");
   });
+
+  it("parses disallowed_tools as csv list", () => {
+    writeAgent("restricted", `---
+description: Restricted Agent
+disallowed_tools: bash, write
+---
+
+No bash or write.`);
+
+    const result = loadCustomAgents(tmpDir);
+    const agent = result.get("restricted")!;
+    expect(agent.disallowedTools).toEqual(["bash", "write"]);
+  });
+
+  it("disallowed_tools defaults to undefined when omitted", () => {
+    writeAgent("unrestricted", `---
+description: Unrestricted
+---
+
+All tools.`);
+
+    const result = loadCustomAgents(tmpDir);
+    expect(result.get("unrestricted")!.disallowedTools).toBeUndefined();
+  });
+
+  it("parses memory scope", () => {
+    writeAgent("rememberer", `---
+description: Agent with memory
+memory: project
+---
+
+Remember things.`);
+
+    const result = loadCustomAgents(tmpDir);
+    expect(result.get("rememberer")!.memory).toBe("project");
+  });
+
+  it("parses memory: user scope", () => {
+    writeAgent("global-mem", `---
+memory: user
+---
+
+User memory.`);
+
+    const result = loadCustomAgents(tmpDir);
+    expect(result.get("global-mem")!.memory).toBe("user");
+  });
+
+  it("memory defaults to undefined when omitted", () => {
+    writeAgent("no-mem", `---
+description: No memory
+---
+
+Stateless.`);
+
+    const result = loadCustomAgents(tmpDir);
+    expect(result.get("no-mem")!.memory).toBeUndefined();
+  });
+
+  it("rejects invalid memory scope", () => {
+    writeAgent("bad-mem", `---
+memory: invalid
+---
+
+Bad memory.`);
+
+    const result = loadCustomAgents(tmpDir);
+    expect(result.get("bad-mem")!.memory).toBeUndefined();
+  });
+
+  it("parses isolation: worktree", () => {
+    writeAgent("isolated-wt", `---
+description: Worktree agent
+isolation: worktree
+---
+
+Isolated.`);
+
+    const result = loadCustomAgents(tmpDir);
+    expect(result.get("isolated-wt")!.isolation).toBe("worktree");
+  });
+
+  it("isolation defaults to undefined when omitted", () => {
+    writeAgent("no-isolation", `---
+description: Normal
+---
+
+Normal.`);
+
+    const result = loadCustomAgents(tmpDir);
+    expect(result.get("no-isolation")!.isolation).toBeUndefined();
+  });
+
+  it("rejects invalid isolation mode", () => {
+    writeAgent("bad-isolation", `---
+isolation: docker
+---
+
+Bad isolation.`);
+
+    const result = loadCustomAgents(tmpDir);
+    expect(result.get("bad-isolation")!.isolation).toBeUndefined();
+  });
 });

--- a/test/memory.test.ts
+++ b/test/memory.test.ts
@@ -1,0 +1,148 @@
+import { describe, it, expect, beforeEach, afterEach } from "vitest";
+import { mkdtempSync, mkdirSync, writeFileSync, rmSync, existsSync } from "node:fs";
+import { join } from "node:path";
+import { tmpdir } from "node:os";
+import { resolveMemoryDir, ensureMemoryDir, readMemoryIndex, buildMemoryBlock, buildReadOnlyMemoryBlock } from "../src/memory.js";
+
+describe("memory", () => {
+  let tmpDir: string;
+
+  beforeEach(() => {
+    tmpDir = mkdtempSync(join(tmpdir(), "pi-mem-test-"));
+  });
+
+  afterEach(() => {
+    rmSync(tmpDir, { recursive: true, force: true });
+  });
+
+  describe("resolveMemoryDir", () => {
+    it("resolves project scope to .pi/agent-memory/<name>", () => {
+      const dir = resolveMemoryDir("auditor", "project", "/workspace");
+      expect(dir).toBe("/workspace/.pi/agent-memory/auditor");
+    });
+
+    it("resolves local scope to .pi/agent-memory-local/<name>", () => {
+      const dir = resolveMemoryDir("auditor", "local", "/workspace");
+      expect(dir).toBe("/workspace/.pi/agent-memory-local/auditor");
+    });
+
+    it("resolves user scope to ~/.pi/agent-memory/<name>", () => {
+      const dir = resolveMemoryDir("auditor", "user", "/workspace");
+      expect(dir).toContain(".pi/agent-memory/auditor");
+      expect(dir).not.toContain("/workspace");
+    });
+
+    it("throws on names with path traversal (..)", () => {
+      expect(() => resolveMemoryDir("../../etc/evil", "project", "/workspace")).toThrow("Unsafe agent name");
+    });
+
+    it("throws on names with forward slash", () => {
+      expect(() => resolveMemoryDir("foo/bar", "project", "/workspace")).toThrow("Unsafe agent name");
+    });
+
+    it("throws on names with backslash", () => {
+      expect(() => resolveMemoryDir("foo\\bar", "project", "/workspace")).toThrow("Unsafe agent name");
+    });
+
+    it("throws on names with null byte", () => {
+      expect(() => resolveMemoryDir("foo\0bar", "project", "/workspace")).toThrow("Unsafe agent name");
+    });
+  });
+
+  describe("ensureMemoryDir", () => {
+    it("creates directory if it doesn't exist", () => {
+      const dir = join(tmpDir, "agent-memory", "test");
+      expect(existsSync(dir)).toBe(false);
+      ensureMemoryDir(dir);
+      expect(existsSync(dir)).toBe(true);
+    });
+
+    it("no-ops if directory already exists", () => {
+      const dir = join(tmpDir, "agent-memory", "test");
+      mkdirSync(dir, { recursive: true });
+      ensureMemoryDir(dir); // should not throw
+      expect(existsSync(dir)).toBe(true);
+    });
+  });
+
+  describe("readMemoryIndex", () => {
+    it("returns undefined when MEMORY.md doesn't exist", () => {
+      const result = readMemoryIndex(tmpDir);
+      expect(result).toBeUndefined();
+    });
+
+    it("reads MEMORY.md content", () => {
+      writeFileSync(join(tmpDir, "MEMORY.md"), "# Memories\n- Item 1\n- Item 2");
+      const result = readMemoryIndex(tmpDir);
+      expect(result).toBe("# Memories\n- Item 1\n- Item 2");
+    });
+
+    it("truncates content beyond 200 lines", () => {
+      const lines = Array.from({ length: 250 }, (_, i) => `Line ${i + 1}`);
+      writeFileSync(join(tmpDir, "MEMORY.md"), lines.join("\n"));
+      const result = readMemoryIndex(tmpDir)!;
+      expect(result).toContain("Line 200");
+      expect(result).not.toContain("Line 201");
+      expect(result).toContain("truncated at 200 lines");
+    });
+  });
+
+  describe("buildMemoryBlock", () => {
+    it("builds memory block with no existing MEMORY.md", () => {
+      const block = buildMemoryBlock("test-agent", "project", tmpDir);
+      expect(block).toContain("Agent Memory");
+      expect(block).toContain("agent-memory/test-agent");
+      expect(block).toContain("No MEMORY.md exists yet");
+      expect(block).toContain("Memory Instructions");
+    });
+
+    it("builds memory block with existing MEMORY.md", () => {
+      const memDir = join(tmpDir, ".pi", "agent-memory", "test-agent");
+      mkdirSync(memDir, { recursive: true });
+      writeFileSync(join(memDir, "MEMORY.md"), "# Existing\n- recall this");
+      const block = buildMemoryBlock("test-agent", "project", tmpDir);
+      expect(block).toContain("Existing");
+      expect(block).toContain("recall this");
+      expect(block).not.toContain("No MEMORY.md exists yet");
+    });
+
+    it("creates memory directory if it doesn't exist", () => {
+      const memDir = join(tmpDir, ".pi", "agent-memory", "new-agent");
+      expect(existsSync(memDir)).toBe(false);
+      buildMemoryBlock("new-agent", "project", tmpDir);
+      expect(existsSync(memDir)).toBe(true);
+    });
+  });
+
+  describe("buildReadOnlyMemoryBlock", () => {
+    it("returns read-only instructions without write/edit mention", () => {
+      const block = buildReadOnlyMemoryBlock("test-agent", "project", tmpDir);
+      expect(block).toContain("read-only");
+      expect(block).not.toContain("Write");
+      expect(block).not.toContain("Edit");
+      expect(block).not.toContain("Memory Instructions");
+    });
+
+    it("does NOT create the memory directory", () => {
+      const memDir = join(tmpDir, ".pi", "agent-memory", "ro-agent");
+      expect(existsSync(memDir)).toBe(false);
+      buildReadOnlyMemoryBlock("ro-agent", "project", tmpDir);
+      expect(existsSync(memDir)).toBe(false);
+    });
+
+    it("includes existing MEMORY.md content", () => {
+      const memDir = join(tmpDir, ".pi", "agent-memory", "test-agent");
+      mkdirSync(memDir, { recursive: true });
+      writeFileSync(join(memDir, "MEMORY.md"), "# Existing\n- recall this");
+      const block = buildReadOnlyMemoryBlock("test-agent", "project", tmpDir);
+      expect(block).toContain("Existing");
+      expect(block).toContain("recall this");
+    });
+
+    it("returns 'no memory available' when no MEMORY.md exists", () => {
+      const block = buildReadOnlyMemoryBlock("test-agent", "project", tmpDir);
+      expect(block).toContain("No memory is available yet");
+      expect(block).not.toContain("Create one");
+    });
+  });
+});

--- a/test/memory.test.ts
+++ b/test/memory.test.ts
@@ -1,8 +1,8 @@
 import { describe, it, expect, beforeEach, afterEach } from "vitest";
-import { mkdtempSync, mkdirSync, writeFileSync, rmSync, existsSync } from "node:fs";
+import { mkdtempSync, mkdirSync, writeFileSync, rmSync, existsSync, symlinkSync } from "node:fs";
 import { join } from "node:path";
 import { tmpdir } from "node:os";
-import { resolveMemoryDir, ensureMemoryDir, readMemoryIndex, buildMemoryBlock, buildReadOnlyMemoryBlock } from "../src/memory.js";
+import { resolveMemoryDir, ensureMemoryDir, readMemoryIndex, buildMemoryBlock, buildReadOnlyMemoryBlock, isUnsafeName, isSymlink, safeReadFile } from "../src/memory.js";
 
 describe("memory", () => {
   let tmpDir: string;
@@ -47,6 +47,57 @@ describe("memory", () => {
     it("throws on names with null byte", () => {
       expect(() => resolveMemoryDir("foo\0bar", "project", "/workspace")).toThrow("Unsafe agent name");
     });
+
+    it("throws on empty name", () => {
+      expect(() => resolveMemoryDir("", "project", "/workspace")).toThrow("Unsafe agent name");
+    });
+
+    it("throws on names starting with dot", () => {
+      expect(() => resolveMemoryDir(".hidden", "project", "/workspace")).toThrow("Unsafe agent name");
+    });
+
+    it("throws on names with spaces", () => {
+      expect(() => resolveMemoryDir("foo bar", "project", "/workspace")).toThrow("Unsafe agent name");
+    });
+
+    it("allows hyphens, underscores, and dots in names", () => {
+      expect(() => resolveMemoryDir("my-agent_v2.1", "project", "/workspace")).not.toThrow();
+    });
+  });
+
+  describe("isUnsafeName (whitelist validation)", () => {
+    it("rejects empty string", () => {
+      expect(isUnsafeName("")).toBe(true);
+    });
+
+    it("rejects names longer than 128 chars", () => {
+      expect(isUnsafeName("a".repeat(129))).toBe(true);
+    });
+
+    it("rejects path traversal", () => {
+      expect(isUnsafeName("../../etc")).toBe(true);
+    });
+
+    it("rejects names starting with dot", () => {
+      expect(isUnsafeName(".hidden")).toBe(true);
+    });
+
+    it("rejects names with spaces", () => {
+      expect(isUnsafeName("foo bar")).toBe(true);
+    });
+
+    it("rejects names with special characters", () => {
+      expect(isUnsafeName("foo;bar")).toBe(true);
+      expect(isUnsafeName("foo|bar")).toBe(true);
+      expect(isUnsafeName("foo`bar")).toBe(true);
+    });
+
+    it("allows valid names", () => {
+      expect(isUnsafeName("my-agent")).toBe(false);
+      expect(isUnsafeName("agent_v2")).toBe(false);
+      expect(isUnsafeName("Agent123")).toBe(false);
+      expect(isUnsafeName("my-agent.v2")).toBe(false);
+    });
   });
 
   describe("ensureMemoryDir", () => {
@@ -63,6 +114,54 @@ describe("memory", () => {
       ensureMemoryDir(dir); // should not throw
       expect(existsSync(dir)).toBe(true);
     });
+
+    it("throws on symlinked directory", () => {
+      const realDir = join(tmpDir, "real-dir");
+      const linkDir = join(tmpDir, "symlink-dir");
+      mkdirSync(realDir, { recursive: true });
+      symlinkSync(realDir, linkDir);
+      expect(() => ensureMemoryDir(linkDir)).toThrow("symlinked memory directory");
+    });
+  });
+
+  describe("isSymlink", () => {
+    it("returns false for regular file", () => {
+      const file = join(tmpDir, "regular.txt");
+      writeFileSync(file, "content");
+      expect(isSymlink(file)).toBe(false);
+    });
+
+    it("returns true for symlink", () => {
+      const file = join(tmpDir, "real.txt");
+      const link = join(tmpDir, "link.txt");
+      writeFileSync(file, "content");
+      symlinkSync(file, link);
+      expect(isSymlink(link)).toBe(true);
+    });
+
+    it("returns false for nonexistent path", () => {
+      expect(isSymlink(join(tmpDir, "nope"))).toBe(false);
+    });
+  });
+
+  describe("safeReadFile", () => {
+    it("reads regular files", () => {
+      const file = join(tmpDir, "regular.txt");
+      writeFileSync(file, "hello");
+      expect(safeReadFile(file)).toBe("hello");
+    });
+
+    it("rejects symlinked files", () => {
+      const file = join(tmpDir, "real.txt");
+      const link = join(tmpDir, "link.txt");
+      writeFileSync(file, "secret");
+      symlinkSync(file, link);
+      expect(safeReadFile(link)).toBeUndefined();
+    });
+
+    it("returns undefined for nonexistent files", () => {
+      expect(safeReadFile(join(tmpDir, "nope.txt"))).toBeUndefined();
+    });
   });
 
   describe("readMemoryIndex", () => {
@@ -75,6 +174,24 @@ describe("memory", () => {
       writeFileSync(join(tmpDir, "MEMORY.md"), "# Memories\n- Item 1\n- Item 2");
       const result = readMemoryIndex(tmpDir);
       expect(result).toBe("# Memories\n- Item 1\n- Item 2");
+    });
+
+    it("rejects symlinked memory directory", () => {
+      const realDir = join(tmpDir, "real-mem");
+      const linkDir = join(tmpDir, "link-mem");
+      mkdirSync(realDir, { recursive: true });
+      writeFileSync(join(realDir, "MEMORY.md"), "# Secret");
+      symlinkSync(realDir, linkDir);
+      expect(readMemoryIndex(linkDir)).toBeUndefined();
+    });
+
+    it("rejects symlinked MEMORY.md file", () => {
+      const realFile = join(tmpDir, "secret.md");
+      writeFileSync(realFile, "# Secret");
+      const memDir = join(tmpDir, "mem-dir");
+      mkdirSync(memDir);
+      symlinkSync(realFile, join(memDir, "MEMORY.md"));
+      expect(readMemoryIndex(memDir)).toBeUndefined();
     });
 
     it("truncates content beyond 200 lines", () => {
@@ -112,6 +229,28 @@ describe("memory", () => {
       buildMemoryBlock("new-agent", "project", tmpDir);
       expect(existsSync(memDir)).toBe(true);
     });
+
+    it("includes Read/Write/Edit instructions", () => {
+      const block = buildMemoryBlock("test-agent", "project", tmpDir);
+      expect(block).toContain("Read, Write, and Edit tools");
+    });
+
+    it("uses correct directory for local scope", () => {
+      const block = buildMemoryBlock("test-agent", "local", tmpDir);
+      expect(block).toContain("agent-memory-local/test-agent");
+    });
+
+    it("uses correct directory for user scope", () => {
+      const block = buildMemoryBlock("test-agent", "user", tmpDir);
+      expect(block).toContain(".pi/agent-memory/test-agent");
+      expect(block).not.toContain(tmpDir);
+    });
+
+    it("includes scope label in header", () => {
+      expect(buildMemoryBlock("a", "project", tmpDir)).toContain("Memory scope: project");
+      expect(buildMemoryBlock("a", "local", tmpDir)).toContain("Memory scope: local");
+      expect(buildMemoryBlock("a", "user", tmpDir)).toContain("Memory scope: user");
+    });
   });
 
   describe("buildReadOnlyMemoryBlock", () => {
@@ -143,6 +282,30 @@ describe("memory", () => {
       const block = buildReadOnlyMemoryBlock("test-agent", "project", tmpDir);
       expect(block).toContain("No memory is available yet");
       expect(block).not.toContain("Create one");
+    });
+
+    it("includes scope label in header", () => {
+      expect(buildReadOnlyMemoryBlock("a", "project", tmpDir)).toContain("Memory scope: project");
+      expect(buildReadOnlyMemoryBlock("a", "local", tmpDir)).toContain("Memory scope: local");
+      expect(buildReadOnlyMemoryBlock("a", "user", tmpDir)).toContain("Memory scope: user");
+    });
+
+    it("does not mention memory directory path for write access", () => {
+      const block = buildReadOnlyMemoryBlock("test-agent", "project", tmpDir);
+      expect(block).not.toContain("persistent memory directory at:");
+      expect(block).not.toContain("Create one at");
+    });
+
+    it("rejects symlinked memory directory in read-only mode", () => {
+      const realDir = join(tmpDir, ".pi", "agent-memory", "test-agent");
+      mkdirSync(realDir, { recursive: true });
+      writeFileSync(join(realDir, "MEMORY.md"), "# Secret");
+      const linkDir = join(tmpDir, ".pi", "agent-memory", "linked-agent");
+      mkdirSync(join(tmpDir, ".pi", "agent-memory"), { recursive: true });
+      symlinkSync(realDir, linkDir);
+      // Should not read through the symlink
+      const block = buildReadOnlyMemoryBlock("linked-agent", "project", tmpDir);
+      expect(block).toContain("No memory is available yet");
     });
   });
 });

--- a/test/prompts.test.ts
+++ b/test/prompts.test.ts
@@ -202,4 +202,110 @@ describe("buildAgentPrompt", () => {
     expect(prompt).toContain("general-purpose coding agent");
     expect(prompt).toContain("Extra stuff.");
   });
+
+  it("injects memory block in replace mode", () => {
+    const config: AgentConfig = {
+      name: "mem-agent",
+      description: "Memory Agent",
+      builtinToolNames: [],
+      extensions: true,
+      skills: true,
+      systemPrompt: "You are a memory agent.",
+      promptMode: "replace",
+      inheritContext: false,
+      runInBackground: false,
+      isolated: false,
+    };
+    const extras = { memoryBlock: "# Agent Memory\nYou have persistent memory at /tmp/mem/" };
+    const prompt = buildAgentPrompt(config, "/workspace", env, undefined, extras);
+    expect(prompt).toContain("You are a memory agent.");
+    expect(prompt).toContain("Agent Memory");
+    expect(prompt).toContain("persistent memory");
+  });
+
+  it("injects memory block in append mode", () => {
+    const config: AgentConfig = {
+      name: "mem-append",
+      description: "Memory Append",
+      builtinToolNames: [],
+      extensions: true,
+      skills: true,
+      systemPrompt: "Custom instructions.",
+      promptMode: "append",
+      inheritContext: false,
+      runInBackground: false,
+      isolated: false,
+    };
+    const extras = { memoryBlock: "# Agent Memory\nPersistent memory here." };
+    const prompt = buildAgentPrompt(config, "/workspace", env, "Parent prompt.", extras);
+    expect(prompt).toContain("<sub_agent_context>");
+    expect(prompt).toContain("Agent Memory");
+    expect(prompt).toContain("Custom instructions.");
+  });
+
+  it("injects preloaded skill blocks", () => {
+    const config: AgentConfig = {
+      name: "skill-agent",
+      description: "Skill Agent",
+      builtinToolNames: [],
+      extensions: true,
+      skills: true,
+      systemPrompt: "You are a skill agent.",
+      promptMode: "replace",
+      inheritContext: false,
+      runInBackground: false,
+      isolated: false,
+    };
+    const extras = {
+      skillBlocks: [
+        { name: "api-conventions", content: "Use REST endpoints." },
+        { name: "error-handling", content: "Handle errors gracefully." },
+      ],
+    };
+    const prompt = buildAgentPrompt(config, "/workspace", env, undefined, extras);
+    expect(prompt).toContain("Preloaded Skill: api-conventions");
+    expect(prompt).toContain("Use REST endpoints.");
+    expect(prompt).toContain("Preloaded Skill: error-handling");
+    expect(prompt).toContain("Handle errors gracefully.");
+  });
+
+  it("injects both memory and skills", () => {
+    const config: AgentConfig = {
+      name: "full-agent",
+      description: "Full Agent",
+      builtinToolNames: [],
+      extensions: true,
+      skills: true,
+      systemPrompt: "Full agent.",
+      promptMode: "replace",
+      inheritContext: false,
+      runInBackground: false,
+      isolated: false,
+    };
+    const extras = {
+      memoryBlock: "# Memory\nRemember this.",
+      skillBlocks: [{ name: "skill1", content: "Skill content." }],
+    };
+    const prompt = buildAgentPrompt(config, "/workspace", env, undefined, extras);
+    expect(prompt).toContain("# Memory");
+    expect(prompt).toContain("Preloaded Skill: skill1");
+  });
+
+  it("no extras means no extra sections", () => {
+    const config: AgentConfig = {
+      name: "plain",
+      description: "Plain",
+      builtinToolNames: [],
+      extensions: true,
+      skills: true,
+      systemPrompt: "Plain agent.",
+      promptMode: "replace",
+      inheritContext: false,
+      runInBackground: false,
+      isolated: false,
+    };
+    const prompt = buildAgentPrompt(config, "/workspace", env);
+    expect(prompt).not.toContain("Agent Memory");
+    expect(prompt).not.toContain("Preloaded Skill");
+  });
 });

--- a/test/skill-loader.test.ts
+++ b/test/skill-loader.test.ts
@@ -1,0 +1,98 @@
+import { describe, it, expect, beforeEach, afterEach } from "vitest";
+import { mkdtempSync, mkdirSync, writeFileSync, rmSync } from "node:fs";
+import { join } from "node:path";
+import { tmpdir } from "node:os";
+import { preloadSkills } from "../src/skill-loader.js";
+
+describe("preloadSkills", () => {
+  let tmpDir: string;
+
+  beforeEach(() => {
+    tmpDir = mkdtempSync(join(tmpdir(), "pi-skill-test-"));
+  });
+
+  afterEach(() => {
+    rmSync(tmpDir, { recursive: true, force: true });
+  });
+
+  function writeSkill(name: string, content: string, ext = ".md") {
+    const dir = join(tmpDir, ".pi", "skills");
+    mkdirSync(dir, { recursive: true });
+    writeFileSync(join(dir, name + ext), content);
+  }
+
+  it("returns empty array for empty skill list", () => {
+    const result = preloadSkills([], tmpDir);
+    expect(result).toEqual([]);
+  });
+
+  it("loads a .md skill file", () => {
+    writeSkill("api-conventions", "# API Conventions\nUse REST.");
+    const result = preloadSkills(["api-conventions"], tmpDir);
+    expect(result).toHaveLength(1);
+    expect(result[0].name).toBe("api-conventions");
+    expect(result[0].content).toContain("API Conventions");
+  });
+
+  it("loads a .txt skill file", () => {
+    writeSkill("error-handling", "Handle errors gracefully.", ".txt");
+    const result = preloadSkills(["error-handling"], tmpDir);
+    expect(result).toHaveLength(1);
+    expect(result[0].content).toContain("Handle errors gracefully");
+  });
+
+  it("prefers .md over .txt", () => {
+    writeSkill("dual", "MD content", ".md");
+    writeSkill("dual", "TXT content", ".txt");
+    const result = preloadSkills(["dual"], tmpDir);
+    expect(result[0].content).toBe("MD content");
+  });
+
+  it("returns fallback message for missing skills", () => {
+    const result = preloadSkills(["nonexistent"], tmpDir);
+    expect(result).toHaveLength(1);
+    expect(result[0].name).toBe("nonexistent");
+    expect(result[0].content).toContain("not found");
+  });
+
+  it("loads multiple skills", () => {
+    writeSkill("skill-a", "Content A");
+    writeSkill("skill-b", "Content B");
+    const result = preloadSkills(["skill-a", "skill-b"], tmpDir);
+    expect(result).toHaveLength(2);
+    expect(result[0].content).toContain("Content A");
+    expect(result[1].content).toContain("Content B");
+  });
+
+  it("loads skills without extension", () => {
+    writeSkill("bare-skill", "Bare content", "");
+    const result = preloadSkills(["bare-skill"], tmpDir);
+    expect(result[0].content).toBe("Bare content");
+  });
+
+  it("skips skill names with path traversal (..)", () => {
+    const result = preloadSkills(["../../etc/passwd"], tmpDir);
+    expect(result).toHaveLength(1);
+    expect(result[0].content).toContain("path traversal");
+  });
+
+  it("skips skill names with forward slash", () => {
+    const result = preloadSkills(["sub/dir"], tmpDir);
+    expect(result).toHaveLength(1);
+    expect(result[0].content).toContain("path traversal");
+  });
+
+  it("skips skill names with backslash", () => {
+    const result = preloadSkills(["sub\\dir"], tmpDir);
+    expect(result).toHaveLength(1);
+    expect(result[0].content).toContain("path traversal");
+  });
+
+  it("loads valid skills alongside skipped unsafe ones", () => {
+    writeSkill("legit", "Good content");
+    const result = preloadSkills(["../evil", "legit"], tmpDir);
+    expect(result).toHaveLength(2);
+    expect(result[0].content).toContain("path traversal");
+    expect(result[1].content).toContain("Good content");
+  });
+});

--- a/test/skill-loader.test.ts
+++ b/test/skill-loader.test.ts
@@ -1,5 +1,5 @@
 import { describe, it, expect, beforeEach, afterEach } from "vitest";
-import { mkdtempSync, mkdirSync, writeFileSync, rmSync } from "node:fs";
+import { mkdtempSync, mkdirSync, writeFileSync, rmSync, symlinkSync } from "node:fs";
 import { join } from "node:path";
 import { tmpdir } from "node:os";
 import { preloadSkills } from "../src/skill-loader.js";
@@ -94,5 +94,29 @@ describe("preloadSkills", () => {
     expect(result).toHaveLength(2);
     expect(result[0].content).toContain("path traversal");
     expect(result[1].content).toContain("Good content");
+  });
+
+  it("rejects symlinked skill files", () => {
+    const dir = join(tmpDir, ".pi", "skills");
+    mkdirSync(dir, { recursive: true });
+    const secretFile = join(tmpDir, "secret.md");
+    writeFileSync(secretFile, "TOP SECRET CONTENT");
+    symlinkSync(secretFile, join(dir, "evil-skill.md"));
+    const result = preloadSkills(["evil-skill"], tmpDir);
+    expect(result).toHaveLength(1);
+    expect(result[0].content).toContain("not found");
+    expect(result[0].content).not.toContain("TOP SECRET");
+  });
+
+  it("skips names with spaces (whitelist validation)", () => {
+    const result = preloadSkills(["my skill"], tmpDir);
+    expect(result).toHaveLength(1);
+    expect(result[0].content).toContain("path traversal");
+  });
+
+  it("skips names starting with dot", () => {
+    const result = preloadSkills([".hidden"], tmpDir);
+    expect(result).toHaveLength(1);
+    expect(result[0].content).toContain("path traversal");
   });
 });

--- a/test/worktree.test.ts
+++ b/test/worktree.test.ts
@@ -1,0 +1,192 @@
+import { describe, it, expect, beforeEach, afterEach } from "vitest";
+import { mkdtempSync, mkdirSync, writeFileSync, rmSync, existsSync } from "node:fs";
+import { execFileSync } from "node:child_process";
+import { join } from "node:path";
+import { tmpdir } from "node:os";
+import { createWorktree, cleanupWorktree, pruneWorktrees } from "../src/worktree.js";
+
+/**
+ * Helper: create a temporary git repo with an initial commit.
+ */
+function initGitRepo(): string {
+  const dir = mkdtempSync(join(tmpdir(), "pi-wt-test-"));
+  execFileSync("git", ["init"], { cwd: dir, stdio: "pipe" });
+  execFileSync("git", ["config", "user.email", "test@test.com"], { cwd: dir, stdio: "pipe" });
+  execFileSync("git", ["config", "user.name", "Test"], { cwd: dir, stdio: "pipe" });
+  writeFileSync(join(dir, "README.md"), "# Test repo");
+  execFileSync("git", ["add", "README.md"], { cwd: dir, stdio: "pipe" });
+  execFileSync("git", ["commit", "-m", "initial"], { cwd: dir, stdio: "pipe" });
+  return dir;
+}
+
+describe("worktree", () => {
+  let repoDir: string;
+
+  beforeEach(() => {
+    repoDir = initGitRepo();
+  });
+
+  afterEach(() => {
+    // Clean up any lingering worktrees first, then remove repo
+    try { pruneWorktrees(repoDir); } catch { /* ignore */ }
+    rmSync(repoDir, { recursive: true, force: true });
+  });
+
+  describe("createWorktree", () => {
+    it("creates a worktree in tmpdir", () => {
+      const wt = createWorktree(repoDir, "test-id-1");
+      expect(wt).toBeDefined();
+      expect(existsSync(wt!.path)).toBe(true);
+      expect(wt!.branch).toBe("pi-agent-test-id-1");
+
+      // Verify it's a valid worktree with the repo's files
+      expect(existsSync(join(wt!.path, "README.md"))).toBe(true);
+
+      // Cleanup
+      try { execFileSync("git", ["worktree", "remove", "--force", wt!.path], { cwd: repoDir, stdio: "pipe" }); } catch { /* ignore */ }
+    });
+
+    it("returns undefined for non-git directory", () => {
+      const nonGit = mkdtempSync(join(tmpdir(), "pi-wt-nongit-"));
+      try {
+        const wt = createWorktree(nonGit, "test-id-2");
+        expect(wt).toBeUndefined();
+      } finally {
+        rmSync(nonGit, { recursive: true, force: true });
+      }
+    });
+
+    it("returns undefined for git repo with no commits", () => {
+      const emptyRepo = mkdtempSync(join(tmpdir(), "pi-wt-empty-"));
+      try {
+        execFileSync("git", ["init"], { cwd: emptyRepo, stdio: "pipe" });
+        const wt = createWorktree(emptyRepo, "no-commits");
+        expect(wt).toBeUndefined();
+      } finally {
+        rmSync(emptyRepo, { recursive: true, force: true });
+      }
+    });
+
+    it("uses unique paths for multiple worktrees", () => {
+      const wt1 = createWorktree(repoDir, "multi-1");
+      const wt2 = createWorktree(repoDir, "multi-2");
+      expect(wt1).toBeDefined();
+      expect(wt2).toBeDefined();
+      expect(wt1!.path).not.toBe(wt2!.path);
+
+      // Cleanup
+      try { execFileSync("git", ["worktree", "remove", "--force", wt1!.path], { cwd: repoDir, stdio: "pipe" }); } catch { /* ignore */ }
+      try { execFileSync("git", ["worktree", "remove", "--force", wt2!.path], { cwd: repoDir, stdio: "pipe" }); } catch { /* ignore */ }
+    });
+  });
+
+  describe("cleanupWorktree", () => {
+    it("removes worktree when no changes made", () => {
+      const wt = createWorktree(repoDir, "clean-1")!;
+      expect(wt).toBeDefined();
+
+      const result = cleanupWorktree(repoDir, wt, "test cleanup");
+      expect(result.hasChanges).toBe(false);
+      expect(result.branch).toBeUndefined();
+    });
+
+    it("commits changes and creates branch when changes exist", () => {
+      const wt = createWorktree(repoDir, "dirty-1")!;
+      expect(wt).toBeDefined();
+
+      // Make a change in the worktree
+      writeFileSync(join(wt.path, "new-file.txt"), "agent wrote this");
+
+      const result = cleanupWorktree(repoDir, wt, "added new file");
+      expect(result.hasChanges).toBe(true);
+      expect(result.branch).toBeDefined();
+      expect(result.branch).toContain("pi-agent-dirty-1");
+
+      // Verify the branch exists in the main repo
+      const branches = execFileSync("git", ["branch", "--list", result.branch!], {
+        cwd: repoDir, stdio: "pipe",
+      }).toString().trim();
+      expect(branches).toContain(result.branch!);
+
+      // Verify the commit message
+      const log = execFileSync("git", ["log", "--oneline", "-1", result.branch!], {
+        cwd: repoDir, stdio: "pipe",
+      }).toString().trim();
+      expect(log).toContain("pi-agent: added new file");
+
+      // Cleanup branch
+      try { execFileSync("git", ["branch", "-D", result.branch!], { cwd: repoDir, stdio: "pipe" }); } catch { /* ignore */ }
+    });
+
+    it("does not force-overwrite existing branch", () => {
+      // Create first worktree, make changes, cleanup → creates branch
+      const wt1 = createWorktree(repoDir, "conflict-1")!;
+      writeFileSync(join(wt1.path, "file1.txt"), "first run");
+      const result1 = cleanupWorktree(repoDir, wt1, "first");
+      expect(result1.branch).toBe("pi-agent-conflict-1");
+
+      // Create second worktree with same agent ID, make changes
+      const wt2 = createWorktree(repoDir, "conflict-1")!;
+      writeFileSync(join(wt2.path, "file2.txt"), "second run");
+      const result2 = cleanupWorktree(repoDir, wt2, "second");
+
+      // Should use a different branch name (timestamp suffix)
+      expect(result2.hasChanges).toBe(true);
+      expect(result2.branch).toBeDefined();
+      expect(result2.branch).not.toBe("pi-agent-conflict-1");
+      expect(result2.branch).toContain("pi-agent-conflict-1-");
+
+      // Both branches should exist
+      const branches = execFileSync("git", ["branch", "--list", "pi-agent-conflict-1*"], {
+        cwd: repoDir, stdio: "pipe",
+      }).toString().trim();
+      expect(branches).toContain("pi-agent-conflict-1");
+      expect(branches).toContain(result2.branch!);
+
+      // Cleanup
+      try { execFileSync("git", ["branch", "-D", result1.branch!], { cwd: repoDir, stdio: "pipe" }); } catch { /* ignore */ }
+      try { execFileSync("git", ["branch", "-D", result2.branch!], { cwd: repoDir, stdio: "pipe" }); } catch { /* ignore */ }
+    });
+
+    it("handles already-deleted worktree gracefully", () => {
+      const wt = createWorktree(repoDir, "gone-1")!;
+      // Manually delete the worktree directory
+      rmSync(wt.path, { recursive: true, force: true });
+
+      const result = cleanupWorktree(repoDir, wt, "already gone");
+      expect(result.hasChanges).toBe(false);
+    });
+
+    it("truncates commit message at 200 chars", () => {
+      const wt = createWorktree(repoDir, "long-msg")!;
+      writeFileSync(join(wt.path, "change.txt"), "something");
+      const longDesc = "x".repeat(300);
+      const result = cleanupWorktree(repoDir, wt, longDesc);
+      expect(result.hasChanges).toBe(true);
+
+      const log = execFileSync("git", ["log", "--oneline", "-1", result.branch!], {
+        cwd: repoDir, stdio: "pipe",
+      }).toString().trim();
+      // "pi-agent: " prefix (10 chars) + 200 chars of x = 210 total max
+      expect(log.length).toBeLessThanOrEqual(220); // some slack for hash prefix
+
+      // Cleanup
+      try { execFileSync("git", ["branch", "-D", result.branch!], { cwd: repoDir, stdio: "pipe" }); } catch { /* ignore */ }
+    });
+  });
+
+  describe("pruneWorktrees", () => {
+    it("does not throw on a clean repo", () => {
+      expect(() => pruneWorktrees(repoDir)).not.toThrow();
+    });
+
+    it("does not throw on non-git directory", () => {
+      const nonGit = mkdtempSync(join(tmpdir(), "pi-wt-nongit-"));
+      try {
+        expect(() => pruneWorktrees(nonGit)).not.toThrow();
+      } finally {
+        rmSync(nonGit, { recursive: true, force: true });
+      }
+    });
+  });
+});


### PR DESCRIPTION
  - Persistent agent memory with three scopes (user, project, local) and automatic read-only fallback for agents without write tools
  - Git worktree isolation (isolation: "worktree") for safe parallel file modifications in a temporary repo copy
  - Skill preloading — skills frontmatter now accepts a comma-separated list of skill names to inject into the prompt
  - Tool denylist (disallowed_tools) to block specific tools even if extensions would provide them
  - Prompt extras system for cleanly injecting memory and skill blocks into agent system prompts

______

  Details

  Persistent Agent Memory

  - New memory frontmatter: "user" (global), "project" (per-project), "local" (gitignored)
  - buildMemoryBlock() creates the memory dir and injects read-write instructions + MEMORY.md content
  - buildReadOnlyMemoryBlock() for agents without write/edit tools — injects existing memory as context without granting write access or creating directories
  - Key fix: read-only agents (e.g. Explore) with memory enabled no longer get silently escalated to read-write. The runner detects write capability and branches accordingly.

  Git Worktree Isolation

  - createWorktree() creates a detached worktree at HEAD in a temp directory
  - cleanupWorktree() auto-commits changes to a pi-agent-<id> branch, or removes the worktree if clean
  - pruneWorktrees() for crash recovery on AgentManager.dispose()
  - All internal cwd references use effectiveCwd (worktree path or parent cwd)

  Skill Preloading

  - skills: "planning, review" reads from .pi/skills/ (project) or ~/.pi/skills/ (global)
  - Tries .md, .txt, and bare extensions; project-level takes priority
  - Content injected into system prompt; noSkills: true passed to resource loader to avoid double-loading

  Tool Denylist

  - disallowed_tools: bash, write blocks tools even if builtinToolNames or extensions include them
  - Enforced in tool filtering for both extension-enabled and extension-disabled agents

  Refactors

  - agent-runner.ts: tool/extension/skill resolution moved before memory detection; ctx.cwd → effectiveCwd throughout
  - custom-agents.ts: extracted parseCsvField() helper; added csvListOptional() and parseMemory()
  - prompts.ts: new PromptExtras interface; buildAgentPrompt() accepts optional extras appended in both replace and append modes