### PR TITLE
feat: auto-trigger parent agent turn on background completion

### DIFF
--- a/src/index.ts
+++ b/src/index.ts
@@ -289,7 +289,7 @@ export default function (pi: ExtensionAPI) {
       content: notification + footer,
       display: true,
       details: buildNotificationDetails(record, 500, agentActivity.get(record.id)),
-    }, { deliverAs: "followUp" });
+    }, { deliverAs: "followUp", triggerTurn: true });
   }
 
   function sendIndividualNudge(record: AgentRecord) {
@@ -326,7 +326,7 @@ export default function (pi: ExtensionAPI) {
           content: `Background agent group completed: ${label}\n\n${notifications}\n\nUse get_subagent_result for full output.`,
           display: true,
           details,
-        }, { deliverAs: "followUp" });
+        }, { deliverAs: "followUp", triggerTurn: true });
       });
       widget.update();
     },


### PR DESCRIPTION
Add `triggerTurn: true` to both `sendMessage` calls (individual nudge and group notification). This wakes up the parent agent when background agents complete, instead of requiring manual user input.

Pi's `sendMessage` API already supports this — we just weren't using it.

**Changes:**
- Individual nudge (`emitIndividualNudge`): added `triggerTurn: true`
- Group notification (`GroupJoinManager` callback): added `triggerTurn: true`

**Fixes:** parent agent stays idle after background agents complete, requiring user to type to trigger processing.

**Verification:**
1. Start pi with the modified extension
2. Spawn 2 background agents
3. Wait for them to complete
4. Parent agent should automatically process the notifications WITHOUT user typing anything