### PR TITLE
fix: pass agentDir and cwd to DefaultResourceLoader and SettingsManager

### DIFF
--- a/src/agent-runner.ts
+++ b/src/agent-runner.ts
@@ -10,6 +10,7 @@ import {
   createAgentSession,
   DefaultResourceLoader,
   type ExtensionAPI,
+  getAgentDir,
   SessionManager,
   SettingsManager,
 } from "@mariozechner/pi-coding-agent";
@@ -235,6 +236,7 @@ export async function runAgent(
   // Load extensions/skills: true or string[] → load; false → don't
   const loader = new DefaultResourceLoader({
     cwd: effectiveCwd,
+    agentDir: getAgentDir(),
     noExtensions: extensions === false,
     noSkills,
     noPromptTemplates: true,
@@ -254,7 +256,7 @@ export async function runAgent(
   const sessionOpts: Record<string, unknown> = {
     cwd: effectiveCwd,
     sessionManager: SessionManager.inMemory(effectiveCwd),
-    settingsManager: SettingsManager.create(),
+    settingsManager: SettingsManager.create(effectiveCwd),
     modelRegistry: ctx.modelRegistry,
     model,
     tools,

--- a/test/agent-runner.test.ts
+++ b/test/agent-runner.test.ts
@@ -9,6 +9,7 @@ vi.mock("@mariozechner/pi-coding-agent", () => ({
   DefaultResourceLoader: class {
     async reload() {}
   },
+  getAgentDir: vi.fn(() => "/mock/agent/dir"),
   SessionManager: { inMemory: vi.fn(() => ({ kind: "memory-session-manager" })) },
   SettingsManager: { create: vi.fn(() => ({ kind: "settings-manager" })) },
 }));


### PR DESCRIPTION
## Problem

Every `Agent` tool invocation fails immediately with:

```
Agent failed: The "paths[0]" argument must be of type string. Received undefined
```

## Root Cause

Two issues in `runAgent()` in `src/agent-runner.ts`:

**1. `DefaultResourceLoader` constructed without `agentDir`**

`DefaultResourceLoader` uses `agentDir` to build paths for skills, themes, extensions and the global system prompt file — all via `join(this.agentDir, ...)`. When `agentDir` is `undefined`, every one of those `join()` calls throws:
```
TypeError: The "paths[0]" argument must be of type string. Received undefined
```

**2. `SettingsManager.create()` called without `cwd`**

`SettingsManager.create(cwd, agentDir)` — when called with no arguments, `cwd` is `undefined`, causing `join(undefined, CONFIG_DIR_NAME, "settings.json")` to throw the same error.

## Fix

```ts
// 1. Import getAgentDir
import { getAgentDir, ... } from "@mariozechner/pi-coding-agent";

// 2. Pass agentDir to DefaultResourceLoader
const loader = new DefaultResourceLoader({
  cwd: effectiveCwd,
  agentDir: getAgentDir(),   // ← added
  ...
});

// 3. Pass cwd to SettingsManager.create()
settingsManager: SettingsManager.create(effectiveCwd),  // ← was create()
```

Also adds `getAgentDir` to the `vi.mock()` in `test/agent-runner.test.ts` so existing tests continue to pass.

## Verified

- All 258 tests pass (`npm test`)
- Confirmed fix works in a live pi session — `Agent` tool launches subagents correctly after restart