### PR TITLE
Pass agentDir into subagent session setup

### DIFF
--- a/src/agent-runner.ts
+++ b/src/agent-runner.ts
@@ -10,6 +10,7 @@ import {
   createAgentSession,
   DefaultResourceLoader,
   type ExtensionAPI,
+  getAgentDir,
   SessionManager,
   SettingsManager,
 } from "@mariozechner/pi-coding-agent";
@@ -232,9 +233,12 @@ export async function runAgent(
   // Still pass noSkills: true since we don't need the skill loader to load them again.
   const noSkills = skills === false || Array.isArray(skills);
 
+  const agentDir = getAgentDir();
+
   // Load extensions/skills: true or string[] → load; false → don't
   const loader = new DefaultResourceLoader({
     cwd: effectiveCwd,
+    agentDir,
     noExtensions: extensions === false,
     noSkills,
     noPromptTemplates: true,
@@ -253,8 +257,9 @@ export async function runAgent(
 
   const sessionOpts: Record<string, unknown> = {
     cwd: effectiveCwd,
+    agentDir,
     sessionManager: SessionManager.inMemory(effectiveCwd),
-    settingsManager: SettingsManager.create(),
+    settingsManager: SettingsManager.create(effectiveCwd, agentDir),
     modelRegistry: ctx.modelRegistry,
     model,
     tools,

--- a/test/agent-runner.test.ts
+++ b/test/agent-runner.test.ts
@@ -1,16 +1,31 @@
 import { beforeEach, describe, expect, it, vi } from "vitest";
 
-const { createAgentSession } = vi.hoisted(() => ({
+const {
+  createAgentSession,
+  defaultResourceLoaderCtor,
+  getAgentDir,
+  sessionManagerInMemory,
+  settingsManagerCreate,
+} = vi.hoisted(() => ({
   createAgentSession: vi.fn(),
+  defaultResourceLoaderCtor: vi.fn(),
+  getAgentDir: vi.fn(() => "/mock/agent-dir"),
+  sessionManagerInMemory: vi.fn(() => ({ kind: "memory-session-manager" })),
+  settingsManagerCreate: vi.fn(() => ({ kind: "settings-manager" })),
 }));
 
 vi.mock("@mariozechner/pi-coding-agent", () => ({
   createAgentSession,
   DefaultResourceLoader: class {
+    constructor(options: any) {
+      defaultResourceLoaderCtor(options);
+    }
+
     async reload() {}
   },
-  SessionManager: { inMemory: vi.fn(() => ({ kind: "memory-session-manager" })) },
-  SettingsManager: { create: vi.fn(() => ({ kind: "settings-manager" })) },
+  getAgentDir,
+  SessionManager: { inMemory: sessionManagerInMemory },
+  SettingsManager: { create: settingsManagerCreate },
 }));
 
 vi.mock("../src/agent-types.js", () => ({
@@ -93,6 +108,10 @@ const pi = {} as any;
 
 beforeEach(() => {
   createAgentSession.mockReset();
+  defaultResourceLoaderCtor.mockClear();
+  getAgentDir.mockClear();
+  sessionManagerInMemory.mockClear();
+  settingsManagerCreate.mockClear();
 });
 
 describe("agent-runner final output capture", () => {
@@ -119,6 +138,25 @@ describe("agent-runner final output capture", () => {
     const bindOrder = session.bindExtensions.mock.invocationCallOrder[0];
     const promptOrder = session.prompt.mock.invocationCallOrder[0];
     expect(bindOrder).toBeLessThan(promptOrder);
+  });
+
+  it("passes effective cwd and agentDir to the loader and settings manager", async () => {
+    const { session } = createSession("CONFIGURED");
+    createAgentSession.mockResolvedValue({ session });
+
+    await runAgent(ctx, "Explore", "Say CONFIGURED", { pi, cwd: "/tmp/worktree" });
+
+    expect(getAgentDir).toHaveBeenCalledTimes(1);
+    expect(defaultResourceLoaderCtor).toHaveBeenCalledWith(expect.objectContaining({
+      cwd: "/tmp/worktree",
+      agentDir: "/mock/agent-dir",
+    }));
+    expect(settingsManagerCreate).toHaveBeenCalledWith("/tmp/worktree", "/mock/agent-dir");
+    expect(sessionManagerInMemory).toHaveBeenCalledWith("/tmp/worktree");
+    expect(createAgentSession).toHaveBeenCalledWith(expect.objectContaining({
+      cwd: "/tmp/worktree",
+      agentDir: "/mock/agent-dir",
+    }));
   });
 
   it("resumeAgent also falls back to the final assistant message text", async () => {


### PR DESCRIPTION
## Summary
- pass the resolved `agentDir` into the subagent resource loader
- create the subagent settings manager with the effective cwd and `agentDir`
- add a regression test that verifies the effective cwd/agentDir handoff

## Why
ATC subagent launches were failing immediately when user-scoped local package paths were configured in `~/.pi/agent/settings.json`. The subagent runner was creating the loader/settings manager without an explicit `agentDir`, which let pi package resolution fall through to `resolve(undefined, ...)` during package identity/deduping.

## Testing
- `npm test`
- `npm run typecheck`
- `npm run build`
- `npx vitest run test/agent-runner.test.ts`
