### PR TITLE
fix: resolve [Tool: unknown] display — use correct ToolCall.name property

### DIFF
--- a/src/agent-runner.ts
+++ b/src/agent-runner.ts
@@ -393,7 +393,7 @@ export function getAgentConversation(session: AgentSession): string {
       const toolCalls: string[] = [];
       for (const c of msg.content) {
         if (c.type === "text" && c.text) textParts.push(c.text);
-        else if (c.type === "toolCall") toolCalls.push(`  Tool: ${(c as any).toolName ?? "unknown"}`);
+        else if (c.type === "toolCall") toolCalls.push(`  Tool: ${(c as any).name ?? (c as any).toolName ?? "unknown"}`);
       }
       if (textParts.length > 0) parts.push(`[Assistant]: ${textParts.join("\n")}`);
       if (toolCalls.length > 0) parts.push(`[Tool Calls]:\n${toolCalls.join("\n")}`);

--- a/src/ui/conversation-viewer.test.ts
+++ b/src/ui/conversation-viewer.test.ts
@@ -197,7 +197,7 @@ describe("ConversationViewer", () => {
           role: "assistant",
           content: [
             { type: "text", text: "Let me check that." },
-            { type: "toolCall", toolUseId: "t1", toolName: "very_long_tool_name_" + "x".repeat(200), input: {} },
+            { type: "toolCall", toolUseId: "t1", name: "very_long_tool_name_" + "x".repeat(200), input: {} },
           ],
         },
       ];

--- a/src/ui/conversation-viewer.ts
+++ b/src/ui/conversation-viewer.ts
@@ -191,7 +191,7 @@ export class ConversationViewer implements Component {
         for (const c of msg.content) {
           if (c.type === "text" && c.text) textParts.push(c.text);
           else if (c.type === "toolCall") {
-            toolCalls.push((c as any).toolName ?? "unknown");
+            toolCalls.push((c as any).name ?? (c as any).toolName ?? "unknown");
           }
         }
         if (needsSeparator) lines.push(th.fg("dim", "───"));


### PR DESCRIPTION
## Bug

`conversation-viewer.ts` and `agent-runner.ts` read `(c as any).toolName` but the `ToolCall` interface from `@mariozechner/pi-ai` defines the property as `name`, not `toolName`. Every tool call displays as `[Tool: unknown]`.

## Fix

Use `(c as any).name ?? (c as any).toolName ?? "unknown"` — reads the correct property with a defensive fallback for any runtime edge cases.

## Changes

- `src/conversation-viewer.ts:194` — tool call name extraction
- `src/agent-runner.ts:396` — same pattern, same fix  
- `src/conversation-viewer.test.ts` — update mock to use `name` property

Fixes #13