### PR TITLE
Fire `session_start` in subagent handlers

### DIFF
--- a/src/agent-runner.ts
+++ b/src/agent-runner.ts
@@ -292,6 +292,19 @@ export async function runAgent(
     session.setActiveToolsByName(activeTools);
   }
 
+  // Bind extensions so that session_start fires and extensions can initialize
+  // (e.g. loading credentials, setting up state). Placed after tool filtering
+  // so extension-provided skills/prompts from extendResourcesFromExtensions()
+  // respect the active tool set. All ExtensionBindings fields are optional.
+  await session.bindExtensions({
+    onError: (err) => {
+      options.onToolActivity?.({
+        type: "end",
+        toolName: `extension-error:${err.extensionPath}`,
+      });
+    },
+  });
+
   options.onSessionCreated?.(session);
 
   // Track turns for graceful max_turns enforcement

--- a/test/agent-runner.test.ts
+++ b/test/agent-runner.test.ts
@@ -76,6 +76,7 @@ function createSession(finalText: string) {
     steer: vi.fn(),
     getActiveToolNames: vi.fn(() => ["read"]),
     setActiveToolsByName: vi.fn(),
+    bindExtensions: vi.fn(async () => {}),
   };
   return { session, listeners };
 }
@@ -102,6 +103,22 @@ describe("agent-runner final output capture", () => {
     const result = await runAgent(ctx, "Explore", "Say LOCKED", { pi });
 
     expect(result.responseText).toBe("LOCKED");
+  });
+
+  it("binds extensions before prompting", async () => {
+    const { session } = createSession("BOUND");
+    createAgentSession.mockResolvedValue({ session });
+
+    await runAgent(ctx, "Explore", "Say BOUND", { pi });
+
+    expect(session.bindExtensions).toHaveBeenCalledTimes(1);
+    expect(session.bindExtensions).toHaveBeenCalledWith(
+      expect.objectContaining({ onError: expect.any(Function) }),
+    );
+
+    const bindOrder = session.bindExtensions.mock.invocationCallOrder[0];
+    const promptOrder = session.prompt.mock.invocationCallOrder[0];
+    expect(bindOrder).toBeLessThan(promptOrder);
   });
 
   it("resumeAgent also falls back to the final assistant message text", async () => {


### PR DESCRIPTION
Extensions which depend on the `session_start` event for functionality like authentication were not successfully triggering from `Agent` toolcalls as the event was not fired.

Discussion of the bug specifics are in issue #20 

Fixes #20