### PR TITLE
fix: trigger LLM turn when background agent completes while parent is idle

### DIFF
--- a/src/index.ts
+++ b/src/index.ts
@@ -289,7 +289,7 @@ export default function (pi: ExtensionAPI) {
       content: notification + footer,
       display: true,
       details: buildNotificationDetails(record, 500, agentActivity.get(record.id)),
-    }, { deliverAs: "followUp" });
+    }, { deliverAs: "followUp", triggerTurn: true });
   }
 
   function sendIndividualNudge(record: AgentRecord) {
@@ -326,7 +326,7 @@ export default function (pi: ExtensionAPI) {
           content: `Background agent group completed: ${label}\n\n${notifications}\n\nUse get_subagent_result for full output.`,
           display: true,
           details,
-        }, { deliverAs: "followUp" });
+        }, { deliverAs: "followUp", triggerTurn: true });
       });
       widget.update();
     },


### PR DESCRIPTION
When a background subagent finishes and the parent agent is not streaming,
`sendMessage` with `deliverAs: "followUp"` silently appends the notification
without triggering a new LLM turn. The parent stays idle until the user
manually sends a message.

Adding `triggerTurn: true` ensures the agent wakes up and processes the
completion notification regardless of streaming state. During streaming,
`deliverAs: "followUp"` takes precedence (checked first in `sendCustomMessage`),
so the flag is harmless.

### Changes

Two-line change in `src/index.ts` — adds `triggerTurn: true` to both individual and grouped background agent completion notifications.