### PR TITLE
Switch to upstream hold condition for bg agents/headless (remove monkeypatch)

### DIFF
--- a/src/index.ts
+++ b/src/index.ts
@@ -409,17 +409,6 @@ export default function (pi: ExtensionAPI) {
     });
   });
 
-  // Expose manager via Symbol.for() global registry for cross-package access.
-  // Standard Node.js pattern for cross-package singletons (used by OpenTelemetry, etc.).
-  const MANAGER_KEY = Symbol.for("pi-subagents:manager");
-  (globalThis as any)[MANAGER_KEY] = {
-    waitForAll: () => manager.waitForAll(),
-    hasRunning: () => manager.hasRunning(),
-    spawn: (piRef: any, ctx: any, type: string, prompt: string, options: any) =>
-      manager.spawn(piRef, ctx, type, prompt, options),
-    getRecord: (id: string) => manager.getRecord(id),
-  };
-
   // --- Cross-extension RPC via pi.events ---
   let currentCtx: ExtensionContext | undefined;
 
@@ -441,13 +430,19 @@ export default function (pi: ExtensionAPI) {
   // Broadcast readiness so extensions loaded after us can discover us
   pi.events.emit("subagents:ready", {});
 
+  // Hold print mode open while background agents are still running.
+  pi.setHoldCondition(async () => {
+    if (!manager.hasRunning()) return [];
+    await manager.waitForAll();
+    return [];
+  });
+
   // On shutdown, abort all agents immediately and clean up.
   // If the session is going down, there's nothing left to consume agent results.
   pi.on("session_shutdown", async () => {
     unsubSpawnRpc();
     unsubPingRpc();
     currentCtx = undefined;
-    delete (globalThis as any)[MANAGER_KEY];
     manager.abortAll();
     for (const timer of pendingNudges.values()) clearTimeout(timer);
     pendingNudges.clear();


### PR DESCRIPTION
extension api - switch to eventbus for events and request actions; keep log of requests

refs https://github.com/badlogic/pi-mono/pull/2138