### PR TITLE
Reliability improvements: leak fixes, two-tier cleanup, error diagnostics

### DIFF
--- a/README.md
+++ b/README.md
@@ -154,9 +154,9 @@ All fields are optional — sensible defaults for everything.
 |-------|---------|-------------|
 | `description` | filename | Agent description shown in tool listings |
 | `display_name` | — | Display name for UI (e.g. widget, agent list) |
-| `tools` | all 7 | Comma-separated built-in tools: read, bash, edit, write, grep, find, ls. `none` for no tools |
-| `extensions` | `true` | Inherit MCP/extension tools. `false` to disable |
-| `skills` | `true` | Inherit skills from parent. Can be a comma-separated list of skill names to preload from `.pi/skills/` |
+| `tools` | all 7 | Comma-separated built-in tools: read, bash, edit, write, grep, find, ls. `all` for all tools, `none` for no tools |
+| `extensions` | `true` | Inherit MCP/extension tools. `true` or `all` to inherit all, `false` or `none` to disable, or comma-separated allowlist |
+| `skills` | `true` | Inherit skills from parent. `true` or `all` to inherit all, `false` or `none` to disable, or comma-separated list of skill names to preload from `.pi/skills/` |
 | `memory` | — | Persistent agent memory scope: `project`, `local`, or `user`. Auto-detects read-only agents |
 | `disallowed_tools` | — | Comma-separated tools to deny even if extensions provide them |
 | `isolation` | — | Set to `worktree` to run in an isolated git worktree |
@@ -166,7 +166,6 @@ All fields are optional — sensible defaults for everything.
 | `prompt_mode` | `replace` | `replace`: body is the full system prompt. `append`: body appended to parent's prompt (agent acts as a "parent twin" with optional extra instructions) |
 | `inherit_context` | `false` | Fork parent conversation into agent |
 | `run_in_background` | `false` | Run in background by default |
-| `isolation` | — | `worktree`: run in a temporary git worktree for full repo isolation |
 | `isolated` | `false` | No extension/MCP tools, only built-in |
 | `enabled` | `true` | Set to `false` to disable an agent (useful for hiding a default agent per-project) |
 

--- a/src/agent-manager.ts
+++ b/src/agent-manager.ts
@@ -210,8 +210,7 @@ export class AgentManager {
         if (record.status !== "stopped") {
           record.status = "error";
         }
-        const modelInfo = record.modelName ? ` [model: ${record.modelName}]` : "";
-        record.error = (err instanceof Error ? err.message : String(err)) + modelInfo;
+        record.error = (err instanceof Error ? err.message : String(err));
         record.completedAt ??= Date.now();
         this.captureStats(record);
         this.releaseRecordResources(record);
@@ -337,7 +336,9 @@ export class AgentManager {
         outputTokens: s.tokens?.output ?? 0,
         totalTokens: s.tokens?.total ?? 0,
       };
-    } catch {}
+    } catch (err) {
+      if (process.env.DEBUG) console.debug("[pi-subagents] captureStats failed:", err);
+    }
   }
 
   /** Flush output subscription and release held resources from a record. */
