### PR TITLE
Prevent AGENTS.md / APPEND_SYSTEM.md leaking into sub-agents

### DIFF
--- a/src/agent-runner.ts
+++ b/src/agent-runner.ts
@@ -240,6 +240,13 @@ export async function runAgent(
     noPromptTemplates: true,
     noThemes: true,
     systemPromptOverride: () => systemPrompt,
+    // Prevent AGENTS.md / CLAUDE.md / APPEND_SYSTEM.md from leaking into sub-agent
+    // prompts. ResourceLoader otherwise re-appends these on top of the override in
+    // agent-session.ts::buildSystemPrompt(), breaking `prompt_mode: replace` and
+    // `isolated` guarantees (e.g. autoresearch-mode parent prompts bleeding into
+    // a fresh Explore sub-agent).
+    agentsFilesOverride: () => ({ agentsFiles: [] }),
+    appendSystemPromptOverride: () => [],
   });
   await loader.reload();
 


### PR DESCRIPTION
## Problem

`systemPromptOverride` in `agent-runner.ts` replaces the base system prompt, but `DefaultResourceLoader` still loads `agentsFiles` (`AGENTS.md`, `CLAUDE.md`) and `appendSystemPrompt` (`APPEND_SYSTEM.md`). Those get re-appended *after* the override in `agent-session.ts::buildSystemPrompt()`:

```js
if (contextFiles.length > 0) {
    prompt += "\n\n# Project Context\n\n";
    prompt += "Project-specific instructions and guidelines:\n\n";
    for (const { path: filePath, content } of contextFiles) {
        prompt += `## ${filePath}\n\n${content}\n\n`;
    }
}
```

This breaks `prompt_mode: replace` and `isolated: true` guarantees. Any parent project context (e.g. an "autoresearch mode" block in `AGENTS.md`) leaks into fresh `Explore` / custom sub-agents, regardless of frontmatter.

## Repro

1. Add a distinctive marker to project `AGENTS.md` (e.g. `SPECIAL-PARENT-ONLY-MODE`).
2. Spawn an `Explore` sub-agent and ask it to describe its system prompt or operational mode.
3. Sub-agent sees `SPECIAL-PARENT-ONLY-MODE` even with `prompt_mode: replace`.

## Fix

Also override `agentsFilesOverride` and `appendSystemPromptOverride` on the `DefaultResourceLoader` so contextFiles and append sources are suppressed for sub-agents.

## Scope

Minimal, 7 lines in `agent-runner.ts`. No behavior change for agents explicitly using `prompt_mode: append` (they still inherit the parent system prompt via `systemPromptOverride`; parent context is embedded there). Custom agents wanting AGENTS.md can opt back in by loading it themselves in their prompt body.

Happy to add tests if a testing pattern exists — pointers welcome.