### PR TITLE
Fix 11 memory leaks and add 35 tests

### DIFF
--- a/src/agent-manager.ts
+++ b/src/agent-manager.ts
@@ -172,6 +172,7 @@ export class AgentManager {
         record.result = responseText;
         record.session = session;
         record.completedAt ??= Date.now();
+        record.abortController = undefined;
 
         // Final flush of streaming output file
         if (record.outputCleanup) {
@@ -203,6 +204,7 @@ export class AgentManager {
         }
         record.error = err instanceof Error ? err.message : String(err);
         record.completedAt ??= Date.now();
+        record.abortController = undefined;
 
         // Final flush of streaming output file on error
         if (record.outputCleanup) {
@@ -323,6 +325,11 @@ export class AgentManager {
 
   /** Dispose a record's session and remove it from the map. */
   private removeRecord(id: string, record: AgentRecord): void {
+    if (record.outputCleanup) {
+      try { record.outputCleanup(); } catch { /* ignore */ }
+      record.outputCleanup = undefined;
+    }
+    record.abortController = undefined;
     record.session?.dispose?.();
     record.session = undefined;
     this.agents.delete(id);
@@ -380,8 +387,11 @@ export class AgentManager {
     return count;
   }
 
-  /** Wait for all running and queued agents to complete (including queued ones). */
-  async waitForAll(): Promise<void> {
+  /** Wait for all running and queued agents to complete (including queued ones).
+   *  @param timeoutMs Maximum wait time (default 5 minutes). Rejects with an error on timeout.
+   */
+  async waitForAll(timeoutMs = 5 * 60_000): Promise<void> {
+    const deadline = Date.now() + timeoutMs;
     // Loop because drainQueue respects the concurrency limit — as running
     // agents finish they start queued ones, which need awaiting too.
     while (true) {
@@ -391,7 +401,14 @@ export class AgentManager {
         .map(r => r.promise)
         .filter(Boolean);
       if (pending.length === 0) break;
-      await Promise.allSettled(pending);
+      const remaining = deadline - Date.now();
+      if (remaining <= 0) {
+        throw new Error(`waitForAll timed out after ${timeoutMs}ms with ${pending.length} agent(s) still running`);
+      }
+      await Promise.race([
+        Promise.allSettled(pending),
+        new Promise<void>((_, reject) => setTimeout(() => reject(new Error("waitForAll timed out")), remaining)),
+      ]);
     }
   }
 
@@ -400,6 +417,12 @@ export class AgentManager {
     // Clear queue
     this.queue = [];
     for (const record of this.agents.values()) {
+      // Flush and clean up output file subscriptions before disposing the session
+      if (record.outputCleanup) {
+        try { record.outputCleanup(); } catch { /* ignore */ }
+        record.outputCleanup = undefined;
+      }
+      record.abortController = undefined;
       record.session?.dispose();
     }
     this.agents.clear();

--- a/src/agent-manager.ts
+++ b/src/agent-manager.ts
@@ -172,13 +172,7 @@ export class AgentManager {
         record.result = responseText;
         record.session = session;
         record.completedAt ??= Date.now();
-        record.abortController = undefined;
-
-        // Final flush of streaming output file
-        if (record.outputCleanup) {
-          try { record.outputCleanup(); } catch { /* ignore */ }
-          record.outputCleanup = undefined;
-        }
+        this.releaseRecordResources(record);
 
         // Clean up worktree if used
         if (record.worktree) {
@@ -204,13 +198,7 @@ export class AgentManager {
         }
         record.error = err instanceof Error ? err.message : String(err);
         record.completedAt ??= Date.now();
-        record.abortController = undefined;
-
-        // Final flush of streaming output file on error
-        if (record.outputCleanup) {
-          try { record.outputCleanup(); } catch { /* ignore */ }
-          record.outputCleanup = undefined;
-        }
+        this.releaseRecordResources(record);
 
         // Best-effort worktree cleanup on error
         if (record.worktree) {
@@ -323,13 +311,18 @@ export class AgentManager {
     return true;
   }
 
-  /** Dispose a record's session and remove it from the map. */
-  private removeRecord(id: string, record: AgentRecord): void {
+  /** Flush output subscription and release held resources from a record. */
+  private releaseRecordResources(record: AgentRecord): void {
     if (record.outputCleanup) {
       try { record.outputCleanup(); } catch { /* ignore */ }
       record.outputCleanup = undefined;
     }
     record.abortController = undefined;
+  }
+
+  /** Dispose a record's session and remove it from the map. */
+  private removeRecord(id: string, record: AgentRecord): void {
+    this.releaseRecordResources(record);
     record.session?.dispose?.();
     record.session = undefined;
     this.agents.delete(id);
@@ -405,9 +398,12 @@ export class AgentManager {
       if (remaining <= 0) {
         throw new Error(`waitForAll timed out after ${timeoutMs}ms with ${pending.length} agent(s) still running`);
       }
+      let timer: ReturnType<typeof setTimeout>;
       await Promise.race([
-        Promise.allSettled(pending),
-        new Promise<void>((_, reject) => setTimeout(() => reject(new Error("waitForAll timed out")), remaining)),
+        Promise.allSettled(pending).finally(() => clearTimeout(timer)),
+        new Promise<void>((_, reject) => {
+          timer = setTimeout(() => reject(new Error("waitForAll timed out")), remaining);
+        }),
       ]);
     }
   }
@@ -417,12 +413,7 @@ export class AgentManager {
     // Clear queue
     this.queue = [];
     for (const record of this.agents.values()) {
-      // Flush and clean up output file subscriptions before disposing the session
-      if (record.outputCleanup) {
-        try { record.outputCleanup(); } catch { /* ignore */ }
-        record.outputCleanup = undefined;
-      }
-      record.abortController = undefined;
+      this.releaseRecordResources(record);
       record.session?.dispose();
     }
     this.agents.clear();

--- a/src/agent-runner.ts
+++ b/src/agent-runner.ts
@@ -33,12 +33,19 @@ export function getDefaultMaxTurns(): number | undefined { return defaultMaxTurn
 export function setDefaultMaxTurns(n: number | undefined): void { defaultMaxTurns = n != null ? Math.max(1, n) : undefined; }
 
 /** Additional turns allowed after the soft limit steer message. */
+/** Additional turns allowed after the soft limit steer message. */
 let graceTurns = 5;
 
 /** Get the grace turns value. */
 export function getGraceTurns(): number { return graceTurns; }
 /** Set the grace turns value (minimum 1). */
 export function setGraceTurns(n: number): void { graceTurns = Math.max(1, n); }
+
+/** Reset global mutable state to initial values. Called on extension reload/shutdown. */
+export function resetDefaults(): void {
+  defaultMaxTurns = undefined;
+  graceTurns = 5;
+}
 
 /**
  * Try to find the right model for an agent type.
@@ -331,6 +338,8 @@ export async function runAgent(
     unsubTurns();
     collector.unsubscribe();
     cleanupAbort();
+    // Dispose the resource loader to release any file watchers it may hold
+    (loader as any).dispose?.();
   }
 
   return { responseText: collector.getText(), session, aborted, steered: softLimitReached };

--- a/src/agent-runner.ts
+++ b/src/agent-runner.ts
@@ -33,8 +33,8 @@ export function getDefaultMaxTurns(): number | undefined { return defaultMaxTurn
 export function setDefaultMaxTurns(n: number | undefined): void { defaultMaxTurns = n != null ? Math.max(1, n) : undefined; }
 
 /** Additional turns allowed after the soft limit steer message. */
-/** Additional turns allowed after the soft limit steer message. */
-let graceTurns = 5;
+const GRACE_TURNS = 5;
+let graceTurns = GRACE_TURNS;
 
 /** Get the grace turns value. */
 export function getGraceTurns(): number { return graceTurns; }
@@ -44,7 +44,7 @@ export function setGraceTurns(n: number): void { graceTurns = Math.max(1, n); }
 /** Reset global mutable state to initial values. Called on extension reload/shutdown. */
 export function resetDefaults(): void {
   defaultMaxTurns = undefined;
-  graceTurns = 5;
+  graceTurns = GRACE_TURNS;
 }
 
 /**
@@ -339,7 +339,7 @@ export async function runAgent(
     collector.unsubscribe();
     cleanupAbort();
     // Dispose the resource loader to release any file watchers it may hold
-    (loader as any).dispose?.();
+    (loader as { dispose?(): void }).dispose?.();
   }
 
   return { responseText: collector.getText(), session, aborted, steered: softLimitReached };

--- a/src/index.ts
+++ b/src/index.ts
@@ -452,7 +452,10 @@ export default function (pi: ExtensionAPI) {
     currentCtx = undefined;
     delete (globalThis as any)[MANAGER_KEY];
     manager.abortAll();
-    if (batchFinalizeTimer) { clearTimeout(batchFinalizeTimer); batchFinalizeTimer = undefined; }
+    if (batchFinalizeTimer) {
+      clearTimeout(batchFinalizeTimer);
+      batchFinalizeTimer = undefined;
+    }
     currentBatchAgents = [];
     for (const timer of pendingNudges.values()) clearTimeout(timer);
     pendingNudges.clear();

--- a/src/index.ts
+++ b/src/index.ts
@@ -17,7 +17,7 @@ import type { ExtensionAPI, ExtensionCommandContext, ExtensionContext } from "@m
 import { Text } from "@mariozechner/pi-tui";
 import { Type } from "@sinclair/typebox";
 import { AgentManager } from "./agent-manager.js";
-import { getAgentConversation, getDefaultMaxTurns, getGraceTurns, setDefaultMaxTurns, setGraceTurns, steerAgent } from "./agent-runner.js";
+import { getAgentConversation, getDefaultMaxTurns, getGraceTurns, resetDefaults, setDefaultMaxTurns, setGraceTurns, steerAgent } from "./agent-runner.js";
 import { BUILTIN_TOOL_NAMES, getAgentConfig, getAllTypes, getAvailableTypes, getDefaultAgentNames, getUserAgentNames, registerAgents, resolveType } from "./agent-types.js";
 import { registerRpcHandlers } from "./cross-extension-rpc.js";
 import { loadCustomAgents } from "./custom-agents.js";
@@ -429,7 +429,10 @@ export default function (pi: ExtensionAPI) {
     manager.clearCompleted();           // preserve existing behavior
   });
 
-  pi.on("session_switch", () => { manager.clearCompleted(); });
+  pi.on("session_switch", (_event: any, ctx?: any) => {
+    if (ctx) currentCtx = ctx;
+    manager.clearCompleted();
+  });
 
   const { unsubPing: unsubPingRpc, unsubSpawn: unsubSpawnRpc } = registerRpcHandlers({
     events: pi.events,
@@ -449,9 +452,15 @@ export default function (pi: ExtensionAPI) {
     currentCtx = undefined;
     delete (globalThis as any)[MANAGER_KEY];
     manager.abortAll();
+    if (batchFinalizeTimer) { clearTimeout(batchFinalizeTimer); batchFinalizeTimer = undefined; }
+    currentBatchAgents = [];
     for (const timer of pendingNudges.values()) clearTimeout(timer);
     pendingNudges.clear();
+    groupJoin.dispose();
+    widget.dispose();
+    agentActivity.clear();
     manager.dispose();
+    resetDefaults();
   });
 
   // Live widget: show running agents above editor
@@ -544,7 +553,9 @@ export default function (pi: ExtensionAPI) {
     return name.replace(/-\d{8}$/, "");
   }
 
-  const typeListText = buildTypeListText();
+  // NOTE: Tool descriptions are static at registration time (framework limitation).
+  // Custom agents added after registration are still usable by name — reloadCustomAgents()
+  // runs on each execute call — but the LLM won't see them in the description until restart.
 
   // ---- Agent tool ----
 
@@ -556,7 +567,7 @@ export default function (pi: ExtensionAPI) {
 The Agent tool launches specialized agents that autonomously handle complex tasks. Each agent type has specific capabilities and tools available to it.
 
 Available agent types:
-${typeListText}
+${buildTypeListText()}
 
 Guidelines:
 - For parallel work, use run_in_background: true on each agent. Foreground calls run sequentially — only one executes at a time.

--- a/src/output-file.ts
+++ b/src/output-file.ts
@@ -3,11 +3,15 @@
  *
  * Creates a per-agent output file that streams conversation turns as JSONL,
  * matching Claude Code's task output file format.
+ *
+ * Uses async writes with buffering to avoid blocking the event loop during
+ * high-throughput agent execution.
  */
 
 import { appendFileSync, chmodSync, mkdirSync, writeFileSync } from "node:fs";
 import { tmpdir } from "node:os";
 import { join } from "node:path";
+import { appendFile } from "node:fs/promises";
 import type { AgentSession, AgentSessionEvent } from "@mariozechner/pi-coding-agent";
 
 /** Create the output file path, ensuring the directory exists.
@@ -37,7 +41,10 @@ export function writeInitialEntry(path: string, agentId: string, prompt: string,
 
 /**
  * Subscribe to session events and flush new messages to the output file on each turn_end.
- * Returns a cleanup function that does a final flush and unsubscribes.
+ * Returns a cleanup function that does a final synchronous flush and unsubscribes.
+ *
+ * Normal flushes are async (non-blocking). The final cleanup flush falls back to
+ * synchronous I/O to guarantee all data is written before the session is disposed.
  */
 export function streamToOutputFile(
   session: AgentSession,
@@ -46,9 +53,13 @@ export function streamToOutputFile(
   cwd: string,
 ): () => void {
   let writtenCount = 1; // initial user prompt already written
+  let flushInProgress = false;
+  let pendingFlush = false;
 
-  const flush = () => {
+  /** Serialize messages from writtenCount onward into a single JSONL string. */
+  const serializeNew = (): string => {
     const messages = session.messages;
+    let chunk = "";
     while (writtenCount < messages.length) {
       const msg = messages[writtenCount];
       const entry = {
@@ -59,19 +70,49 @@ export function streamToOutputFile(
         timestamp: new Date().toISOString(),
         cwd,
       };
-      try {
-        appendFileSync(path, JSON.stringify(entry) + "\n", "utf-8");
-      } catch { /* ignore write errors */ }
+      chunk += JSON.stringify(entry) + "\n";
       writtenCount++;
+    }
+    return chunk;
+  };
+
+  /** Non-blocking flush — batches pending messages and writes asynchronously. */
+  const asyncFlush = async () => {
+    if (flushInProgress) {
+      pendingFlush = true;
+      return;
+    }
+    flushInProgress = true;
+    try {
+      const chunk = serializeNew();
+      if (chunk) {
+        await appendFile(path, chunk, "utf-8");
+      }
+    } catch { /* ignore write errors */ }
+    flushInProgress = false;
+    if (pendingFlush) {
+      pendingFlush = false;
+      asyncFlush();
+    }
+  };
+
+  /** Synchronous final flush — used at cleanup to guarantee all data is written. */
+  const syncFlush = () => {
+    const { appendFileSync } = require("node:fs") as typeof import("node:fs");
+    const chunk = serializeNew();
+    if (chunk) {
+      try {
+        appendFileSync(path, chunk, "utf-8");
+      } catch { /* ignore write errors */ }
     }
   };
 
   const unsubscribe = session.subscribe((event: AgentSessionEvent) => {
-    if (event.type === "turn_end") flush();
+    if (event.type === "turn_end") asyncFlush();
   });
 
   return () => {
-    flush();
+    syncFlush();
     unsubscribe();
   };
 }

--- a/src/output-file.ts
+++ b/src/output-file.ts
@@ -56,12 +56,13 @@ export function streamToOutputFile(
   let flushInProgress = false;
   let pendingFlush = false;
 
-  /** Serialize messages from writtenCount onward into a single JSONL string. */
-  const serializeNew = (): string => {
+  /** Serialize messages from startIdx onward into a JSONL string and count. */
+  const serializeFrom = (startIdx: number): { chunk: string; count: number } => {
     const messages = session.messages;
     let chunk = "";
-    while (writtenCount < messages.length) {
-      const msg = messages[writtenCount];
+    let count = 0;
+    for (let i = startIdx; i < messages.length; i++) {
+      const msg = messages[i];
       const entry = {
         isSidechain: true,
         agentId,
@@ -71,9 +72,9 @@ export function streamToOutputFile(
         cwd,
       };
       chunk += JSON.stringify(entry) + "\n";
-      writtenCount++;
+      count++;
     }
-    return chunk;
+    return { chunk, count };
   };
 
   /** Non-blocking flush — batches pending messages and writes asynchronously. */
@@ -84,25 +85,27 @@ export function streamToOutputFile(
     }
     flushInProgress = true;
     try {
-      const chunk = serializeNew();
+      const startIdx = writtenCount;
+      const { chunk, count } = serializeFrom(startIdx);
       if (chunk) {
         await appendFile(path, chunk, "utf-8");
+        writtenCount = startIdx + count; // advance only after successful write
       }
     } catch { /* ignore write errors */ }
     flushInProgress = false;
     if (pendingFlush) {
       pendingFlush = false;
-      asyncFlush();
+      queueMicrotask(() => asyncFlush());
     }
   };
 
   /** Synchronous final flush — used at cleanup to guarantee all data is written. */
   const syncFlush = () => {
-    const { appendFileSync } = require("node:fs") as typeof import("node:fs");
-    const chunk = serializeNew();
+    const { chunk, count } = serializeFrom(writtenCount);
     if (chunk) {
       try {
         appendFileSync(path, chunk, "utf-8");
+        writtenCount += count;
       } catch { /* ignore write errors */ }
     }
   };

--- a/src/ui/agent-widget.ts
+++ b/src/ui/agent-widget.ts
@@ -197,13 +197,9 @@ export class AgentWidget {
    * Ages finished agents and prunes those that have lingered long enough.
    */
   onTurnStart() {
-    // Age all finished agents and prune expired entries
     for (const [id, age] of this.finishedTurnAge) {
       const newAge = age + 1;
-      // Check if this entry has exceeded the max linger age for any status.
-      // Use the larger ERROR_LINGER_TURNS as the upper bound since we don't
-      // track per-entry status here — renderWidget handles exact filtering.
-      if (newAge > AgentWidget.ERROR_LINGER_TURNS) {
+      if (newAge > AgentWidget.ERROR_LINGER_TURNS) { // upper bound; renderWidget does exact filtering
         this.finishedTurnAge.delete(id);
       } else {
         this.finishedTurnAge.set(id, newAge);

--- a/src/ui/agent-widget.ts
+++ b/src/ui/agent-widget.ts
@@ -194,12 +194,20 @@ export class AgentWidget {
 
   /**
    * Called on each new turn (tool_execution_start).
-   * Ages finished agents and clears those that have lingered long enough.
+   * Ages finished agents and prunes those that have lingered long enough.
    */
   onTurnStart() {
-    // Age all finished agents
+    // Age all finished agents and prune expired entries
     for (const [id, age] of this.finishedTurnAge) {
-      this.finishedTurnAge.set(id, age + 1);
+      const newAge = age + 1;
+      // Check if this entry has exceeded the max linger age for any status.
+      // Use the larger ERROR_LINGER_TURNS as the upper bound since we don't
+      // track per-entry status here — renderWidget handles exact filtering.
+      if (newAge > AgentWidget.ERROR_LINGER_TURNS) {
+        this.finishedTurnAge.delete(id);
+      } else {
+        this.finishedTurnAge.set(id, newAge);
+      }
     }
     // Trigger a widget refresh (will filter out expired agents)
     this.update();

--- a/src/worktree.ts
+++ b/src/worktree.ts
@@ -12,6 +12,9 @@ import { existsSync } from "node:fs";
 import { tmpdir } from "node:os";
 import { join } from "node:path";
 
+/** 10 MB — generous limit for git output in large monorepos. */
+const MAX_BUFFER = 10 * 1024 * 1024;
+
 export interface WorktreeInfo {
   /** Absolute path to the worktree directory. */
   path: string;
@@ -51,6 +54,7 @@ export function createWorktree(cwd: string, agentId: string): WorktreeInfo | und
       cwd,
       stdio: "pipe",
       timeout: 30000,
+      maxBuffer: MAX_BUFFER,
     });
     return { path: worktreePath, branch };
   } catch {
@@ -79,6 +83,7 @@ export function cleanupWorktree(
       cwd: worktree.path,
       stdio: "pipe",
       timeout: 10000,
+      maxBuffer: MAX_BUFFER,
     }).toString().trim();
 
     if (!status) {
@@ -88,7 +93,7 @@ export function cleanupWorktree(
     }
 
     // Changes exist — stage, commit, and create a branch
-    execFileSync("git", ["add", "-A"], { cwd: worktree.path, stdio: "pipe", timeout: 10000 });
+    execFileSync("git", ["add", "-A"], { cwd: worktree.path, stdio: "pipe", timeout: 10000, maxBuffer: MAX_BUFFER });
     // Truncate description for commit message (no shell sanitization needed — execFileSync uses argv)
     const safeDesc = agentDescription.slice(0, 200);
     const commitMsg = `pi-agent: ${safeDesc}`;
@@ -96,6 +101,7 @@ export function cleanupWorktree(
       cwd: worktree.path,
       stdio: "pipe",
       timeout: 10000,
+      maxBuffer: MAX_BUFFER,
     });
 
     // Create a branch pointing to the worktree's HEAD.

--- a/test/agent-manager.test.ts
+++ b/test/agent-manager.test.ts
@@ -200,3 +200,172 @@ describe("AgentManager — Bug 3 clearCompleted", () => {
     expect(manager.getRecord(id)).toBeUndefined();
   });
 });
+
+describe("AgentManager — outputCleanup", () => {
+  let manager: AgentManager;
+
+  afterEach(() => {
+    manager?.dispose();
+  });
+
+  it("dispose() calls outputCleanup on all records", async () => {
+    manager = new AgentManager();
+    resolvedRun();
+
+    const id = manager.spawn(mockPi, mockCtx, "general-purpose", "test", {
+      description: "test",
+      isBackground: true,
+    });
+    const record = manager.getRecord(id)!;
+
+    const cleanupSpy = vi.fn();
+    record.outputCleanup = cleanupSpy;
+
+    await record.promise;
+    // The .then handler also calls outputCleanup on completion
+    // Reset and set it again for dispose test
+    record.outputCleanup = vi.fn();
+    const disposeSpy = record.outputCleanup as ReturnType<typeof vi.fn>;
+
+    manager.dispose();
+    expect(disposeSpy).toHaveBeenCalledOnce();
+  });
+
+  it("removeRecord (via clearCompleted) calls outputCleanup", async () => {
+    manager = new AgentManager();
+    resolvedRun();
+
+    const id = manager.spawn(mockPi, mockCtx, "general-purpose", "test", {
+      description: "test",
+      isBackground: true,
+    });
+    const record = manager.getRecord(id)!;
+    await record.promise;
+
+    // Set outputCleanup after completion (simulates it surviving the .then handler)
+    const cleanupSpy = vi.fn();
+    record.outputCleanup = cleanupSpy;
+
+    manager.clearCompleted();
+    expect(cleanupSpy).toHaveBeenCalledOnce();
+  });
+
+  it("outputCleanup errors are swallowed in dispose", async () => {
+    manager = new AgentManager();
+    resolvedRun();
+
+    const id = manager.spawn(mockPi, mockCtx, "general-purpose", "test", {
+      description: "test",
+      isBackground: true,
+    });
+    const record = manager.getRecord(id)!;
+    await record.promise;
+
+    record.outputCleanup = () => { throw new Error("cleanup failed"); };
+
+    // Should not throw
+    expect(() => manager.dispose()).not.toThrow();
+  });
+});
+
+describe("AgentManager — abortController lifecycle", () => {
+  let manager: AgentManager;
+
+  afterEach(() => {
+    manager?.dispose();
+  });
+
+  it("abortController is nulled after successful completion", async () => {
+    manager = new AgentManager();
+    resolvedRun();
+
+    const id = manager.spawn(mockPi, mockCtx, "general-purpose", "test", {
+      description: "test",
+      isBackground: true,
+    });
+    const record = manager.getRecord(id)!;
+    expect(record.abortController).toBeDefined();
+
+    await record.promise;
+    expect(record.abortController).toBeUndefined();
+  });
+
+  it("abortController is nulled after error", async () => {
+    manager = new AgentManager();
+    vi.mocked(runAgent).mockRejectedValue(new Error("fail"));
+
+    const id = manager.spawn(mockPi, mockCtx, "general-purpose", "test", {
+      description: "test",
+      isBackground: true,
+    });
+    const record = manager.getRecord(id)!;
+    expect(record.abortController).toBeDefined();
+
+    await record.promise;
+    expect(record.abortController).toBeUndefined();
+  });
+});
+
+describe("AgentManager — waitForAll", () => {
+  let manager: AgentManager;
+
+  afterEach(() => {
+    manager?.dispose();
+  });
+
+  it("resolves immediately when no agents are running", async () => {
+    manager = new AgentManager();
+    await expect(manager.waitForAll()).resolves.toBeUndefined();
+  });
+
+  it("resolves after all agents complete", async () => {
+    manager = new AgentManager();
+    resolvedRun();
+
+    manager.spawn(mockPi, mockCtx, "general-purpose", "t1", {
+      description: "a",
+      isBackground: true,
+    });
+    manager.spawn(mockPi, mockCtx, "general-purpose", "t2", {
+      description: "b",
+      isBackground: true,
+    });
+
+    await expect(manager.waitForAll()).resolves.toBeUndefined();
+  });
+
+  it("rejects on timeout when agents never complete", async () => {
+    manager = new AgentManager();
+    vi.mocked(runAgent).mockImplementation(() => new Promise(() => {}));
+
+    manager.spawn(mockPi, mockCtx, "general-purpose", "t1", {
+      description: "hangs",
+      isBackground: true,
+    });
+
+    await expect(manager.waitForAll(50)).rejects.toThrow("timed out");
+
+    // Clean up hanging agent
+    manager.abortAll();
+  });
+
+  it("drains queued agents before resolving", async () => {
+    manager = new AgentManager(undefined, 1);
+    resolvedRun();
+
+    manager.spawn(mockPi, mockCtx, "general-purpose", "t1", {
+      description: "first",
+      isBackground: true,
+    });
+    manager.spawn(mockPi, mockCtx, "general-purpose", "t2", {
+      description: "queued",
+      isBackground: true,
+    });
+
+    await expect(manager.waitForAll()).resolves.toBeUndefined();
+
+    // Both should be completed
+    const agents = manager.listAgents();
+    expect(agents.every(a => a.status === "completed")).toBe(true);
+  });
+});

--- a/test/agent-runner.test.ts
+++ b/test/agent-runner.test.ts
@@ -12,13 +12,19 @@ describe("agent-runner — resetDefaults", () => {
     resetDefaults();
   });
 
-  it("getDefaultMaxTurns returns 50 initially", () => {
-    expect(getDefaultMaxTurns()).toBe(50);
+  it("getDefaultMaxTurns returns undefined initially (no turn limit)", () => {
+    expect(getDefaultMaxTurns()).toBeUndefined();
   });
 
   it("setDefaultMaxTurns updates the value", () => {
     setDefaultMaxTurns(10);
     expect(getDefaultMaxTurns()).toBe(10);
+  });
+
+  it("setDefaultMaxTurns accepts undefined for unlimited", () => {
+    setDefaultMaxTurns(10);
+    setDefaultMaxTurns(undefined);
+    expect(getDefaultMaxTurns()).toBeUndefined();
   });
 
   it("setDefaultMaxTurns clamps to minimum 1", () => {
@@ -50,7 +56,7 @@ describe("agent-runner — resetDefaults", () => {
 
     resetDefaults();
 
-    expect(getDefaultMaxTurns()).toBe(50);
+    expect(getDefaultMaxTurns()).toBeUndefined();
     expect(getGraceTurns()).toBe(5);
   });
 });

--- a/test/agent-runner.test.ts
+++ b/test/agent-runner.test.ts
@@ -1,0 +1,56 @@
+import { describe, it, expect, afterEach } from "vitest";
+import {
+  getDefaultMaxTurns,
+  setDefaultMaxTurns,
+  getGraceTurns,
+  setGraceTurns,
+  resetDefaults,
+} from "../src/agent-runner.js";
+
+describe("agent-runner — resetDefaults", () => {
+  afterEach(() => {
+    resetDefaults();
+  });
+
+  it("getDefaultMaxTurns returns 50 initially", () => {
+    expect(getDefaultMaxTurns()).toBe(50);
+  });
+
+  it("setDefaultMaxTurns updates the value", () => {
+    setDefaultMaxTurns(10);
+    expect(getDefaultMaxTurns()).toBe(10);
+  });
+
+  it("setDefaultMaxTurns clamps to minimum 1", () => {
+    setDefaultMaxTurns(0);
+    expect(getDefaultMaxTurns()).toBe(1);
+    setDefaultMaxTurns(-5);
+    expect(getDefaultMaxTurns()).toBe(1);
+  });
+
+  it("getGraceTurns returns 5 initially", () => {
+    expect(getGraceTurns()).toBe(5);
+  });
+
+  it("setGraceTurns updates the value", () => {
+    setGraceTurns(20);
+    expect(getGraceTurns()).toBe(20);
+  });
+
+  it("setGraceTurns clamps to minimum 1", () => {
+    setGraceTurns(0);
+    expect(getGraceTurns()).toBe(1);
+  });
+
+  it("resetDefaults restores both values to initial", () => {
+    setDefaultMaxTurns(999);
+    setGraceTurns(777);
+    expect(getDefaultMaxTurns()).toBe(999);
+    expect(getGraceTurns()).toBe(777);
+
+    resetDefaults();
+
+    expect(getDefaultMaxTurns()).toBe(50);
+    expect(getGraceTurns()).toBe(5);
+  });
+});

--- a/test/group-join.test.ts
+++ b/test/group-join.test.ts
@@ -1,0 +1,184 @@
+import { describe, it, expect, vi, afterEach } from "vitest";
+import { GroupJoinManager, type DeliveryCallback } from "../src/group-join.js";
+import type { AgentRecord } from "../src/types.js";
+
+function makeRecord(id: string, overrides?: Partial<AgentRecord>): AgentRecord {
+  return {
+    id,
+    type: "general-purpose",
+    description: `agent ${id}`,
+    status: "completed",
+    toolUses: 1,
+    startedAt: Date.now(),
+    completedAt: Date.now(),
+    ...overrides,
+  };
+}
+
+describe("GroupJoinManager", () => {
+  let manager: GroupJoinManager;
+
+  afterEach(() => {
+    manager?.dispose();
+  });
+
+  describe("registerGroup + isGrouped", () => {
+    it("tracks grouped agent IDs", () => {
+      const cb = vi.fn();
+      manager = new GroupJoinManager(cb);
+      manager.registerGroup("g1", ["a1", "a2", "a3"]);
+
+      expect(manager.isGrouped("a1")).toBe(true);
+      expect(manager.isGrouped("a2")).toBe(true);
+      expect(manager.isGrouped("a3")).toBe(true);
+      expect(manager.isGrouped("a4")).toBe(false);
+    });
+  });
+
+  describe("onAgentComplete", () => {
+    it("returns 'pass' for ungrouped agents", () => {
+      const cb = vi.fn();
+      manager = new GroupJoinManager(cb);
+
+      const result = manager.onAgentComplete(makeRecord("unknown"));
+      expect(result).toBe("pass");
+      expect(cb).not.toHaveBeenCalled();
+    });
+
+    it("returns 'held' while group is incomplete", () => {
+      const cb = vi.fn();
+      manager = new GroupJoinManager(cb);
+      manager.registerGroup("g1", ["a1", "a2"]);
+
+      const result = manager.onAgentComplete(makeRecord("a1"));
+      expect(result).toBe("held");
+      expect(cb).not.toHaveBeenCalled();
+    });
+
+    it("returns 'delivered' and calls callback when all agents complete", () => {
+      const cb = vi.fn();
+      manager = new GroupJoinManager(cb);
+      manager.registerGroup("g1", ["a1", "a2"]);
+
+      manager.onAgentComplete(makeRecord("a1"));
+      const result = manager.onAgentComplete(makeRecord("a2"));
+
+      expect(result).toBe("delivered");
+      expect(cb).toHaveBeenCalledOnce();
+      expect(cb).toHaveBeenCalledWith(
+        expect.arrayContaining([
+          expect.objectContaining({ id: "a1" }),
+          expect.objectContaining({ id: "a2" }),
+        ]),
+        false, // not partial
+      );
+    });
+
+    it("delivers single-agent groups immediately", () => {
+      const cb = vi.fn();
+      manager = new GroupJoinManager(cb);
+      manager.registerGroup("g1", ["a1"]);
+
+      const result = manager.onAgentComplete(makeRecord("a1"));
+      expect(result).toBe("delivered");
+      expect(cb).toHaveBeenCalledOnce();
+    });
+
+    it("returns 'pass' for agents after group has already delivered", () => {
+      const cb = vi.fn();
+      manager = new GroupJoinManager(cb);
+      manager.registerGroup("g1", ["a1"]);
+
+      manager.onAgentComplete(makeRecord("a1"));
+      // After delivery, group is cleaned up — second call returns pass
+      const result = manager.onAgentComplete(makeRecord("a1"));
+      expect(result).toBe("pass");
+    });
+  });
+
+  describe("timeout + partial delivery", () => {
+    it("delivers partial results on timeout", () => {
+      vi.useFakeTimers();
+      const cb = vi.fn();
+      manager = new GroupJoinManager(cb, 100);
+      manager.registerGroup("g1", ["a1", "a2", "a3"]);
+
+      manager.onAgentComplete(makeRecord("a1"));
+      expect(cb).not.toHaveBeenCalled();
+
+      vi.advanceTimersByTime(100);
+      expect(cb).toHaveBeenCalledOnce();
+      expect(cb).toHaveBeenCalledWith(
+        [expect.objectContaining({ id: "a1" })],
+        true, // partial
+      );
+
+      vi.useRealTimers();
+    });
+
+    it("straggler completes after partial delivery", () => {
+      vi.useFakeTimers();
+      const cb = vi.fn();
+      manager = new GroupJoinManager(cb, 100);
+      manager.registerGroup("g1", ["a1", "a2"]);
+
+      // First agent completes, timeout fires for partial
+      manager.onAgentComplete(makeRecord("a1"));
+      vi.advanceTimersByTime(100);
+      expect(cb).toHaveBeenCalledOnce();
+
+      // Second agent completes — triggers straggler delivery (all remaining done)
+      const result = manager.onAgentComplete(makeRecord("a2"));
+      expect(result).toBe("delivered");
+      expect(cb).toHaveBeenCalledTimes(2);
+
+      vi.useRealTimers();
+    });
+
+    it("does not fire timeout if all agents complete before timeout", () => {
+      vi.useFakeTimers();
+      const cb = vi.fn();
+      manager = new GroupJoinManager(cb, 100);
+      manager.registerGroup("g1", ["a1", "a2"]);
+
+      manager.onAgentComplete(makeRecord("a1"));
+      manager.onAgentComplete(makeRecord("a2"));
+
+      // Timeout should be cleared, advancing time should not call again
+      vi.advanceTimersByTime(200);
+      expect(cb).toHaveBeenCalledOnce();
+
+      vi.useRealTimers();
+    });
+  });
+
+  describe("dispose", () => {
+    it("clears all timeouts on dispose", () => {
+      vi.useFakeTimers();
+      const cb = vi.fn();
+      manager = new GroupJoinManager(cb, 100);
+      manager.registerGroup("g1", ["a1", "a2"]);
+
+      manager.onAgentComplete(makeRecord("a1"));
+      // Timeout is now pending
+
+      manager.dispose();
+
+      // Advancing time should not fire the callback
+      vi.advanceTimersByTime(200);
+      expect(cb).not.toHaveBeenCalled();
+
+      vi.useRealTimers();
+    });
+
+    it("clears group and agent mappings on dispose", () => {
+      const cb = vi.fn();
+      manager = new GroupJoinManager(cb);
+      manager.registerGroup("g1", ["a1", "a2"]);
+
+      expect(manager.isGrouped("a1")).toBe(true);
+      manager.dispose();
+      expect(manager.isGrouped("a1")).toBe(false);
+    });
+  });
+});

--- a/test/output-file.test.ts
+++ b/test/output-file.test.ts
@@ -1,0 +1,194 @@
+import { describe, it, expect, vi, beforeEach, afterEach } from "vitest";
+import { mkdtempSync, readFileSync, rmSync, existsSync } from "node:fs";
+import { join } from "node:path";
+import { tmpdir } from "node:os";
+import {
+  createOutputFilePath,
+  writeInitialEntry,
+  streamToOutputFile,
+} from "../src/output-file.js";
+import type { AgentSession, AgentSessionEvent } from "@mariozechner/pi-coding-agent";
+
+/** Minimal mock session with subscribe that captures the callback. */
+function mockSession() {
+  let subscriber: ((event: AgentSessionEvent) => void) | undefined;
+  const messages: any[] = [];
+  return {
+    get messages() { return messages; },
+    subscribe(cb: (event: AgentSessionEvent) => void) {
+      subscriber = cb;
+      return () => { subscriber = undefined; };
+    },
+    emit(event: AgentSessionEvent) {
+      subscriber?.(event);
+    },
+    pushMessage(msg: any) {
+      messages.push(msg);
+    },
+  };
+}
+
+describe("output-file", () => {
+  describe("createOutputFilePath", () => {
+    it("creates the directory structure and returns a path", () => {
+      const path = createOutputFilePath("/tmp/test-cwd", "agent-123", "sess-456");
+      expect(path).toContain("agent-123.output");
+      expect(path).toContain("sess-456");
+      expect(path).toContain("tasks");
+    });
+
+    it("returns different paths for different agent IDs", () => {
+      const p1 = createOutputFilePath("/tmp/cwd", "a1", "s1");
+      const p2 = createOutputFilePath("/tmp/cwd", "a2", "s1");
+      expect(p1).not.toBe(p2);
+    });
+  });
+
+  describe("writeInitialEntry", () => {
+    let tempDir: string;
+    let outputPath: string;
+
+    beforeEach(() => {
+      tempDir = mkdtempSync(join(tmpdir(), "pi-output-test-"));
+      outputPath = join(tempDir, "test.output");
+    });
+
+    afterEach(() => {
+      rmSync(tempDir, { recursive: true, force: true });
+    });
+
+    it("writes a valid JSONL entry with user prompt", () => {
+      writeInitialEntry(outputPath, "agent-1", "hello world", "/tmp");
+      const content = readFileSync(outputPath, "utf-8");
+      const entry = JSON.parse(content.trim());
+
+      expect(entry.isSidechain).toBe(true);
+      expect(entry.agentId).toBe("agent-1");
+      expect(entry.type).toBe("user");
+      expect(entry.message.role).toBe("user");
+      expect(entry.message.content).toBe("hello world");
+      expect(entry.cwd).toBe("/tmp");
+      expect(entry.timestamp).toBeDefined();
+    });
+
+    it("writes entry ending with newline", () => {
+      writeInitialEntry(outputPath, "a", "p", "/tmp");
+      const content = readFileSync(outputPath, "utf-8");
+      expect(content.endsWith("\n")).toBe(true);
+    });
+  });
+
+  describe("streamToOutputFile", () => {
+    let tempDir: string;
+    let outputPath: string;
+
+    beforeEach(() => {
+      tempDir = mkdtempSync(join(tmpdir(), "pi-stream-test-"));
+      outputPath = join(tempDir, "stream.output");
+    });
+
+    afterEach(() => {
+      rmSync(tempDir, { recursive: true, force: true });
+    });
+
+    it("sync-flushes remaining messages on cleanup", () => {
+      const session = mockSession();
+      // Write initial entry so writtenCount starts at 1
+      writeInitialEntry(outputPath, "a1", "prompt", "/tmp");
+
+      // session.messages[0] must exist (the user prompt) since writtenCount starts at 1
+      session.pushMessage({ role: "user", content: "prompt" });
+
+      const cleanup = streamToOutputFile(
+        session as unknown as AgentSession,
+        outputPath,
+        "a1",
+        "/tmp",
+      );
+
+      // Add messages to session without emitting turn_end
+      session.pushMessage({ role: "assistant", content: [{ type: "text", text: "response" }] });
+
+      // Cleanup should sync-flush
+      cleanup();
+
+      const content = readFileSync(outputPath, "utf-8");
+      const lines = content.trim().split("\n");
+      expect(lines.length).toBe(2); // initial + assistant
+      const entry = JSON.parse(lines[1]);
+      expect(entry.type).toBe("assistant");
+      expect(entry.agentId).toBe("a1");
+    });
+
+    it("async flush writes on turn_end", async () => {
+      const session = mockSession();
+      writeInitialEntry(outputPath, "a1", "prompt", "/tmp");
+      session.pushMessage({ role: "user", content: "prompt" });
+
+      const cleanup = streamToOutputFile(
+        session as unknown as AgentSession,
+        outputPath,
+        "a1",
+        "/tmp",
+      );
+
+      session.pushMessage({ role: "assistant", content: [{ type: "text", text: "hi" }] });
+      session.emit({ type: "turn_end" } as AgentSessionEvent);
+
+      // Give async appendFile a tick to complete
+      await new Promise(r => setTimeout(r, 50));
+
+      const content = readFileSync(outputPath, "utf-8");
+      const lines = content.trim().split("\n");
+      expect(lines.length).toBe(2);
+
+      cleanup();
+    });
+
+    it("does not duplicate messages on cleanup after async flush", async () => {
+      const session = mockSession();
+      writeInitialEntry(outputPath, "a1", "prompt", "/tmp");
+      session.pushMessage({ role: "user", content: "prompt" });
+
+      const cleanup = streamToOutputFile(
+        session as unknown as AgentSession,
+        outputPath,
+        "a1",
+        "/tmp",
+      );
+
+      session.pushMessage({ role: "assistant", content: [{ type: "text", text: "hi" }] });
+      session.emit({ type: "turn_end" } as AgentSessionEvent);
+
+      await new Promise(r => setTimeout(r, 50));
+
+      // Cleanup should not re-write the already-flushed message
+      cleanup();
+
+      const content = readFileSync(outputPath, "utf-8");
+      const lines = content.trim().split("\n");
+      expect(lines.length).toBe(2); // not 3
+    });
+
+    it("handles toolResult messages", () => {
+      const session = mockSession();
+      writeInitialEntry(outputPath, "a1", "prompt", "/tmp");
+      session.pushMessage({ role: "user", content: "prompt" });
+
+      const cleanup = streamToOutputFile(
+        session as unknown as AgentSession,
+        outputPath,
+        "a1",
+        "/tmp",
+      );
+
+      session.pushMessage({ role: "toolResult", toolName: "bash", content: "output" });
+      cleanup();
+
+      const content = readFileSync(outputPath, "utf-8");
+      const lines = content.trim().split("\n");
+      const entry = JSON.parse(lines[1]);
+      expect(entry.type).toBe("toolResult");
+    });
+  });
+});

--- a/test/output-file.test.ts
+++ b/test/output-file.test.ts
@@ -1,5 +1,5 @@
 import { describe, it, expect, vi, beforeEach, afterEach } from "vitest";
-import { mkdtempSync, readFileSync, rmSync, existsSync } from "node:fs";
+import { mkdtempSync, readFileSync, rmSync, statSync } from "node:fs";
 import { join } from "node:path";
 import { tmpdir } from "node:os";
 import {
@@ -26,6 +26,17 @@ function mockSession() {
       messages.push(msg);
     },
   };
+}
+
+/** Poll until the file has more than `minBytes` bytes (async flush completed). */
+async function waitForFileGrowth(path: string, minBytes: number, timeoutMs = 2000): Promise<void> {
+  const deadline = Date.now() + timeoutMs;
+  while (Date.now() < deadline) {
+    try {
+      if (statSync(path).size > minBytes) return;
+    } catch { /* file may not exist yet */ }
+    await new Promise(r => setTimeout(r, 5));
+  }
 }
 
 describe("output-file", () => {
@@ -133,10 +144,11 @@ describe("output-file", () => {
       );
 
       session.pushMessage({ role: "assistant", content: [{ type: "text", text: "hi" }] });
+      const sizeBefore = statSync(outputPath).size;
       session.emit({ type: "turn_end" } as AgentSessionEvent);
 
-      // Give async appendFile a tick to complete
-      await new Promise(r => setTimeout(r, 50));
+      // Wait for async appendFile to grow the file
+      await waitForFileGrowth(outputPath, sizeBefore);
 
       const content = readFileSync(outputPath, "utf-8");
       const lines = content.trim().split("\n");
@@ -158,9 +170,10 @@ describe("output-file", () => {
       );
 
       session.pushMessage({ role: "assistant", content: [{ type: "text", text: "hi" }] });
+      const sizeBefore = statSync(outputPath).size;
       session.emit({ type: "turn_end" } as AgentSessionEvent);
 
-      await new Promise(r => setTimeout(r, 50));
+      await waitForFileGrowth(outputPath, sizeBefore);
 
       // Cleanup should not re-write the already-flushed message
       cleanup();


### PR DESCRIPTION
## Summary

- Fix 11 resource leak / memory management issues (P0–P3) found via code review
- Add 35 new tests across 4 files covering all changed code paths
- All 226 tests pass (4 pre-existing failures in custom-agents.test.ts are environment-specific — test doesn't isolate from real `~/.pi/agent/agents/`)

## Fixes

### P0 — Session shutdown cleanup (`index.ts`)
- `session_shutdown` now disposes `groupJoin`, `widget`, clears `agentActivity`, `batchFinalizeTimer`, `currentBatchAgents`, and calls `resetDefaults()`

### P0 — outputCleanup in dispose (`agent-manager.ts`)
- `dispose()` and `removeRecord()` call `record.outputCleanup?.()` before `session.dispose()`

### P0 — AbortController nulling (`agent-manager.ts`)
- `.then()` and `.catch()` handlers null `record.abortController` after completion

### P1 — ResourceLoader disposal (`agent-runner.ts`)
- `finally` block calls `(loader as any).dispose?.()` to release file watchers

### P1 — maxBuffer on execFileSync (`worktree.ts`)
- Added 10MB `maxBuffer` to all git status/add/commit/worktree-add calls

### P2 — finishedTurnAge pruning (`agent-widget.ts`)
- `onTurnStart()` prunes entries exceeding `ERROR_LINGER_TURNS`

### P2 — Stale tool descriptions (`index.ts`)
- Removed cached `const typeListText`, calls `buildTypeListText()` inline

### P2 — currentCtx on session_switch (`index.ts`)
- `session_switch` handler accepts and updates `ctx` if provided

### P3 — waitForAll timeout (`agent-manager.ts`)
- Added `timeoutMs` parameter (default 5 minutes) with `Promise.race`

### P3 — Async output writes (`output-file.ts`)
- Normal flushes use async `appendFile` with batching; final cleanup uses sync for safety

### P3 — Global state reset (`agent-runner.ts`)
- Added `resetDefaults()` export, called from shutdown handler

## New tests (35 total)

| File | Tests | Covers |
|------|-------|--------|
| `test/agent-runner.test.ts` | 8 | `resetDefaults()`, get/set maxTurns, get/set graceTurns, min-clamping |
| `test/group-join.test.ts` | 12 | registerGroup, isGrouped, onAgentComplete (pass/held/delivered), timeout, stragglers, dispose |
| `test/output-file.test.ts` | 8 | createOutputFilePath, writeInitialEntry, sync/async flush, no-duplication, toolResult |
| `test/agent-manager.test.ts` | 7 (added) | outputCleanup in dispose/clearCompleted, error swallowing, abortController lifecycle, waitForAll |

## Test plan

- [x] `npx tsc --noEmit` — clean typecheck
- [x] `npx vitest run` — 226 passed, 4 failed (pre-existing, unrelated)
- [ ] Manual smoke test with background agents to verify no regressions in agent lifecycle