@@ -365,11 +366,17 @@ export class AgentManager {
   }
 
   private cleanup() {
-    const cutoff = Date.now() - this.cleanupRetentionMs;
-    for (const record of this.agents.values()) {
+    const tier1Cutoff = Date.now() - this.cleanupRetentionMs;
+    const tier2Cutoff = Date.now() - this.cleanupRetentionMs * 3;
+    for (const [id, record] of this.agents) {
       if (record.status === "running" || record.status === "queued") continue;
-      if ((record.completedAt ?? 0) >= cutoff) continue;
-      if (record.session) this.disposeRecordSession(record); // Tier 1 only
+      const completed = record.completedAt ?? 0;
+      if (completed >= tier1Cutoff) continue;
+      if (completed < tier2Cutoff) {
+        this.removeRecord(id, record); // Tier 2: full removal
+      } else if (record.session) {
+        this.disposeRecordSession(record); // Tier 1: session only
+      }
     }
   }
 

--- a/src/agent-manager.ts
+++ b/src/agent-manager.ts
@@ -172,6 +172,7 @@ export class AgentManager {
         record.result = responseText;
         record.session = session;
         record.completedAt ??= Date.now();
+        record.abortController = undefined;
 
         // Final flush of streaming output file
         if (record.outputCleanup) {
@@ -203,6 +204,7 @@ export class AgentManager {
         }
         record.error = err instanceof Error ? err.message : String(err);
         record.completedAt ??= Date.now();
+        record.abortController = undefined;
 
         // Final flush of streaming output file on error
         if (record.outputCleanup) {
@@ -323,6 +325,11 @@ export class AgentManager {
 
   /** Dispose a record's session and remove it from the map. */
   private removeRecord(id: string, record: AgentRecord): void {
+    if (record.outputCleanup) {
+      try { record.outputCleanup(); } catch { /* ignore */ }
+      record.outputCleanup = undefined;
+    }
+    record.abortController = undefined;
     record.session?.dispose?.();
     record.session = undefined;
     this.agents.delete(id);
@@ -380,8 +387,11 @@ export class AgentManager {
     return count;
   }
 
-  /** Wait for all running and queued agents to complete (including queued ones). */
-  async waitForAll(): Promise<void> {
+  /** Wait for all running and queued agents to complete (including queued ones).
+   *  @param timeoutMs Maximum wait time (default 5 minutes). Rejects with an error on timeout.
+   */
+  async waitForAll(timeoutMs = 5 * 60_000): Promise<void> {
+    const deadline = Date.now() + timeoutMs;
     // Loop because drainQueue respects the concurrency limit — as running
     // agents finish they start queued ones, which need awaiting too.
     while (true) {
@@ -391,7 +401,14 @@ export class AgentManager {
         .map(r => r.promise)
         .filter(Boolean);
       if (pending.length === 0) break;
-      await Promise.allSettled(pending);
+      const remaining = deadline - Date.now();
+      if (remaining <= 0) {
+        throw new Error(`waitForAll timed out after ${timeoutMs}ms with ${pending.length} agent(s) still running`);
+      }
+      await Promise.race([
+        Promise.allSettled(pending),
+        new Promise<void>((_, reject) => setTimeout(() => reject(new Error("waitForAll timed out")), remaining)),
+      ]);
     }
   }
 
@@ -400,6 +417,12 @@ export class AgentManager {
     // Clear queue
     this.queue = [];
     for (const record of this.agents.values()) {
+      // Flush and clean up output file subscriptions before disposing the session
+      if (record.outputCleanup) {
+        try { record.outputCleanup(); } catch { /* ignore */ }
+        record.outputCleanup = undefined;
+      }
+      record.abortController = undefined;
       record.session?.dispose();
     }
     this.agents.clear();

--- a/src/agent-manager.ts
+++ b/src/agent-manager.ts
@@ -172,13 +172,7 @@ export class AgentManager {
         record.result = responseText;
         record.session = session;
         record.completedAt ??= Date.now();
-        record.abortController = undefined;
-
-        // Final flush of streaming output file
-        if (record.outputCleanup) {
-          try { record.outputCleanup(); } catch { /* ignore */ }
-          record.outputCleanup = undefined;
-        }
+        this.releaseRecordResources(record);
 
         // Clean up worktree if used
         if (record.worktree) {
@@ -204,13 +198,7 @@ export class AgentManager {
         }
         record.error = err instanceof Error ? err.message : String(err);
         record.completedAt ??= Date.now();
-        record.abortController = undefined;
-
-        // Final flush of streaming output file on error
-        if (record.outputCleanup) {
-          try { record.outputCleanup(); } catch { /* ignore */ }
-          record.outputCleanup = undefined;
-        }
+        this.releaseRecordResources(record);
 
         // Best-effort worktree cleanup on error
         if (record.worktree) {
@@ -323,13 +311,18 @@ export class AgentManager {
     return true;
   }
 
-  /** Dispose a record's session and remove it from the map. */
-  private removeRecord(id: string, record: AgentRecord): void {
+  /** Flush output subscription and release held resources from a record. */
+  private releaseRecordResources(record: AgentRecord): void {
     if (record.outputCleanup) {
       try { record.outputCleanup(); } catch { /* ignore */ }
       record.outputCleanup = undefined;
     }
     record.abortController = undefined;
+  }
+
+  /** Dispose a record's session and remove it from the map. */
+  private removeRecord(id: string, record: AgentRecord): void {
+    this.releaseRecordResources(record);
     record.session?.dispose?.();
     record.session = undefined;
     this.agents.delete(id);
@@ -405,9 +398,12 @@ export class AgentManager {
       if (remaining <= 0) {
         throw new Error(`waitForAll timed out after ${timeoutMs}ms with ${pending.length} agent(s) still running`);
       }
+      let timer: ReturnType<typeof setTimeout>;
       await Promise.race([
-        Promise.allSettled(pending),
-        new Promise<void>((_, reject) => setTimeout(() => reject(new Error("waitForAll timed out")), remaining)),
+        Promise.allSettled(pending).finally(() => clearTimeout(timer)),
+        new Promise<void>((_, reject) => {
+          timer = setTimeout(() => reject(new Error("waitForAll timed out")), remaining);
+        }),
       ]);
     }
   }
@@ -417,12 +413,7 @@ export class AgentManager {
     // Clear queue
     this.queue = [];
     for (const record of this.agents.values()) {
-      // Flush and clean up output file subscriptions before disposing the session
-      if (record.outputCleanup) {
-        try { record.outputCleanup(); } catch { /* ignore */ }
-        record.outputCleanup = undefined;
-      }
-      record.abortController = undefined;
+      this.releaseRecordResources(record);
       record.session?.dispose();
     }
     this.agents.clear();

--- a/src/agent-manager.ts
+++ b/src/agent-manager.ts
@@ -220,7 +220,9 @@ export class AgentManager {
           try {
             const wtResult = cleanupWorktree(ctx.cwd, record.worktree, options.description);
             record.worktreeResult = wtResult;
-          } catch { /* ignore cleanup errors */ }
+          } catch (err) {
+            if (process.env.DEBUG) console.debug(`[pi-subagents] Worktree cleanup failed for ${id}:`, err);
+          }
         }
 
         if (options.isBackground) {

--- a/src/agent-manager.ts
+++ b/src/agent-manager.ts
@@ -45,6 +45,8 @@ interface SpawnOptions {
   onSessionCreated?: (session: AgentSession) => void;
   /** Called at the end of each agentic turn with the cumulative count. */
   onTurnEnd?: (turnCount: number) => void;
+  /** Human-readable model identifier for diagnostics. */
+  modelName?: string;
 }
 
 export class AgentManager {
@@ -53,6 +55,7 @@ export class AgentManager {
   private onComplete?: OnAgentComplete;
   private onStart?: OnAgentStart;
   private maxConcurrent: number;
+  private cleanupRetentionMs = 10 * 60_000;
 
   /** Queue of background agents waiting to start. */
   private queue: { id: string; args: SpawnArgs }[] = [];
@@ -76,6 +79,15 @@ export class AgentManager {
 
   getMaxConcurrent(): number {
     return this.maxConcurrent;
+  }
+
+  /** Update the cleanup retention period (how long completed records survive before session disposal). */
+  setCleanupRetention(ms: number) {
+    this.cleanupRetentionMs = Math.max(60_000, ms);
+  }
+
+  getCleanupRetention(): number {
+    return this.cleanupRetentionMs;
   }
 
   /**
@@ -118,6 +130,7 @@ export class AgentManager {
   private startAgent(id: string, record: AgentRecord, { pi, ctx, type, prompt, options }: SpawnArgs) {
     record.status = "running";
     record.startedAt = Date.now();
+    if (options.modelName) record.modelName = options.modelName;
     if (options.isBackground) this.runningBackground++;
     this.onStart?.(record);
 
@@ -172,6 +185,7 @@ export class AgentManager {
         record.result = responseText;
         record.session = session;
         record.completedAt ??= Date.now();
+        this.captureStats(record);
         this.releaseRecordResources(record);
 
         // Clean up worktree if used
@@ -196,8 +210,10 @@ export class AgentManager {
         if (record.status !== "stopped") {
           record.status = "error";
         }
-        record.error = err instanceof Error ? err.message : String(err);
+        const modelInfo = record.modelName ? ` [model: ${record.modelName}]` : "";
+        record.error = (err instanceof Error ? err.message : String(err)) + modelInfo;
         record.completedAt ??= Date.now();
+        this.captureStats(record);
         this.releaseRecordResources(record);
 
         // Best-effort worktree cleanup on error
@@ -311,6 +327,19 @@ export class AgentManager {
     return true;
   }
 
+  /** Capture session token stats onto the record (idempotent). */
+  private captureStats(record: AgentRecord): void {
+    if (!record.session || record.stats) return;
+    try {
+      const s = record.session.getSessionStats();
+      record.stats = {
+        inputTokens: s.tokens?.input ?? 0,
+        outputTokens: s.tokens?.output ?? 0,
+        totalTokens: s.tokens?.total ?? 0,
+      };
+    } catch {}
+  }
+
   /** Flush output subscription and release held resources from a record. */
   private releaseRecordResources(record: AgentRecord): void {
     if (record.outputCleanup) {
@@ -320,20 +349,27 @@ export class AgentManager {
     record.abortController = undefined;
   }
 
-  /** Dispose a record's session and remove it from the map. */
-  private removeRecord(id: string, record: AgentRecord): void {
+  /** Tier 1 cleanup: dispose session resources but keep the record in the Map. */
+  private disposeRecordSession(record: AgentRecord): void {
+    this.captureStats(record);
     this.releaseRecordResources(record);
     record.session?.dispose?.();
     record.session = undefined;
+    record.promise = undefined;
+  }
+
+  /** Dispose a record's session and remove it from the map. */
+  private removeRecord(id: string, record: AgentRecord): void {
+    this.disposeRecordSession(record);
     this.agents.delete(id);
   }
 
   private cleanup() {
-    const cutoff = Date.now() - 10 * 60_000;
-    for (const [id, record] of this.agents) {
+    const cutoff = Date.now() - this.cleanupRetentionMs;
+    for (const record of this.agents.values()) {
       if (record.status === "running" || record.status === "queued") continue;
       if ((record.completedAt ?? 0) >= cutoff) continue;
-      this.removeRecord(id, record);
+      if (record.session) this.disposeRecordSession(record); // Tier 1 only
     }
   }
 

--- a/src/agent-runner.ts
+++ b/src/agent-runner.ts
@@ -33,12 +33,19 @@ export function getDefaultMaxTurns(): number | undefined { return defaultMaxTurn
 export function setDefaultMaxTurns(n: number | undefined): void { defaultMaxTurns = n != null ? Math.max(1, n) : undefined; }
 
 /** Additional turns allowed after the soft limit steer message. */
+/** Additional turns allowed after the soft limit steer message. */
 let graceTurns = 5;
 
 /** Get the grace turns value. */
 export function getGraceTurns(): number { return graceTurns; }
 /** Set the grace turns value (minimum 1). */
 export function setGraceTurns(n: number): void { graceTurns = Math.max(1, n); }
+
+/** Reset global mutable state to initial values. Called on extension reload/shutdown. */
+export function resetDefaults(): void {
+  defaultMaxTurns = undefined;
+  graceTurns = 5;
+}
 
 /**
  * Try to find the right model for an agent type.
@@ -331,6 +338,8 @@ export async function runAgent(
     unsubTurns();
     collector.unsubscribe();
     cleanupAbort();
+    // Dispose the resource loader to release any file watchers it may hold
+    (loader as any).dispose?.();
   }
 
   return { responseText: collector.getText(), session, aborted, steered: softLimitReached };

--- a/src/agent-runner.ts
+++ b/src/agent-runner.ts
@@ -33,8 +33,8 @@ export function getDefaultMaxTurns(): number | undefined { return defaultMaxTurn
 export function setDefaultMaxTurns(n: number | undefined): void { defaultMaxTurns = n != null ? Math.max(1, n) : undefined; }
 
 /** Additional turns allowed after the soft limit steer message. */
-/** Additional turns allowed after the soft limit steer message. */
-let graceTurns = 5;
+const GRACE_TURNS = 5;
+let graceTurns = GRACE_TURNS;
 
 /** Get the grace turns value. */
 export function getGraceTurns(): number { return graceTurns; }
@@ -44,7 +44,7 @@ export function setGraceTurns(n: number): void { graceTurns = Math.max(1, n); }
 /** Reset global mutable state to initial values. Called on extension reload/shutdown. */
 export function resetDefaults(): void {
   defaultMaxTurns = undefined;
-  graceTurns = 5;
+  graceTurns = GRACE_TURNS;
 }
 
 /**
@@ -339,7 +339,7 @@ export async function runAgent(
     collector.unsubscribe();
     cleanupAbort();
     // Dispose the resource loader to release any file watchers it may hold
-    (loader as any).dispose?.();
+    (loader as { dispose?(): void }).dispose?.();
   }
 
   return { responseText: collector.getText(), session, aborted, steered: softLimitReached };

--- a/src/custom-agents.ts
+++ b/src/custom-agents.ts
@@ -101,10 +101,12 @@ function parseCsvField(val: unknown): string[] | undefined {
 
 /**
  * Parse a comma-separated list field with defaults.
- * omitted → defaults; "none"/empty → []; csv → listed items.
+ * omitted → defaults; "all" → defaults; "none"/empty → []; csv → listed items.
  */
 function csvList(val: unknown, defaults: string[]): string[] {
   if (val === undefined || val === null) return defaults;
+  const s = String(val).trim();
+  if (s === "all") return defaults;
   return parseCsvField(val) ?? [];
 }
 

--- a/src/custom-agents.ts
+++ b/src/custom-agents.ts
@@ -35,7 +35,8 @@ function loadFromDir(dir: string, agents: Map<string, AgentConfig>, source: "pro
   let files: string[];
   try {
     files = readdirSync(dir).filter(f => f.endsWith(".md"));
-  } catch {
+  } catch (err) {
+    if (process.env.DEBUG) console.debug(`[pi-subagents] Failed to read agents dir ${dir}:`, err);
     return;
   }
 
@@ -45,7 +46,8 @@ function loadFromDir(dir: string, agents: Map<string, AgentConfig>, source: "pro
     let content: string;
     try {
       content = readFileSync(join(dir, file), "utf-8");
-    } catch {
+    } catch (err) {
+      if (process.env.DEBUG) console.debug(`[pi-subagents] Failed to read agent file ${join(dir, file)}:`, err);
       continue;
     }
 
@@ -107,7 +109,9 @@ function csvList(val: unknown, defaults: string[]): string[] {
   if (val === undefined || val === null) return defaults;
   const s = String(val).trim();
   if (s === "all") return defaults;
-  return parseCsvField(val) ?? [];
+  if (!s || s === "none") return [];
+  const items = s.split(",").map(t => t.trim()).filter(Boolean);
+  return items.length > 0 ? items : [];
 }
 
 /**

--- a/src/custom-agents.ts
+++ b/src/custom-agents.ts
@@ -133,11 +133,12 @@ function parseMemory(val: unknown): MemoryScope | undefined {
 
 /**
  * Parse an inherit field (extensions, skills).
- * omitted/true → true (inherit all); false/"none"/empty → false; csv → listed names.
+ * omitted/true/"all" → true (inherit all); false/"none"/empty → false; csv → listed names.
  */
 function inheritField(val: unknown): true | string[] | false {
   if (val === undefined || val === null || val === true) return true;
   if (val === false || val === "none") return false;
+  if (typeof val === "string" && val.trim() === "all") return true;
   const items = csvList(val, []);
   return items.length > 0 ? items : false;
 }

--- a/src/index.ts
+++ b/src/index.ts
@@ -443,8 +443,7 @@ export default function (pi: ExtensionAPI) {
     manager.clearCompleted();           // preserve existing behavior
   });
 
-  pi.on("session_switch", (_event: any, ctx?: any) => {
-    if (ctx) currentCtx = ctx;
+  pi.on("session_switch", () => {
     manager.clearCompleted();
   });
 
@@ -1070,7 +1069,12 @@ Guidelines:
         output += "Agent is still running. Use wait: true or check back later.";
       } else if (record.status === "error") {
         output += `Error: ${record.error}`;
-        output += `\n\nTip: Check provider status or try a different model.`;
+        // Only show provider tip for likely API/model errors, not user-initiated stops or timeouts
+        const err = (record.error ?? "").toLowerCase();
+        const isProviderError = !err.includes("abort") && !err.includes("timeout") && !err.includes("timed out") && !err.includes("stopped");
+        if (isProviderError) {
+          output += `\n\nTip: Check provider status or try a different model.`;
+        }
       } else {
         output += record.result ?? "No output.";
       }

--- a/src/index.ts
+++ b/src/index.ts
@@ -452,7 +452,10 @@ export default function (pi: ExtensionAPI) {
     currentCtx = undefined;
     delete (globalThis as any)[MANAGER_KEY];
     manager.abortAll();
-    if (batchFinalizeTimer) { clearTimeout(batchFinalizeTimer); batchFinalizeTimer = undefined; }
+    if (batchFinalizeTimer) {
+      clearTimeout(batchFinalizeTimer);
+      batchFinalizeTimer = undefined;
+    }
     currentBatchAgents = [];
     for (const timer of pendingNudges.values()) clearTimeout(timer);
     pendingNudges.clear();

--- a/src/index.ts
+++ b/src/index.ts
@@ -23,7 +23,7 @@ import { registerRpcHandlers } from "./cross-extension-rpc.js";
 import { loadCustomAgents } from "./custom-agents.js";
 import { GroupJoinManager } from "./group-join.js";
 import { type ModelRegistry, resolveModel } from "./model-resolver.js";
-import { createOutputFilePath, streamToOutputFile, writeInitialEntry } from "./output-file.js";
+import { createOutputFilePath, parseOutputFileResult, streamToOutputFile, writeInitialEntry } from "./output-file.js";
 import { type AgentConfig, type AgentRecord, type JoinMode, type NotificationDetails, type SubagentType, type ThinkingLevel } from "./types.js";
 import {
   type AgentActivity,
@@ -124,6 +124,8 @@ function formatTaskNotification(record: AgentRecord, resultMaxLen: number): stri
     if (record.session) {
       const stats = record.session.getSessionStats();
       totalTokens = stats.tokens?.total ?? 0;
+    } else if (record.stats) {
+      totalTokens = record.stats.totalTokens;
     }
   } catch { /* session stats unavailable */ }
 
@@ -138,6 +140,7 @@ function formatTaskNotification(record: AgentRecord, resultMaxLen: number): stri
     `<task-id>${record.id}</task-id>`,
     record.toolCallId ? `<tool-use-id>${escapeXml(record.toolCallId)}</tool-use-id>` : null,
     record.outputFile ? `<output-file>${escapeXml(record.outputFile)}</output-file>` : null,
+    record.modelName ? `<model>${escapeXml(record.modelName)}</model>` : null,
     `<status>${escapeXml(status)}</status>`,
     `<summary>Agent "${escapeXml(record.description)}" ${record.status}</summary>`,
     `<result>${escapeXml(resultPreview)}</result>`,
@@ -149,14 +152,16 @@ function formatTaskNotification(record: AgentRecord, resultMaxLen: number): stri
 /** Build AgentDetails from a base + record-specific fields. */
 function buildDetails(
   base: Pick<AgentDetails, "displayName" | "description" | "subagentType" | "modelName" | "tags">,
-  record: { toolUses: number; startedAt: number; completedAt?: number; status: string; error?: string; id?: string; session?: any },
+  record: { toolUses: number; startedAt: number; completedAt?: number; status: string; error?: string; id?: string; session?: any; stats?: { totalTokens: number } },
   activity?: AgentActivity,
   overrides?: Partial<AgentDetails>,
 ): AgentDetails {
+  const tokens = safeFormatTokens(record.session)
+    || (record.stats ? formatTokens(record.stats.totalTokens) : "");
   return {
     ...base,
     toolUses: record.toolUses,
-    tokens: safeFormatTokens(record.session),
+    tokens,
     turnCount: activity?.turnCount,
     maxTurns: activity?.maxTurns,
     durationMs: (record.completedAt ?? Date.now()) - record.startedAt,
@@ -172,6 +177,7 @@ function buildNotificationDetails(record: AgentRecord, resultMaxLen: number, act
   let totalTokens = 0;
   try {
     if (record.session) totalTokens = record.session.getSessionStats().tokens?.total ?? 0;
+    else if (record.stats) totalTokens = record.stats.totalTokens;
   } catch {}
 
   return {
@@ -185,6 +191,7 @@ function buildNotificationDetails(record: AgentRecord, resultMaxLen: number, act
     durationMs: record.completedAt ? record.completedAt - record.startedAt : 0,
     outputFile: record.outputFile,
     error: record.error,
+    modelName: record.modelName,
     resultPreview: record.result
       ? record.result.length > resultMaxLen
         ? record.result.slice(0, resultMaxLen) + "…"
@@ -213,6 +220,7 @@ export default function (pi: ExtensionAPI) {
 
         // Line 2: stats
         const parts: string[] = [];
+        if (d.modelName) parts.push(d.modelName);
         if (d.turnCount > 0) parts.push(formatTurns(d.turnCount, d.maxTurns));
         if (d.toolUses > 0) parts.push(`${d.toolUses} tool use${d.toolUses === 1 ? "" : "s"}`);
         if (d.totalTokens > 0) parts.push(formatTokens(d.totalTokens));
@@ -344,6 +352,12 @@ export default function (pi: ExtensionAPI) {
           input: stats.tokens?.input ?? 0,
           output: stats.tokens?.output ?? 0,
           total: stats.tokens?.total ?? 0,
+        };
+      } else if (record.stats) {
+        tokens = {
+          input: record.stats.inputTokens,
+          output: record.stats.outputTokens,
+          total: record.stats.totalTokens,
         };
       }
     } catch { /* session stats unavailable */ }
@@ -845,6 +859,7 @@ Guidelines:
           thinkingLevel: thinking,
           isBackground: true,
           isolation,
+          modelName: agentModelName,
           ...bgCallbacks,
         });
 
@@ -952,6 +967,7 @@ Guidelines:
         inheritContext,
         thinkingLevel: thinking,
         isolation,
+        modelName: agentModelName,
         ...fgCallbacks,
       });
 
@@ -1009,9 +1025,23 @@ Guidelines:
         }),
       ),
     }),
-    execute: async (_toolCallId, params, _signal, _onUpdate, _ctx) => {
+    execute: async (_toolCallId, params, _signal, _onUpdate, ctx) => {
       const record = manager.getRecord(params.agent_id);
       if (!record) {
+        // Validate agent_id format (UUID prefix) to prevent path traversal
+        if (!/^[\w-]+$/.test(params.agent_id)) {
+          return textResult(`Agent not found: "${params.agent_id}". It may have been cleaned up.`);
+        }
+        // Fallback: try to recover result from on-disk transcript.
+        // This works because createOutputFilePath is a pure function of (cwd, agentId, sessionId).
+        const fallbackPath = createOutputFilePath(ctx.cwd, params.agent_id, ctx.sessionManager.getSessionId());
+        const fallbackResult = parseOutputFileResult(fallbackPath);
+        if (fallbackResult) {
+          return textResult(
+            `Agent "${params.agent_id}" record was cleaned up, but output was recovered from transcript.\n` +
+            `Note: Stats unavailable.\n\n` + fallbackResult
+          );
+        }
         return textResult(`Agent not found: "${params.agent_id}". It may have been cleaned up.`);
       }
 
@@ -1027,7 +1057,8 @@ Guidelines:
 
       const displayName = getDisplayName(record.type);
       const duration = formatDuration(record.startedAt, record.completedAt);
-      const tokens = safeFormatTokens(record.session);
+      const tokens = safeFormatTokens(record.session)
+        || (record.stats ? formatTokens(record.stats.totalTokens) : "");
       const toolStats = tokens ? `Tool uses: ${record.toolUses} | ${tokens}` : `Tool uses: ${record.toolUses}`;
 
       let output =
@@ -1039,6 +1070,7 @@ Guidelines:
         output += "Agent is still running. Use wait: true or check back later.";
       } else if (record.status === "error") {
         output += `Error: ${record.error}`;
+        output += `\n\nTip: Check provider status or try a different model.`;
       } else {
         output += record.result ?? "No output.";
       }
@@ -1627,8 +1659,10 @@ ${systemPrompt}
   }
 
   async function showSettings(ctx: ExtensionCommandContext) {
+    const retentionMin = Math.round(manager.getCleanupRetention() / 60_000);
     const choice = await ctx.ui.select("Settings", [
       `Max concurrency (current: ${manager.getMaxConcurrent()})`,
+      `Cleanup retention (current: ${retentionMin} min)`,
       `Default max turns (current: ${getDefaultMaxTurns() ?? "unlimited"})`,
       `Grace turns (current: ${getGraceTurns()})`,
       `Join mode (current: ${getDefaultJoinMode()})`,
@@ -1644,6 +1678,17 @@ ${systemPrompt}
           ctx.ui.notify(`Max concurrency set to ${n}`, "info");
         } else {
           ctx.ui.notify("Must be a positive integer.", "warning");
+        }
+      }
+    } else if (choice.startsWith("Cleanup retention")) {
+      const val = await ctx.ui.input("Cleanup retention in minutes (min 1)", String(retentionMin));
+      if (val) {
+        const n = parseInt(val, 10);
+        if (n >= 1) {
+          manager.setCleanupRetention(n * 60_000);
+          ctx.ui.notify(`Cleanup retention set to ${n} minute(s)`, "info");
+        } else {
+          ctx.ui.notify("Must be at least 1 minute.", "warning");
         }
       }
     } else if (choice.startsWith("Default max turns")) {

--- a/src/index.ts
+++ b/src/index.ts
@@ -17,7 +17,7 @@ import type { ExtensionAPI, ExtensionCommandContext, ExtensionContext } from "@m
 import { Text } from "@mariozechner/pi-tui";
 import { Type } from "@sinclair/typebox";
 import { AgentManager } from "./agent-manager.js";
-import { getAgentConversation, getDefaultMaxTurns, getGraceTurns, setDefaultMaxTurns, setGraceTurns, steerAgent } from "./agent-runner.js";
+import { getAgentConversation, getDefaultMaxTurns, getGraceTurns, resetDefaults, setDefaultMaxTurns, setGraceTurns, steerAgent } from "./agent-runner.js";
 import { BUILTIN_TOOL_NAMES, getAgentConfig, getAllTypes, getAvailableTypes, getDefaultAgentNames, getUserAgentNames, registerAgents, resolveType } from "./agent-types.js";
 import { registerRpcHandlers } from "./cross-extension-rpc.js";
 import { loadCustomAgents } from "./custom-agents.js";
@@ -429,7 +429,10 @@ export default function (pi: ExtensionAPI) {
     manager.clearCompleted();           // preserve existing behavior
   });
 
-  pi.on("session_switch", () => { manager.clearCompleted(); });
+  pi.on("session_switch", (_event: any, ctx?: any) => {
+    if (ctx) currentCtx = ctx;
+    manager.clearCompleted();
+  });
 
   const { unsubPing: unsubPingRpc, unsubSpawn: unsubSpawnRpc } = registerRpcHandlers({
     events: pi.events,
@@ -449,9 +452,15 @@ export default function (pi: ExtensionAPI) {
     currentCtx = undefined;
     delete (globalThis as any)[MANAGER_KEY];
     manager.abortAll();
+    if (batchFinalizeTimer) { clearTimeout(batchFinalizeTimer); batchFinalizeTimer = undefined; }
+    currentBatchAgents = [];
     for (const timer of pendingNudges.values()) clearTimeout(timer);
     pendingNudges.clear();
+    groupJoin.dispose();
+    widget.dispose();
+    agentActivity.clear();
     manager.dispose();
+    resetDefaults();
   });
 
   // Live widget: show running agents above editor
@@ -544,7 +553,9 @@ export default function (pi: ExtensionAPI) {
     return name.replace(/-\d{8}$/, "");
   }
 
-  const typeListText = buildTypeListText();
+  // NOTE: Tool descriptions are static at registration time (framework limitation).
+  // Custom agents added after registration are still usable by name — reloadCustomAgents()
+  // runs on each execute call — but the LLM won't see them in the description until restart.
 
   // ---- Agent tool ----
 
@@ -556,7 +567,7 @@ export default function (pi: ExtensionAPI) {
 The Agent tool launches specialized agents that autonomously handle complex tasks. Each agent type has specific capabilities and tools available to it.
 
 Available agent types:
-${typeListText}
+${buildTypeListText()}
 
 Guidelines:
 - For parallel work, use run_in_background: true on each agent. Foreground calls run sequentially — only one executes at a time.

--- a/src/index.ts
+++ b/src/index.ts
@@ -1398,7 +1398,12 @@ Guidelines:
     const fmFields: string[] = [];
     fmFields.push(`description: ${cfg.description}`);
     if (cfg.displayName) fmFields.push(`display_name: ${cfg.displayName}`);
-    fmFields.push(`tools: ${cfg.builtinToolNames?.length ? cfg.builtinToolNames.join(", ") : BUILTIN_TOOL_NAMES.join(", ")}`);
+    const toolsValue = !cfg.builtinToolNames
+      ? BUILTIN_TOOL_NAMES.join(", ")
+      : cfg.builtinToolNames.length === 0
+        ? "none"
+        : cfg.builtinToolNames.join(", ");
+    fmFields.push(`tools: ${toolsValue}`);
     if (cfg.model) fmFields.push(`model: ${cfg.model}`);
     if (cfg.thinking) fmFields.push(`thinking: ${cfg.thinking}`);
     if (cfg.maxTurns) fmFields.push(`max_turns: ${cfg.maxTurns}`);

--- a/src/index.ts
+++ b/src/index.ts
@@ -1398,7 +1398,7 @@ Guidelines:
     const fmFields: string[] = [];
     fmFields.push(`description: ${cfg.description}`);
     if (cfg.displayName) fmFields.push(`display_name: ${cfg.displayName}`);
-    fmFields.push(`tools: ${cfg.builtinToolNames?.join(", ") || "all"}`);
+    fmFields.push(`tools: ${cfg.builtinToolNames?.length ? cfg.builtinToolNames.join(", ") : BUILTIN_TOOL_NAMES.join(", ")}`);
     if (cfg.model) fmFields.push(`model: ${cfg.model}`);
     if (cfg.thinking) fmFields.push(`thinking: ${cfg.thinking}`);
     if (cfg.maxTurns) fmFields.push(`max_turns: ${cfg.maxTurns}`);

--- a/src/memory.ts
+++ b/src/memory.ts
@@ -44,7 +44,8 @@ export function safeReadFile(filePath: string): string | undefined {
   if (isSymlink(filePath)) return undefined;
   try {
     return readFileSync(filePath, "utf-8");
-  } catch {
+  } catch (err) {
+    if (process.env.DEBUG) console.debug(`[pi-subagents] Failed to read memory file ${filePath}:`, err);
     return undefined;
   }
 }

--- a/src/output-file.ts
+++ b/src/output-file.ts
@@ -8,7 +8,7 @@
  * high-throughput agent execution.
  */
 
-import { appendFileSync, chmodSync, existsSync, mkdirSync, readFileSync, writeFileSync } from "node:fs";
+import { appendFileSync, chmodSync, closeSync, existsSync, mkdirSync, openSync, readFileSync, readSync, statSync, writeFileSync } from "node:fs";
 import { tmpdir } from "node:os";
 import { join } from "node:path";
 import { appendFile } from "node:fs/promises";
@@ -89,9 +89,12 @@ export function streamToOutputFile(
       const { chunk, count } = serializeFrom(startIdx);
       if (chunk) {
         await appendFile(path, chunk, "utf-8");
-        writtenCount = startIdx + count; // advance only after successful write
+        // Guard: syncFlush may have run while we were awaiting
+        if (writtenCount === startIdx) {
+          writtenCount = startIdx + count;
+        }
       }
-    } catch { /* ignore write errors */ }
+    } catch { /* best-effort async write — failures expected on read-only FS */ }
     flushInProgress = false;
     if (pendingFlush) {
       pendingFlush = false;
@@ -106,7 +109,7 @@ export function streamToOutputFile(
       try {
         appendFileSync(path, chunk, "utf-8");
         writtenCount += count;
-      } catch { /* ignore write errors */ }
+      } catch { /* best-effort sync flush — failures expected on read-only FS */ }
     }
   };
 
@@ -128,7 +131,17 @@ export function parseOutputFileResult(filePath: string): string | undefined {
   if (!existsSync(filePath)) return undefined;
   let content: string;
   try {
-    content = readFileSync(filePath, "utf-8");
+    const MAX_TAIL = 256 * 1024;
+    const stat = statSync(filePath);
+    const fd = openSync(filePath, 'r');
+    try {
+      const start = Math.max(0, stat.size - MAX_TAIL);
+      const buf = Buffer.alloc(Math.min(stat.size, MAX_TAIL));
+      readSync(fd, buf, 0, buf.length, start);
+      content = buf.toString("utf-8");
+    } finally {
+      closeSync(fd);
+    }
   } catch {
     return undefined;
   }

--- a/src/output-file.ts
+++ b/src/output-file.ts
@@ -8,7 +8,7 @@
  * high-throughput agent execution.
  */
 
-import { appendFileSync, chmodSync, mkdirSync, writeFileSync } from "node:fs";
+import { appendFileSync, chmodSync, existsSync, mkdirSync, readFileSync, writeFileSync } from "node:fs";
 import { tmpdir } from "node:os";
 import { join } from "node:path";
 import { appendFile } from "node:fs/promises";
@@ -118,4 +118,40 @@ export function streamToOutputFile(
     syncFlush();
     unsubscribe();
   };
+}
+
+/**
+ * Parse an output JSONL file and extract the last assistant message text.
+ * Returns undefined if the file doesn't exist or contains no assistant messages.
+ */
+export function parseOutputFileResult(filePath: string): string | undefined {
+  if (!existsSync(filePath)) return undefined;
+  let content: string;
+  try {
+    content = readFileSync(filePath, "utf-8");
+  } catch {
+    return undefined;
+  }
+  const lines = content.trim().split("\n");
+  let lastAssistantText: string | undefined;
+  for (const line of lines) {
+    let entry: any;
+    try {
+      entry = JSON.parse(line);
+    } catch {
+      continue; // skip malformed lines
+    }
+    if (entry.type !== "assistant") continue;
+    const msg = entry.message;
+    if (!msg) continue;
+    if (typeof msg.content === "string") {
+      lastAssistantText = msg.content;
+    } else if (Array.isArray(msg.content)) {
+      const textParts = msg.content
+        .filter((c: any) => c.type === "text" && typeof c.text === "string")
+        .map((c: any) => c.text);
+      if (textParts.length > 0) lastAssistantText = textParts.join("");
+    }
+  }
+  return lastAssistantText;
 }

--- a/src/output-file.ts
+++ b/src/output-file.ts
@@ -3,11 +3,15 @@
  *
  * Creates a per-agent output file that streams conversation turns as JSONL,
  * matching Claude Code's task output file format.
+ *
+ * Uses async writes with buffering to avoid blocking the event loop during
+ * high-throughput agent execution.
  */
 
 import { appendFileSync, chmodSync, mkdirSync, writeFileSync } from "node:fs";
 import { tmpdir } from "node:os";
 import { join } from "node:path";
+import { appendFile } from "node:fs/promises";
 import type { AgentSession, AgentSessionEvent } from "@mariozechner/pi-coding-agent";
 
 /** Create the output file path, ensuring the directory exists.
@@ -37,7 +41,10 @@ export function writeInitialEntry(path: string, agentId: string, prompt: string,
 
 /**
  * Subscribe to session events and flush new messages to the output file on each turn_end.
- * Returns a cleanup function that does a final flush and unsubscribes.
+ * Returns a cleanup function that does a final synchronous flush and unsubscribes.
+ *
+ * Normal flushes are async (non-blocking). The final cleanup flush falls back to
+ * synchronous I/O to guarantee all data is written before the session is disposed.
  */
 export function streamToOutputFile(
   session: AgentSession,
@@ -46,9 +53,13 @@ export function streamToOutputFile(
   cwd: string,
 ): () => void {
   let writtenCount = 1; // initial user prompt already written
+  let flushInProgress = false;
+  let pendingFlush = false;
 
-  const flush = () => {
+  /** Serialize messages from writtenCount onward into a single JSONL string. */
+  const serializeNew = (): string => {
     const messages = session.messages;
+    let chunk = "";
     while (writtenCount < messages.length) {
       const msg = messages[writtenCount];
       const entry = {
@@ -59,19 +70,49 @@ export function streamToOutputFile(
         timestamp: new Date().toISOString(),
         cwd,
       };
-      try {
-        appendFileSync(path, JSON.stringify(entry) + "\n", "utf-8");
-      } catch { /* ignore write errors */ }
+      chunk += JSON.stringify(entry) + "\n";
       writtenCount++;
+    }
+    return chunk;
+  };
+
+  /** Non-blocking flush — batches pending messages and writes asynchronously. */
+  const asyncFlush = async () => {
+    if (flushInProgress) {
+      pendingFlush = true;
+      return;
+    }
+    flushInProgress = true;
+    try {
+      const chunk = serializeNew();
+      if (chunk) {
+        await appendFile(path, chunk, "utf-8");
+      }
+    } catch { /* ignore write errors */ }
+    flushInProgress = false;
+    if (pendingFlush) {
+      pendingFlush = false;
+      asyncFlush();
+    }
+  };
+
+  /** Synchronous final flush — used at cleanup to guarantee all data is written. */
+  const syncFlush = () => {
+    const { appendFileSync } = require("node:fs") as typeof import("node:fs");
+    const chunk = serializeNew();
+    if (chunk) {
+      try {
+        appendFileSync(path, chunk, "utf-8");
+      } catch { /* ignore write errors */ }
     }
   };
 
   const unsubscribe = session.subscribe((event: AgentSessionEvent) => {
-    if (event.type === "turn_end") flush();
+    if (event.type === "turn_end") asyncFlush();
   });
 
   return () => {
-    flush();
+    syncFlush();
     unsubscribe();
   };
 }

--- a/src/output-file.ts
+++ b/src/output-file.ts
@@ -56,12 +56,13 @@ export function streamToOutputFile(
   let flushInProgress = false;
   let pendingFlush = false;
 
-  /** Serialize messages from writtenCount onward into a single JSONL string. */
-  const serializeNew = (): string => {
+  /** Serialize messages from startIdx onward into a JSONL string and count. */
+  const serializeFrom = (startIdx: number): { chunk: string; count: number } => {
     const messages = session.messages;
     let chunk = "";
-    while (writtenCount < messages.length) {
-      const msg = messages[writtenCount];
+    let count = 0;
+    for (let i = startIdx; i < messages.length; i++) {
+      const msg = messages[i];
       const entry = {
         isSidechain: true,
         agentId,
@@ -71,9 +72,9 @@ export function streamToOutputFile(
         cwd,
       };
       chunk += JSON.stringify(entry) + "\n";
-      writtenCount++;
+      count++;
     }
-    return chunk;
+    return { chunk, count };
   };
 
   /** Non-blocking flush — batches pending messages and writes asynchronously. */
@@ -84,25 +85,27 @@ export function streamToOutputFile(
     }
     flushInProgress = true;
     try {
-      const chunk = serializeNew();
+      const startIdx = writtenCount;
+      const { chunk, count } = serializeFrom(startIdx);
       if (chunk) {
         await appendFile(path, chunk, "utf-8");
+        writtenCount = startIdx + count; // advance only after successful write
       }
     } catch { /* ignore write errors */ }
     flushInProgress = false;
     if (pendingFlush) {
       pendingFlush = false;
-      asyncFlush();
+      queueMicrotask(() => asyncFlush());
     }
   };
 
   /** Synchronous final flush — used at cleanup to guarantee all data is written. */
   const syncFlush = () => {
-    const { appendFileSync } = require("node:fs") as typeof import("node:fs");
-    const chunk = serializeNew();
+    const { chunk, count } = serializeFrom(writtenCount);
     if (chunk) {
       try {
         appendFileSync(path, chunk, "utf-8");
+        writtenCount += count;
       } catch { /* ignore write errors */ }
     }
   };

--- a/src/output-file.ts
+++ b/src/output-file.ts
@@ -142,7 +142,8 @@ export function parseOutputFileResult(filePath: string): string | undefined {
     } finally {
       closeSync(fd);
     }
-  } catch {
+  } catch (err) {
+    if (process.env.DEBUG) console.debug(`[pi-subagents] Failed to read output file ${filePath}:`, err);
     return undefined;
   }
   const lines = content.trim().split("\n");

--- a/src/types.ts
+++ b/src/types.ts
@@ -85,6 +85,10 @@ export interface AgentRecord {
   outputFile?: string;
   /** Cleanup function for the output file stream subscription. */
   outputCleanup?: () => void;
+  /** Captured session stats before session disposal (survives Tier 1 cleanup). */
+  stats?: { inputTokens: number; outputTokens: number; totalTokens: number };
+  /** Human-readable model identifier for diagnostics. */
+  modelName?: string;
 }
 
 /** Details attached to custom notification messages for visual rendering. */
@@ -100,6 +104,8 @@ export interface NotificationDetails {
   outputFile?: string;
   error?: string;
   resultPreview: string;
+  /** Human-readable model identifier for diagnostics. */
+  modelName?: string;
   /** Additional agents in a group notification. */
   others?: NotificationDetails[];
 }

--- a/src/ui/agent-widget.ts
+++ b/src/ui/agent-widget.ts
@@ -197,13 +197,9 @@ export class AgentWidget {
    * Ages finished agents and prunes those that have lingered long enough.
    */
   onTurnStart() {
-    // Age all finished agents and prune expired entries
     for (const [id, age] of this.finishedTurnAge) {
       const newAge = age + 1;
-      // Check if this entry has exceeded the max linger age for any status.
-      // Use the larger ERROR_LINGER_TURNS as the upper bound since we don't
-      // track per-entry status here — renderWidget handles exact filtering.
-      if (newAge > AgentWidget.ERROR_LINGER_TURNS) {
+      if (newAge > AgentWidget.ERROR_LINGER_TURNS) { // upper bound; renderWidget does exact filtering
         this.finishedTurnAge.delete(id);
       } else {
         this.finishedTurnAge.set(id, newAge);

--- a/src/ui/agent-widget.ts
+++ b/src/ui/agent-widget.ts
@@ -194,12 +194,20 @@ export class AgentWidget {
 
   /**
    * Called on each new turn (tool_execution_start).
-   * Ages finished agents and clears those that have lingered long enough.
+   * Ages finished agents and prunes those that have lingered long enough.
    */
   onTurnStart() {
-    // Age all finished agents
+    // Age all finished agents and prune expired entries
     for (const [id, age] of this.finishedTurnAge) {
-      this.finishedTurnAge.set(id, age + 1);
+      const newAge = age + 1;
+      // Check if this entry has exceeded the max linger age for any status.
+      // Use the larger ERROR_LINGER_TURNS as the upper bound since we don't
+      // track per-entry status here — renderWidget handles exact filtering.
+      if (newAge > AgentWidget.ERROR_LINGER_TURNS) {
+        this.finishedTurnAge.delete(id);
+      } else {
+        this.finishedTurnAge.set(id, newAge);
+      }
     }
     // Trigger a widget refresh (will filter out expired agents)
     this.update();

--- a/src/worktree.ts
+++ b/src/worktree.ts
@@ -12,6 +12,9 @@ import { existsSync } from "node:fs";
 import { tmpdir } from "node:os";
 import { join } from "node:path";
 
+/** 10 MB — generous limit for git output in large monorepos. */
+const MAX_BUFFER = 10 * 1024 * 1024;
+
 export interface WorktreeInfo {
   /** Absolute path to the worktree directory. */
   path: string;
@@ -51,6 +54,7 @@ export function createWorktree(cwd: string, agentId: string): WorktreeInfo | und
       cwd,
       stdio: "pipe",
       timeout: 30000,
+      maxBuffer: MAX_BUFFER,
     });
     return { path: worktreePath, branch };
   } catch {
@@ -79,6 +83,7 @@ export function cleanupWorktree(
       cwd: worktree.path,
       stdio: "pipe",
       timeout: 10000,
+      maxBuffer: MAX_BUFFER,
     }).toString().trim();
 
     if (!status) {
@@ -88,7 +93,7 @@ export function cleanupWorktree(
     }
 
     // Changes exist — stage, commit, and create a branch
-    execFileSync("git", ["add", "-A"], { cwd: worktree.path, stdio: "pipe", timeout: 10000 });
+    execFileSync("git", ["add", "-A"], { cwd: worktree.path, stdio: "pipe", timeout: 10000, maxBuffer: MAX_BUFFER });
     // Truncate description for commit message (no shell sanitization needed — execFileSync uses argv)
     const safeDesc = agentDescription.slice(0, 200);
     const commitMsg = `pi-agent: ${safeDesc}`;
@@ -96,6 +101,7 @@ export function cleanupWorktree(
       cwd: worktree.path,
       stdio: "pipe",
       timeout: 10000,
+      maxBuffer: MAX_BUFFER,
     });
 
     // Create a branch pointing to the worktree's HEAD.

--- a/test/agent-manager.test.ts
+++ b/test/agent-manager.test.ts
@@ -200,3 +200,172 @@ describe("AgentManager — Bug 3 clearCompleted", () => {
     expect(manager.getRecord(id)).toBeUndefined();
   });
 });
+
+describe("AgentManager — outputCleanup", () => {
+  let manager: AgentManager;
+
+  afterEach(() => {
+    manager?.dispose();
+  });
+
+  it("dispose() calls outputCleanup on all records", async () => {
+    manager = new AgentManager();
+    resolvedRun();
+
+    const id = manager.spawn(mockPi, mockCtx, "general-purpose", "test", {
+      description: "test",
+      isBackground: true,
+    });
+    const record = manager.getRecord(id)!;
+
+    const cleanupSpy = vi.fn();
+    record.outputCleanup = cleanupSpy;
+
+    await record.promise;
+    // The .then handler also calls outputCleanup on completion
+    // Reset and set it again for dispose test
+    record.outputCleanup = vi.fn();
+    const disposeSpy = record.outputCleanup as ReturnType<typeof vi.fn>;
+
+    manager.dispose();
+    expect(disposeSpy).toHaveBeenCalledOnce();
+  });
+
+  it("removeRecord (via clearCompleted) calls outputCleanup", async () => {
+    manager = new AgentManager();
+    resolvedRun();
+
+    const id = manager.spawn(mockPi, mockCtx, "general-purpose", "test", {
+      description: "test",
+      isBackground: true,
+    });
+    const record = manager.getRecord(id)!;
+    await record.promise;
+
+    // Set outputCleanup after completion (simulates it surviving the .then handler)
+    const cleanupSpy = vi.fn();
+    record.outputCleanup = cleanupSpy;
+
+    manager.clearCompleted();
+    expect(cleanupSpy).toHaveBeenCalledOnce();
+  });
+
+  it("outputCleanup errors are swallowed in dispose", async () => {
+    manager = new AgentManager();
+    resolvedRun();
+
+    const id = manager.spawn(mockPi, mockCtx, "general-purpose", "test", {
+      description: "test",
+      isBackground: true,
+    });
+    const record = manager.getRecord(id)!;
+    await record.promise;
+
+    record.outputCleanup = () => { throw new Error("cleanup failed"); };
+
+    // Should not throw
+    expect(() => manager.dispose()).not.toThrow();
+  });
+});
+
+describe("AgentManager — abortController lifecycle", () => {
+  let manager: AgentManager;
+
+  afterEach(() => {
+    manager?.dispose();
+  });
+
+  it("abortController is nulled after successful completion", async () => {
+    manager = new AgentManager();
+    resolvedRun();
+
+    const id = manager.spawn(mockPi, mockCtx, "general-purpose", "test", {
+      description: "test",
+      isBackground: true,
+    });
+    const record = manager.getRecord(id)!;
+    expect(record.abortController).toBeDefined();
+
+    await record.promise;
+    expect(record.abortController).toBeUndefined();
+  });
+
+  it("abortController is nulled after error", async () => {
+    manager = new AgentManager();
+    vi.mocked(runAgent).mockRejectedValue(new Error("fail"));
+
+    const id = manager.spawn(mockPi, mockCtx, "general-purpose", "test", {
+      description: "test",
+      isBackground: true,
+    });
+    const record = manager.getRecord(id)!;
+    expect(record.abortController).toBeDefined();
+
+    await record.promise;
+    expect(record.abortController).toBeUndefined();
+  });
+});
+
+describe("AgentManager — waitForAll", () => {
+  let manager: AgentManager;
+
+  afterEach(() => {
+    manager?.dispose();
+  });
+
+  it("resolves immediately when no agents are running", async () => {
+    manager = new AgentManager();
+    await expect(manager.waitForAll()).resolves.toBeUndefined();
+  });
+
+  it("resolves after all agents complete", async () => {
+    manager = new AgentManager();
+    resolvedRun();
+
+    manager.spawn(mockPi, mockCtx, "general-purpose", "t1", {
+      description: "a",
+      isBackground: true,
+    });
+    manager.spawn(mockPi, mockCtx, "general-purpose", "t2", {
+      description: "b",
+      isBackground: true,
+    });
+
+    await expect(manager.waitForAll()).resolves.toBeUndefined();
+  });
+
+  it("rejects on timeout when agents never complete", async () => {
+    manager = new AgentManager();
+    vi.mocked(runAgent).mockImplementation(() => new Promise(() => {}));
+
+    manager.spawn(mockPi, mockCtx, "general-purpose", "t1", {
+      description: "hangs",
+      isBackground: true,
+    });
+
+    await expect(manager.waitForAll(50)).rejects.toThrow("timed out");
+
+    // Clean up hanging agent
+    manager.abortAll();
+  });
+
+  it("drains queued agents before resolving", async () => {
+    manager = new AgentManager(undefined, 1);
+    resolvedRun();
+
+    manager.spawn(mockPi, mockCtx, "general-purpose", "t1", {
+      description: "first",
+      isBackground: true,
+    });
+    manager.spawn(mockPi, mockCtx, "general-purpose", "t2", {
+      description: "queued",
+      isBackground: true,
+    });
+
+    await expect(manager.waitForAll()).resolves.toBeUndefined();
+
+    // Both should be completed
+    const agents = manager.listAgents();
+    expect(agents.every(a => a.status === "completed")).toBe(true);
+  });
+});

--- a/test/agent-manager.test.ts
+++ b/test/agent-manager.test.ts
@@ -396,20 +396,48 @@ describe("AgentManager — Two-tier cleanup", () => {
     });
     await manager.getRecord(id)!.promise;
 
-    // Manually set completedAt to the past so cleanup fires
+    // Manually set completedAt to 2 min ago — past tier1 (1 min) but before tier2 (3 min)
     const record = manager.getRecord(id)!;
-    record.completedAt = Date.now() - 15 * 60_000;
+    record.completedAt = Date.now() - 2 * 60_000;
 
     // Trigger cleanup via internal timer (call it indirectly via a new interval tick)
     // We access the private cleanup method through a workaround
     (manager as any).cleanup();
 
-    // Record should still be in the map
+    // Record should still be in the map (Tier 1: session disposed, record kept)
     expect(manager.getRecord(id)).toBeDefined();
     // Session should be disposed
     expect(record.session).toBeUndefined();
     expect(record.promise).toBeUndefined();
     expect(sess.dispose).toHaveBeenCalled();
+  });
+
+  it("Tier 2 cleanup fully removes record after 3x retention", async () => {
+    manager = new AgentManager(undefined, 4, undefined);
+    manager.setCleanupRetention(60_000); // min 1 min
+
+    const sess = { dispose: vi.fn(), getSessionStats: vi.fn(() => ({ tokens: { input: 10, output: 20, total: 30 } })) };
+    vi.mocked(runAgent).mockResolvedValue({
+      responseText: "done",
+      session: sess as any,
+      aborted: false,
+      steered: false,
+    });
+
+    const id = manager.spawn(mockPi, mockCtx, "general-purpose", "test", {
+      description: "test",
+      isBackground: true,
+    });
+    await manager.getRecord(id)!.promise;
+
+    // Set completedAt to 5 min ago — well past tier2 cutoff (3 min)
+    const record = manager.getRecord(id)!;
+    record.completedAt = Date.now() - 5 * 60_000;
+
+    (manager as any).cleanup();
+
+    // Record should be fully removed from the map
+    expect(manager.getRecord(id)).toBeUndefined();
   });
 
   it("clearCompleted removes records that survived Tier 1", async () => {
@@ -581,7 +609,9 @@ describe("AgentManager — Error diagnostics", () => {
     const record = manager.getRecord(id)!;
     expect(record.status).toBe("error");
     expect(record.error).toContain("rate limit exceeded");
-    expect(record.error).toContain("[model: gemini-2.5-pro]");
+    expect(record.error).not.toContain("[model:");
+    // Model info is carried separately in record.modelName
+    expect(record.modelName).toBe("gemini-2.5-pro");
   });
 
   it("error record works without model name", async () => {

--- a/test/agent-manager.test.ts
+++ b/test/agent-manager.test.ts
@@ -369,3 +369,234 @@ describe("AgentManager — waitForAll", () => {
     expect(agents.every(a => a.status === "completed")).toBe(true);
   });
 });
+
+describe("AgentManager — Two-tier cleanup", () => {
+  let manager: AgentManager;
+
+  afterEach(() => {
+    manager?.dispose();
+  });
+
+  it("Tier 1 cleanup disposes session but keeps record in Map", async () => {
+    manager = new AgentManager(undefined, 4, undefined);
+    // Use very short retention so cleanup triggers immediately
+    manager.setCleanupRetention(60_000); // min 1 min
+
+    const sess = { dispose: vi.fn(), getSessionStats: vi.fn(() => ({ tokens: { input: 10, output: 20, total: 30 } })) };
+    vi.mocked(runAgent).mockResolvedValue({
+      responseText: "done",
+      session: sess as any,
+      aborted: false,
+      steered: false,
+    });
+
+    const id = manager.spawn(mockPi, mockCtx, "general-purpose", "test", {
+      description: "test",
+      isBackground: true,
+    });
+    await manager.getRecord(id)!.promise;
+
+    // Manually set completedAt to the past so cleanup fires
+    const record = manager.getRecord(id)!;
+    record.completedAt = Date.now() - 15 * 60_000;
+
+    // Trigger cleanup via internal timer (call it indirectly via a new interval tick)
+    // We access the private cleanup method through a workaround
+    (manager as any).cleanup();
+
+    // Record should still be in the map
+    expect(manager.getRecord(id)).toBeDefined();
+    // Session should be disposed
+    expect(record.session).toBeUndefined();
+    expect(record.promise).toBeUndefined();
+    expect(sess.dispose).toHaveBeenCalled();
+  });
+
+  it("clearCompleted removes records that survived Tier 1", async () => {
+    manager = new AgentManager();
+    const sess = { dispose: vi.fn(), getSessionStats: vi.fn(() => ({ tokens: { input: 0, output: 0, total: 0 } })) };
+    vi.mocked(runAgent).mockResolvedValue({
+      responseText: "done",
+      session: sess as any,
+      aborted: false,
+      steered: false,
+    });
+
+    const id = manager.spawn(mockPi, mockCtx, "general-purpose", "test", {
+      description: "test",
+      isBackground: true,
+    });
+    await manager.getRecord(id)!.promise;
+
+    // Tier 1: dispose session
+    const record = manager.getRecord(id)!;
+    record.completedAt = Date.now() - 15 * 60_000;
+    (manager as any).cleanup();
+    expect(manager.getRecord(id)).toBeDefined();
+    expect(record.session).toBeUndefined();
+
+    // Tier 2: full removal
+    manager.clearCompleted();
+    expect(manager.getRecord(id)).toBeUndefined();
+  });
+
+  it("Tier 1 captures stats before disposing session", async () => {
+    manager = new AgentManager();
+    const sess = {
+      dispose: vi.fn(),
+      getSessionStats: vi.fn(() => ({ tokens: { input: 100, output: 200, total: 300 } })),
+    };
+    vi.mocked(runAgent).mockResolvedValue({
+      responseText: "done",
+      session: sess as any,
+      aborted: false,
+      steered: false,
+    });
+
+    const id = manager.spawn(mockPi, mockCtx, "general-purpose", "test", {
+      description: "test",
+      isBackground: true,
+    });
+    await manager.getRecord(id)!.promise;
+
+    const record = manager.getRecord(id)!;
+    // Stats should already be captured in .then handler
+    expect(record.stats).toEqual({ inputTokens: 100, outputTokens: 200, totalTokens: 300 });
+
+    // Tier 1 cleanup should not overwrite existing stats
+    record.completedAt = Date.now() - 15 * 60_000;
+    (manager as any).cleanup();
+    expect(record.stats).toEqual({ inputTokens: 100, outputTokens: 200, totalTokens: 300 });
+  });
+
+  it("Tier 1 is idempotent (double cleanup doesn't throw)", async () => {
+    manager = new AgentManager();
+    const sess = {
+      dispose: vi.fn(),
+      getSessionStats: vi.fn(() => ({ tokens: { input: 0, output: 0, total: 0 } })),
+    };
+    vi.mocked(runAgent).mockResolvedValue({
+      responseText: "done",
+      session: sess as any,
+      aborted: false,
+      steered: false,
+    });
+
+    const id = manager.spawn(mockPi, mockCtx, "general-purpose", "test", {
+      description: "test",
+      isBackground: true,
+    });
+    await manager.getRecord(id)!.promise;
+
+    const record = manager.getRecord(id)!;
+    record.completedAt = Date.now() - 15 * 60_000;
+
+    // Double cleanup should not throw
+    expect(() => {
+      (manager as any).cleanup();
+      (manager as any).cleanup();
+    }).not.toThrow();
+  });
+
+  it("cleanup skips running/queued agents", async () => {
+    manager = new AgentManager(undefined, 1);
+    vi.mocked(runAgent).mockImplementation(() => new Promise(() => {}));
+
+    const id1 = manager.spawn(mockPi, mockCtx, "general-purpose", "test1", {
+      description: "running",
+      isBackground: true,
+    });
+    const id2 = manager.spawn(mockPi, mockCtx, "general-purpose", "test2", {
+      description: "queued",
+      isBackground: true,
+    });
+
+    expect(manager.getRecord(id1)!.status).toBe("running");
+    expect(manager.getRecord(id2)!.status).toBe("queued");
+
+    (manager as any).cleanup();
+
+    expect(manager.getRecord(id1)).toBeDefined();
+    expect(manager.getRecord(id2)).toBeDefined();
+
+    manager.abortAll();
+  });
+
+  it("stats are captured in .catch handler for error agents", async () => {
+    manager = new AgentManager();
+    const sess = {
+      dispose: vi.fn(),
+      getSessionStats: vi.fn(() => ({ tokens: { input: 50, output: 60, total: 110 } })),
+    };
+    // Mock runAgent to create a session then reject
+    vi.mocked(runAgent).mockImplementation(async (_ctx, _type, _prompt, opts: any) => {
+      opts.onSessionCreated?.(sess);
+      throw new Error("model error");
+    });
+
+    const id = manager.spawn(mockPi, mockCtx, "general-purpose", "test", {
+      description: "test",
+      isBackground: true,
+    });
+    await manager.getRecord(id)!.promise;
+
+    const record = manager.getRecord(id)!;
+    expect(record.status).toBe("error");
+    expect(record.stats).toEqual({ inputTokens: 50, outputTokens: 60, totalTokens: 110 });
+  });
+
+  it("modelName is threaded through spawn options", async () => {
+    manager = new AgentManager();
+    resolvedRun();
+
+    const id = manager.spawn(mockPi, mockCtx, "general-purpose", "test", {
+      description: "test",
+      isBackground: true,
+      modelName: "gpt-5.4",
+    });
+    await manager.getRecord(id)!.promise;
+
+    expect(manager.getRecord(id)!.modelName).toBe("gpt-5.4");
+  });
+});
+
+describe("AgentManager — Error diagnostics", () => {
+  let manager: AgentManager;
+
+  afterEach(() => {
+    manager?.dispose();
+  });
+
+  it("error record includes model name when provided", async () => {
+    manager = new AgentManager();
+    vi.mocked(runAgent).mockRejectedValue(new Error("rate limit exceeded"));
+
+    const id = manager.spawn(mockPi, mockCtx, "general-purpose", "test", {
+      description: "test",
+      isBackground: true,
+      modelName: "gemini-2.5-pro",
+    });
+    await manager.getRecord(id)!.promise;
+
+    const record = manager.getRecord(id)!;
+    expect(record.status).toBe("error");
+    expect(record.error).toContain("rate limit exceeded");
+    expect(record.error).toContain("[model: gemini-2.5-pro]");
+  });
+
+  it("error record works without model name", async () => {
+    manager = new AgentManager();
+    vi.mocked(runAgent).mockRejectedValue(new Error("connection failed"));
+
+    const id = manager.spawn(mockPi, mockCtx, "general-purpose", "test", {
+      description: "test",
+      isBackground: true,
+    });
+    await manager.getRecord(id)!.promise;
+
+    const record = manager.getRecord(id)!;
+    expect(record.status).toBe("error");
+    expect(record.error).toBe("connection failed");
+    expect(record.error).not.toContain("[model:");
+  });
+});

--- a/test/agent-runner.test.ts
+++ b/test/agent-runner.test.ts
@@ -12,13 +12,19 @@ describe("agent-runner — resetDefaults", () => {
     resetDefaults();
   });
 
-  it("getDefaultMaxTurns returns 50 initially", () => {
-    expect(getDefaultMaxTurns()).toBe(50);
+  it("getDefaultMaxTurns returns undefined initially (no turn limit)", () => {
+    expect(getDefaultMaxTurns()).toBeUndefined();
   });
 
   it("setDefaultMaxTurns updates the value", () => {
     setDefaultMaxTurns(10);
     expect(getDefaultMaxTurns()).toBe(10);
+  });
+
+  it("setDefaultMaxTurns accepts undefined for unlimited", () => {
+    setDefaultMaxTurns(10);
+    setDefaultMaxTurns(undefined);
+    expect(getDefaultMaxTurns()).toBeUndefined();
   });
 
   it("setDefaultMaxTurns clamps to minimum 1", () => {
@@ -50,7 +56,7 @@ describe("agent-runner — resetDefaults", () => {
 
     resetDefaults();
 
-    expect(getDefaultMaxTurns()).toBe(50);
+    expect(getDefaultMaxTurns()).toBeUndefined();
     expect(getGraceTurns()).toBe(5);
   });
 });

--- a/test/agent-runner.test.ts
+++ b/test/agent-runner.test.ts
@@ -1,0 +1,56 @@
+import { describe, it, expect, afterEach } from "vitest";
+import {
+  getDefaultMaxTurns,
+  setDefaultMaxTurns,
+  getGraceTurns,
+  setGraceTurns,
+  resetDefaults,
+} from "../src/agent-runner.js";
+
+describe("agent-runner — resetDefaults", () => {
+  afterEach(() => {
+    resetDefaults();
+  });
+
+  it("getDefaultMaxTurns returns 50 initially", () => {
+    expect(getDefaultMaxTurns()).toBe(50);
+  });
+
+  it("setDefaultMaxTurns updates the value", () => {
+    setDefaultMaxTurns(10);
+    expect(getDefaultMaxTurns()).toBe(10);
+  });
+
+  it("setDefaultMaxTurns clamps to minimum 1", () => {
+    setDefaultMaxTurns(0);
+    expect(getDefaultMaxTurns()).toBe(1);
+    setDefaultMaxTurns(-5);
+    expect(getDefaultMaxTurns()).toBe(1);
+  });
+
+  it("getGraceTurns returns 5 initially", () => {
+    expect(getGraceTurns()).toBe(5);
+  });
+
+  it("setGraceTurns updates the value", () => {
+    setGraceTurns(20);
+    expect(getGraceTurns()).toBe(20);
+  });
+
+  it("setGraceTurns clamps to minimum 1", () => {
+    setGraceTurns(0);
+    expect(getGraceTurns()).toBe(1);
+  });
+
+  it("resetDefaults restores both values to initial", () => {
+    setDefaultMaxTurns(999);
+    setGraceTurns(777);
+    expect(getDefaultMaxTurns()).toBe(999);
+    expect(getGraceTurns()).toBe(777);
+
+    resetDefaults();
+
+    expect(getDefaultMaxTurns()).toBe(50);
+    expect(getGraceTurns()).toBe(5);
+  });
+});

--- a/test/custom-agents.test.ts
+++ b/test/custom-agents.test.ts
@@ -442,6 +442,43 @@ Bad isolation.`);
     expect(result.get("bad-isolation")!.isolation).toBeUndefined();
   });
 
+  it("loads agents from mocked global dir", () => {
+    const dir = join(globalHomeDir, ".pi", "agent", "agents");
+    mkdirSync(dir, { recursive: true });
+    writeFileSync(join(dir, "global-agent.md"), `---
+description: Global Agent
+---
+
+Global.`);
+
+    const result = loadCustomAgents(tmpDir);
+    expect(result.size).toBe(1);
+    expect(result.get("global-agent")!.description).toBe("Global Agent");
+    expect(result.get("global-agent")!.source).toBe("global");
+  });
+
+  it("project agents override global agents with same name", () => {
+    const globalDir = join(globalHomeDir, ".pi", "agent", "agents");
+    mkdirSync(globalDir, { recursive: true });
+    writeFileSync(join(globalDir, "shared.md"), `---
+description: Global version
+---
+
+Global prompt.`);
+
+    writeAgent("shared", `---
+description: Project version
+---
+
+Project prompt.`);
+
+    const result = loadCustomAgents(tmpDir);
+    expect(result.size).toBe(1);
+    const agent = result.get("shared")!;
+    expect(agent.description).toBe("Project version");
+    expect(agent.source).toBe("project");
+  });
+
   it("handles tools: all as all built-in tools (ejected agent compat)", () => {
     writeAgent("ejected-gp", `---
 description: General-purpose agent for complex, multi-step tasks

--- a/test/custom-agents.test.ts
+++ b/test/custom-agents.test.ts
@@ -479,6 +479,20 @@ Project prompt.`);
     expect(agent.source).toBe("project");
   });
 
+  it("extensions: all → true (inherit all)", () => {
+    writeAgent("extall", `---
+extensions: all
+skills: all
+---
+
+All via string.`);
+
+    const result = loadCustomAgents(tmpDir);
+    const agent = result.get("extall")!;
+    expect(agent.extensions).toBe(true);
+    expect(agent.skills).toBe(true);
+  });
+
   it("handles tools: all as all built-in tools (ejected agent compat)", () => {
     writeAgent("ejected-gp", `---
 description: General-purpose agent for complex, multi-step tasks

--- a/test/custom-agents.test.ts
+++ b/test/custom-agents.test.ts
@@ -1,19 +1,29 @@
 import { mkdirSync, mkdtempSync, rmSync, writeFileSync } from "node:fs";
 import { tmpdir } from "node:os";
 import { join } from "node:path";
-import { afterEach, beforeEach, describe, expect, it } from "vitest";
+import { afterEach, beforeEach, describe, expect, it, vi } from "vitest";
 import { BUILTIN_TOOL_NAMES } from "../src/agent-types.js";
 import { loadCustomAgents } from "../src/custom-agents.js";
+
+// Isolate from real global agents in ~/.pi/agent/agents/
+vi.mock("node:os", async (importOriginal) => {
+  const actual = await importOriginal<typeof import("node:os")>();
+  return { ...actual, homedir: () => globalHomeDir };
+});
+
+let globalHomeDir: string;
 
 describe("loadCustomAgents", () => {
   let tmpDir: string;
 
   beforeEach(() => {
     tmpDir = mkdtempSync(join(tmpdir(), "pi-test-"));
+    globalHomeDir = mkdtempSync(join(tmpdir(), "pi-test-home-"));
   });
 
   afterEach(() => {
     rmSync(tmpDir, { recursive: true, force: true });
+    rmSync(globalHomeDir, { recursive: true, force: true });
   });
 
   function writeAgent(name: string, content: string) {
@@ -430,5 +440,20 @@ Bad isolation.`);
 
     const result = loadCustomAgents(tmpDir);
     expect(result.get("bad-isolation")!.isolation).toBeUndefined();
+  });
+
+  it("handles tools: all as all built-in tools (ejected agent compat)", () => {
+    writeAgent("ejected-gp", `---
+description: General-purpose agent for complex, multi-step tasks
+tools: all
+prompt_mode: append
+---
+
+`);
+
+    const result = loadCustomAgents(tmpDir);
+    const agent = result.get("ejected-gp")!;
+    // "all" should resolve to all built-in tools, not literally ["all"]
+    expect(agent.builtinToolNames).toEqual(BUILTIN_TOOL_NAMES);
   });
 });

--- a/test/group-join.test.ts
+++ b/test/group-join.test.ts
@@ -1,0 +1,184 @@
+import { describe, it, expect, vi, afterEach } from "vitest";
+import { GroupJoinManager, type DeliveryCallback } from "../src/group-join.js";
+import type { AgentRecord } from "../src/types.js";
+
+function makeRecord(id: string, overrides?: Partial<AgentRecord>): AgentRecord {
+  return {
+    id,
+    type: "general-purpose",
+    description: `agent ${id}`,
+    status: "completed",
+    toolUses: 1,
+    startedAt: Date.now(),
+    completedAt: Date.now(),
+    ...overrides,
+  };
+}
+
+describe("GroupJoinManager", () => {
+  let manager: GroupJoinManager;
+
+  afterEach(() => {
+    manager?.dispose();
+  });
+
+  describe("registerGroup + isGrouped", () => {
+    it("tracks grouped agent IDs", () => {
+      const cb = vi.fn();
+      manager = new GroupJoinManager(cb);
+      manager.registerGroup("g1", ["a1", "a2", "a3"]);
+
+      expect(manager.isGrouped("a1")).toBe(true);
+      expect(manager.isGrouped("a2")).toBe(true);
+      expect(manager.isGrouped("a3")).toBe(true);
+      expect(manager.isGrouped("a4")).toBe(false);
+    });
+  });
+
+  describe("onAgentComplete", () => {
+    it("returns 'pass' for ungrouped agents", () => {
+      const cb = vi.fn();
+      manager = new GroupJoinManager(cb);
+
+      const result = manager.onAgentComplete(makeRecord("unknown"));
+      expect(result).toBe("pass");
+      expect(cb).not.toHaveBeenCalled();
+    });
+
+    it("returns 'held' while group is incomplete", () => {
+      const cb = vi.fn();
+      manager = new GroupJoinManager(cb);
+      manager.registerGroup("g1", ["a1", "a2"]);
+
+      const result = manager.onAgentComplete(makeRecord("a1"));
+      expect(result).toBe("held");
+      expect(cb).not.toHaveBeenCalled();
+    });
+
+    it("returns 'delivered' and calls callback when all agents complete", () => {
+      const cb = vi.fn();
+      manager = new GroupJoinManager(cb);
+      manager.registerGroup("g1", ["a1", "a2"]);
+
+      manager.onAgentComplete(makeRecord("a1"));
+      const result = manager.onAgentComplete(makeRecord("a2"));
+
+      expect(result).toBe("delivered");
+      expect(cb).toHaveBeenCalledOnce();
+      expect(cb).toHaveBeenCalledWith(
+        expect.arrayContaining([
+          expect.objectContaining({ id: "a1" }),
+          expect.objectContaining({ id: "a2" }),
+        ]),
+        false, // not partial
+      );
+    });
+
+    it("delivers single-agent groups immediately", () => {
+      const cb = vi.fn();
+      manager = new GroupJoinManager(cb);
+      manager.registerGroup("g1", ["a1"]);
+
+      const result = manager.onAgentComplete(makeRecord("a1"));
+      expect(result).toBe("delivered");
+      expect(cb).toHaveBeenCalledOnce();
+    });
+
+    it("returns 'pass' for agents after group has already delivered", () => {
+      const cb = vi.fn();
+      manager = new GroupJoinManager(cb);
+      manager.registerGroup("g1", ["a1"]);
+
+      manager.onAgentComplete(makeRecord("a1"));
+      // After delivery, group is cleaned up — second call returns pass
+      const result = manager.onAgentComplete(makeRecord("a1"));
+      expect(result).toBe("pass");
+    });
+  });
+
+  describe("timeout + partial delivery", () => {
+    it("delivers partial results on timeout", () => {
+      vi.useFakeTimers();
+      const cb = vi.fn();
+      manager = new GroupJoinManager(cb, 100);
+      manager.registerGroup("g1", ["a1", "a2", "a3"]);
+
+      manager.onAgentComplete(makeRecord("a1"));
+      expect(cb).not.toHaveBeenCalled();
+
+      vi.advanceTimersByTime(100);
+      expect(cb).toHaveBeenCalledOnce();
+      expect(cb).toHaveBeenCalledWith(
+        [expect.objectContaining({ id: "a1" })],
+        true, // partial
+      );
+
+      vi.useRealTimers();
+    });
+
+    it("straggler completes after partial delivery", () => {
+      vi.useFakeTimers();
+      const cb = vi.fn();
+      manager = new GroupJoinManager(cb, 100);
+      manager.registerGroup("g1", ["a1", "a2"]);
+
+      // First agent completes, timeout fires for partial
+      manager.onAgentComplete(makeRecord("a1"));
+      vi.advanceTimersByTime(100);
+      expect(cb).toHaveBeenCalledOnce();
+
+      // Second agent completes — triggers straggler delivery (all remaining done)
+      const result = manager.onAgentComplete(makeRecord("a2"));
+      expect(result).toBe("delivered");
+      expect(cb).toHaveBeenCalledTimes(2);
+
+      vi.useRealTimers();
+    });
+
+    it("does not fire timeout if all agents complete before timeout", () => {
+      vi.useFakeTimers();
+      const cb = vi.fn();
+      manager = new GroupJoinManager(cb, 100);
+      manager.registerGroup("g1", ["a1", "a2"]);
+
+      manager.onAgentComplete(makeRecord("a1"));
+      manager.onAgentComplete(makeRecord("a2"));
+
+      // Timeout should be cleared, advancing time should not call again
+      vi.advanceTimersByTime(200);
+      expect(cb).toHaveBeenCalledOnce();
+
+      vi.useRealTimers();
+    });
+  });
+
+  describe("dispose", () => {
+    it("clears all timeouts on dispose", () => {
+      vi.useFakeTimers();
+      const cb = vi.fn();
+      manager = new GroupJoinManager(cb, 100);
+      manager.registerGroup("g1", ["a1", "a2"]);
+
+      manager.onAgentComplete(makeRecord("a1"));
+      // Timeout is now pending
+
+      manager.dispose();
+
+      // Advancing time should not fire the callback
+      vi.advanceTimersByTime(200);
+      expect(cb).not.toHaveBeenCalled();
+
+      vi.useRealTimers();
+    });
+
+    it("clears group and agent mappings on dispose", () => {
+      const cb = vi.fn();
+      manager = new GroupJoinManager(cb);
+      manager.registerGroup("g1", ["a1", "a2"]);
+
+      expect(manager.isGrouped("a1")).toBe(true);
+      manager.dispose();
+      expect(manager.isGrouped("a1")).toBe(false);
+    });
+  });
+});

--- a/test/output-file.test.ts
+++ b/test/output-file.test.ts
@@ -175,6 +175,8 @@ describe("output-file", () => {
       session.emit({ type: "turn_end" } as AgentSessionEvent);
 
       await waitForFileGrowth(outputPath, sizeBefore);
+      // Allow asyncFlush continuation to finish updating writtenCount
+      await new Promise(r => setTimeout(r, 10));
 
       // Cleanup should not re-write the already-flushed message
       cleanup();

--- a/test/output-file.test.ts
+++ b/test/output-file.test.ts
@@ -1,11 +1,12 @@
 import { describe, it, expect, vi, beforeEach, afterEach } from "vitest";
-import { mkdtempSync, readFileSync, rmSync, statSync } from "node:fs";
+import { mkdtempSync, readFileSync, rmSync, statSync, writeFileSync } from "node:fs";
 import { join } from "node:path";
 import { tmpdir } from "node:os";
 import {
   createOutputFilePath,
   writeInitialEntry,
   streamToOutputFile,
+  parseOutputFileResult,
 } from "../src/output-file.js";
 import type { AgentSession, AgentSessionEvent } from "@mariozechner/pi-coding-agent";
 
@@ -202,6 +203,86 @@ describe("output-file", () => {
       const lines = content.trim().split("\n");
       const entry = JSON.parse(lines[1]);
       expect(entry.type).toBe("toolResult");
+    });
+  });
+
+  describe("parseOutputFileResult", () => {
+    let tempDir: string;
+
+    beforeEach(() => {
+      tempDir = mkdtempSync(join(tmpdir(), "pi-parse-test-"));
+    });
+
+    afterEach(() => {
+      rmSync(tempDir, { recursive: true, force: true });
+    });
+
+    it("extracts last assistant message from JSONL", () => {
+      const filePath = join(tempDir, "test.output");
+      const lines = [
+        JSON.stringify({ type: "user", message: { role: "user", content: "hello" } }),
+        JSON.stringify({ type: "assistant", message: { role: "assistant", content: "world" } }),
+      ].join("\n") + "\n";
+      writeFileSync(filePath, lines, "utf-8");
+
+      expect(parseOutputFileResult(filePath)).toBe("world");
+    });
+
+    it("returns undefined for non-existent file", () => {
+      expect(parseOutputFileResult(join(tempDir, "nope.output"))).toBeUndefined();
+    });
+
+    it("returns undefined for file with no assistant messages", () => {
+      const filePath = join(tempDir, "test.output");
+      const lines = [
+        JSON.stringify({ type: "user", message: { role: "user", content: "hello" } }),
+      ].join("\n") + "\n";
+      writeFileSync(filePath, lines, "utf-8");
+
+      expect(parseOutputFileResult(filePath)).toBeUndefined();
+    });
+
+    it("handles multiple assistant messages (returns last)", () => {
+      const filePath = join(tempDir, "test.output");
+      const lines = [
+        JSON.stringify({ type: "assistant", message: { role: "assistant", content: "first" } }),
+        JSON.stringify({ type: "user", message: { role: "user", content: "more" } }),
+        JSON.stringify({ type: "assistant", message: { role: "assistant", content: "second" } }),
+      ].join("\n") + "\n";
+      writeFileSync(filePath, lines, "utf-8");
+
+      expect(parseOutputFileResult(filePath)).toBe("second");
+    });
+
+    it("skips malformed JSONL lines", () => {
+      const filePath = join(tempDir, "test.output");
+      const lines = [
+        "not valid json",
+        JSON.stringify({ type: "assistant", message: { role: "assistant", content: "ok" } }),
+        "also broken {",
+      ].join("\n") + "\n";
+      writeFileSync(filePath, lines, "utf-8");
+
+      expect(parseOutputFileResult(filePath)).toBe("ok");
+    });
+
+    it("handles array-style message content", () => {
+      const filePath = join(tempDir, "test.output");
+      const lines = [
+        JSON.stringify({
+          type: "assistant",
+          message: {
+            role: "assistant",
+            content: [
+              { type: "text", text: "hello " },
+              { type: "text", text: "world" },
+            ],
+          },
+        }),
+      ].join("\n") + "\n";
+      writeFileSync(filePath, lines, "utf-8");
+
+      expect(parseOutputFileResult(filePath)).toBe("hello world");
     });
   });
 });

--- a/test/output-file.test.ts
+++ b/test/output-file.test.ts
@@ -1,0 +1,194 @@
+import { describe, it, expect, vi, beforeEach, afterEach } from "vitest";
+import { mkdtempSync, readFileSync, rmSync, existsSync } from "node:fs";
+import { join } from "node:path";
+import { tmpdir } from "node:os";
+import {
+  createOutputFilePath,
+  writeInitialEntry,
+  streamToOutputFile,
+} from "../src/output-file.js";
+import type { AgentSession, AgentSessionEvent } from "@mariozechner/pi-coding-agent";
+
+/** Minimal mock session with subscribe that captures the callback. */
+function mockSession() {
+  let subscriber: ((event: AgentSessionEvent) => void) | undefined;
+  const messages: any[] = [];
+  return {
+    get messages() { return messages; },
+    subscribe(cb: (event: AgentSessionEvent) => void) {
+      subscriber = cb;
+      return () => { subscriber = undefined; };
+    },
+    emit(event: AgentSessionEvent) {
+      subscriber?.(event);
+    },
+    pushMessage(msg: any) {
+      messages.push(msg);
+    },
+  };
+}
+
+describe("output-file", () => {
+  describe("createOutputFilePath", () => {
+    it("creates the directory structure and returns a path", () => {
+      const path = createOutputFilePath("/tmp/test-cwd", "agent-123", "sess-456");
+      expect(path).toContain("agent-123.output");
+      expect(path).toContain("sess-456");
+      expect(path).toContain("tasks");
+    });
+
+    it("returns different paths for different agent IDs", () => {
+      const p1 = createOutputFilePath("/tmp/cwd", "a1", "s1");
+      const p2 = createOutputFilePath("/tmp/cwd", "a2", "s1");
+      expect(p1).not.toBe(p2);
+    });
+  });
+
+  describe("writeInitialEntry", () => {
+    let tempDir: string;
+    let outputPath: string;
+
+    beforeEach(() => {
+      tempDir = mkdtempSync(join(tmpdir(), "pi-output-test-"));
+      outputPath = join(tempDir, "test.output");
+    });
+
+    afterEach(() => {
+      rmSync(tempDir, { recursive: true, force: true });
+    });
+
+    it("writes a valid JSONL entry with user prompt", () => {
+      writeInitialEntry(outputPath, "agent-1", "hello world", "/tmp");
+      const content = readFileSync(outputPath, "utf-8");
+      const entry = JSON.parse(content.trim());
+
+      expect(entry.isSidechain).toBe(true);
+      expect(entry.agentId).toBe("agent-1");
+      expect(entry.type).toBe("user");
+      expect(entry.message.role).toBe("user");
+      expect(entry.message.content).toBe("hello world");
+      expect(entry.cwd).toBe("/tmp");
+      expect(entry.timestamp).toBeDefined();
+    });
+
+    it("writes entry ending with newline", () => {
+      writeInitialEntry(outputPath, "a", "p", "/tmp");
+      const content = readFileSync(outputPath, "utf-8");
+      expect(content.endsWith("\n")).toBe(true);
+    });
+  });
+
+  describe("streamToOutputFile", () => {
+    let tempDir: string;
+    let outputPath: string;
+
+    beforeEach(() => {
+      tempDir = mkdtempSync(join(tmpdir(), "pi-stream-test-"));
+      outputPath = join(tempDir, "stream.output");
+    });
+
+    afterEach(() => {
+      rmSync(tempDir, { recursive: true, force: true });
+    });
+
+    it("sync-flushes remaining messages on cleanup", () => {
+      const session = mockSession();
+      // Write initial entry so writtenCount starts at 1
+      writeInitialEntry(outputPath, "a1", "prompt", "/tmp");
+
+      // session.messages[0] must exist (the user prompt) since writtenCount starts at 1
+      session.pushMessage({ role: "user", content: "prompt" });
+
+      const cleanup = streamToOutputFile(
+        session as unknown as AgentSession,
+        outputPath,
+        "a1",
+        "/tmp",
+      );
+
+      // Add messages to session without emitting turn_end
+      session.pushMessage({ role: "assistant", content: [{ type: "text", text: "response" }] });
+
+      // Cleanup should sync-flush
+      cleanup();
+
+      const content = readFileSync(outputPath, "utf-8");
+      const lines = content.trim().split("\n");
+      expect(lines.length).toBe(2); // initial + assistant
+      const entry = JSON.parse(lines[1]);
+      expect(entry.type).toBe("assistant");
+      expect(entry.agentId).toBe("a1");
+    });
+
+    it("async flush writes on turn_end", async () => {
+      const session = mockSession();
+      writeInitialEntry(outputPath, "a1", "prompt", "/tmp");
+      session.pushMessage({ role: "user", content: "prompt" });
+
+      const cleanup = streamToOutputFile(
+        session as unknown as AgentSession,
+        outputPath,
+        "a1",
+        "/tmp",
+      );
+
+      session.pushMessage({ role: "assistant", content: [{ type: "text", text: "hi" }] });
+      session.emit({ type: "turn_end" } as AgentSessionEvent);
+
+      // Give async appendFile a tick to complete
+      await new Promise(r => setTimeout(r, 50));
+
+      const content = readFileSync(outputPath, "utf-8");
+      const lines = content.trim().split("\n");
+      expect(lines.length).toBe(2);
+
+      cleanup();
+    });
+
+    it("does not duplicate messages on cleanup after async flush", async () => {
+      const session = mockSession();
+      writeInitialEntry(outputPath, "a1", "prompt", "/tmp");
+      session.pushMessage({ role: "user", content: "prompt" });
+
+      const cleanup = streamToOutputFile(
+        session as unknown as AgentSession,
+        outputPath,
+        "a1",
+        "/tmp",
+      );
+
+      session.pushMessage({ role: "assistant", content: [{ type: "text", text: "hi" }] });
+      session.emit({ type: "turn_end" } as AgentSessionEvent);
+
+      await new Promise(r => setTimeout(r, 50));
+
+      // Cleanup should not re-write the already-flushed message
+      cleanup();
+
+      const content = readFileSync(outputPath, "utf-8");
+      const lines = content.trim().split("\n");
+      expect(lines.length).toBe(2); // not 3
+    });
+
+    it("handles toolResult messages", () => {
+      const session = mockSession();
+      writeInitialEntry(outputPath, "a1", "prompt", "/tmp");
+      session.pushMessage({ role: "user", content: "prompt" });
+
+      const cleanup = streamToOutputFile(
+        session as unknown as AgentSession,
+        outputPath,
+        "a1",
+        "/tmp",
+      );
+
+      session.pushMessage({ role: "toolResult", toolName: "bash", content: "output" });
+      cleanup();
+
+      const content = readFileSync(outputPath, "utf-8");
+      const lines = content.trim().split("\n");
+      const entry = JSON.parse(lines[1]);
+      expect(entry.type).toBe("toolResult");
+    });
+  });
+});

--- a/test/output-file.test.ts
+++ b/test/output-file.test.ts
@@ -1,5 +1,5 @@
 import { describe, it, expect, vi, beforeEach, afterEach } from "vitest";
-import { mkdtempSync, readFileSync, rmSync, existsSync } from "node:fs";
+import { mkdtempSync, readFileSync, rmSync, statSync } from "node:fs";
 import { join } from "node:path";
 import { tmpdir } from "node:os";
 import {
@@ -26,6 +26,17 @@ function mockSession() {
       messages.push(msg);
     },
   };
+}
+
+/** Poll until the file has more than `minBytes` bytes (async flush completed). */
+async function waitForFileGrowth(path: string, minBytes: number, timeoutMs = 2000): Promise<void> {
+  const deadline = Date.now() + timeoutMs;
+  while (Date.now() < deadline) {
+    try {
+      if (statSync(path).size > minBytes) return;
+    } catch { /* file may not exist yet */ }
+    await new Promise(r => setTimeout(r, 5));
+  }
 }
 
 describe("output-file", () => {
@@ -133,10 +144,11 @@ describe("output-file", () => {
       );
 
       session.pushMessage({ role: "assistant", content: [{ type: "text", text: "hi" }] });
+      const sizeBefore = statSync(outputPath).size;
       session.emit({ type: "turn_end" } as AgentSessionEvent);
 
-      // Give async appendFile a tick to complete
-      await new Promise(r => setTimeout(r, 50));
+      // Wait for async appendFile to grow the file
+      await waitForFileGrowth(outputPath, sizeBefore);
 
       const content = readFileSync(outputPath, "utf-8");
       const lines = content.trim().split("\n");
@@ -158,9 +170,10 @@ describe("output-file", () => {
       );
 
       session.pushMessage({ role: "assistant", content: [{ type: "text", text: "hi" }] });
+      const sizeBefore = statSync(outputPath).size;
       session.emit({ type: "turn_end" } as AgentSessionEvent);
 
-      await new Promise(r => setTimeout(r, 50));
+      await waitForFileGrowth(outputPath, sizeBefore);
 
       // Cleanup should not re-write the already-flushed message
       cleanup();


### PR DESCRIPTION
 ## Summary

  Hardens the subagent lifecycle with memory leak fixes, bounded resource cleanup, and improved error reporting.

  - **Fix 11 memory leaks**: session disposal, output file subscriptions, abort controllers, and event listener cleanup across
  agent-manager, agent-runner, and worktree modules
  - **Two-tier cleanup**: Tier 1 (1x retention) disposes sessions; Tier 2 (3x retention) fully removes stale records from the Map
  to prevent unbounded growth in long sessions
  - **Async/sync flush race guard**: `asyncFlush` now checks if `syncFlush` advanced `writtenCount` during the `await`, preventing
  duplicate JSONL entries in output files
  - **Bounded output file reads**: `parseOutputFileResult` reads only the last 256KB instead of the entire file
  - **Smarter error tips**: "Check provider status" tip only shown for likely API/model errors, not user-initiated stops or
  timeouts
  - **Error message cleanup**: Model info removed from `record.error` string (already carried in `record.modelName`)
  - **Type safety**: Removed `any` types from `session_switch` handler
  - **Debug logging**: Added `process.env.DEBUG` logging for `captureStats` failures instead of silent swallow
  - **35 new tests** covering cleanup tiers, flush races, output file edge cases, group-join, and agent-runner lifecycle

  ## Depends on

  > **Merge https://github.com/tintinweb/pi-subagents/pull/8 first**, then rebase this PR onto `master` before merging.

  ## Test plan

  - [x] `npx vitest run` — 242 tests passing (4 pre-existing `custom-agents.test.ts` failures unrelated to this branch)
  - [x] Tier 1 cleanup: session disposed, record retained in Map
  - [x] Tier 2 cleanup: record fully removed after 3x retention
  - [x] Flush race guard: no duplicate JSONL entries when syncFlush runs during async await
  - [x] Error tip suppressed for abort/timeout/stopped errors
  - [x] `record.error` no longer includes `[model: ...]` suffix