### PR TITLE
feat: persist /agents settings (#24) + events for listeners

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -7,6 +7,10 @@ and this project adheres to [Semantic Versioning](https://semver.org/spec/v2.0.0
 
 ## [Unreleased]
 
+### Added
+- **Persistent `/agents` → Settings** ([#24](https://github.com/tintinweb/pi-subagents/issues/24)) — the four runtime tuning values (`maxConcurrent`, `defaultMaxTurns`, `graceTurns`, `defaultJoinMode`) now survive pi restarts via a two-file dual-scope model mirroring pi's own `SettingsManager`. Global `~/.pi/agent/subagents.json` provides machine-wide defaults (edit by hand; the menu never writes here); project `<cwd>/.pi/subagents.json` holds per-project overrides (written by `/agents` → Settings). Load merges both with project winning on conflicts. Invalid fields are silently dropped per field; malformed JSON emits a warning to stderr and falls back to defaults so startup always proceeds; write failures downgrade the settings toast to a warning with `(session only; failed to persist)` so changes aren't silently reverted on next restart.
+- **New lifecycle events** — `subagents:settings_loaded` (emitted once at extension init with the merged settings) and `subagents:settings_changed` (emitted on each `/agents` → Settings mutation with the new snapshot and a `persisted: boolean` flag so listeners can react to write failures).
+
 ## [0.6.0] - 2026-04-24
 
 > **⚠️ Breaking: drops support for `pi` < 0.68.** The upstream `pi-coding-agent` package shipped breaking API changes in v0.68 (and further ones in v0.70). This release migrates to `^0.70.2` and is **not** backward-compatible with hosts on `pi` 0.62–0.67. Users on those versions must upgrade their `pi` installation (`npm install -g @mariozechner/pi-coding-agent@latest`) before updating this extension.

--- a/README.md
+++ b/README.md
@@ -272,6 +272,36 @@ When background agents complete, they notify the main agent. The **join mode** c
 **Configuration:**
 - Configure join mode in `/agents` → Settings → Join mode
 
+## Persistent Settings
+
+Runtime tuning values set via `/agents` → Settings (max concurrency, default max turns, grace turns, default join mode) persist across pi restarts. Two files, merged on load:
+
+- **Global:** `~/.pi/agent/subagents.json` — your machine-wide defaults. Edit by hand; the `/agents` menu never writes here.
+- **Project:** `<cwd>/.pi/subagents.json` — per-project overrides. Written by `/agents` → Settings.
+
+**Precedence:** project overrides global on any field present in both. Missing fields fall back to the hardcoded defaults (max concurrency `4`, default max turns unlimited, grace turns `5`, join mode `smart`).
+
+**Example — global defaults for a beefy machine:**
+
+```bash
+mkdir -p ~/.pi/agent
+cat > ~/.pi/agent/subagents.json <<'EOF'
+{
+  "maxConcurrent": 16,
+  "graceTurns": 10
+}
+EOF
+```
+
+Every project now starts with concurrency 16 and grace 10, without ever touching the menu. Individual projects can still override via `/agents` → Settings.
+
+**Failure behavior:**
+
+- **Missing file** — silent fallback to defaults. Expected for fresh installs.
+- **Malformed JSON** — a warning is printed to stderr on startup (`[pi-subagents] Ignoring malformed settings at …`), and defaults apply.
+- **Invalid field values** (negative numbers, non-integers, unknown join modes) — silently dropped per field; remaining valid fields still apply.
+- **Save failure** (read-only FS, permission denied) — the `/agents` → Settings toast downgrades to a warning with `(session only; failed to persist)` so you know the change won't survive restart.
+
 ## Events
 
 Agent lifecycle events are emitted via `pi.events.emit()` so other extensions can react:
@@ -284,6 +314,8 @@ Agent lifecycle events are emitted via `pi.events.emit()` so other extensions ca
 | `subagents:failed` | Agent errored, stopped, or aborted | same as completed + `error`, `status` |
 | `subagents:steered` | Steering message sent | `id`, `message` |
 | `subagents:ready` | Extension loaded and RPC handlers registered | — |
+| `subagents:settings_loaded` | Persisted settings applied at extension init | `settings` (merged global + project) |
+| `subagents:settings_changed` | `/agents` → Settings mutation was applied | `settings`, `persisted` (`boolean` — `false` on write failure) |
 
 ## Cross-Extension RPC
 

--- a/README.md
+++ b/README.md
@@ -295,12 +295,7 @@ EOF
 
 Every project now starts with concurrency 16 and grace 10, without ever touching the menu. Individual projects can still override via `/agents` → Settings.
 
-**Failure behavior:**
-
-- **Missing file** — silent fallback to defaults. Expected for fresh installs.
-- **Malformed JSON** — a warning is printed to stderr on startup (`[pi-subagents] Ignoring malformed settings at …`), and defaults apply.
-- **Invalid field values** (negative numbers, non-integers, unknown join modes) — silently dropped per field; remaining valid fields still apply.
-- **Save failure** (read-only FS, permission denied) — the `/agents` → Settings toast downgrades to a warning with `(session only; failed to persist)` so you know the change won't survive restart.
+**Failure behavior:** missing file is silent; malformed JSON logs a `[pi-subagents] Ignoring malformed settings at …` warning to stderr; invalid/out-of-range field values are dropped per-field; write failures downgrade the `/agents` toast to a warning with `(session only; failed to persist)`.
 
 ## Events
 

--- a/src/index.ts
+++ b/src/index.ts
@@ -25,7 +25,7 @@ import { GroupJoinManager } from "./group-join.js";
 import { resolveAgentInvocationConfig, resolveJoinMode } from "./invocation-config.js";
 import { type ModelRegistry, resolveModel } from "./model-resolver.js";
 import { createOutputFilePath, streamToOutputFile, writeInitialEntry } from "./output-file.js";
-import { applySettings, loadSettings, persistToastFor, type SubagentsSettings, saveSettings } from "./settings.js";
+import { applyAndEmitLoaded, type SubagentsSettings, saveAndEmitChanged } from "./settings.js";
 import { type AgentConfig, type AgentRecord, type JoinMode, type NotificationDetails, type SubagentType } from "./types.js";
 import {
   type AgentActivity,
@@ -549,16 +549,18 @@ export default function (pi: ExtensionAPI) {
 
   const typeListText = buildTypeListText();
 
-  // Apply persisted settings on startup (global + project merged; missing → defaults;
-  // corrupt file emits a warning to stderr and falls back to defaults)
-  const loadedSettings = loadSettings();
-  applySettings(loadedSettings, {
-    setMaxConcurrent: (n) => manager.setMaxConcurrent(n),
-    setDefaultMaxTurns,
-    setGraceTurns,
-    setDefaultJoinMode,
-  });
-  pi.events.emit("subagents:settings_loaded", { settings: loadedSettings });
+  // Apply persisted settings on startup and emit `subagents:settings_loaded`.
+  // Global + project merged; missing → defaults; corrupt file emits a warning
+  // to stderr and falls back to defaults.
+  applyAndEmitLoaded(
+    {
+      setMaxConcurrent: (n) => manager.setMaxConcurrent(n),
+      setDefaultMaxTurns,
+      setGraceTurns,
+      setDefaultJoinMode,
+    },
+    (event, payload) => pi.events.emit(event, payload),
+  );
 
   // ---- Agent tool ----
 
@@ -1620,7 +1622,9 @@ ${systemPrompt}
   function snapshotSettings(): SubagentsSettings {
     return {
       maxConcurrent: manager.getMaxConcurrent(),
-      defaultMaxTurns: getDefaultMaxTurns() ?? 0, // 0 = unlimited
+      // 0 = unlimited — per SubagentsSettings.defaultMaxTurns docstring and
+      // normalizeMaxTurns() in agent-runner.ts (which maps 0 → undefined).
+      defaultMaxTurns: getDefaultMaxTurns() ?? 0,
       graceTurns: getGraceTurns(),
       defaultJoinMode: getDefaultJoinMode(),
     };
@@ -1685,15 +1689,16 @@ ${systemPrompt}
     }
   }
 
-  // Persist current settings snapshot, emit the changed-event, and surface the
-  // right toast — successful saves show info; persistence failures downgrade to
-  // warning so users aren't silently reverted on restart. Event fires regardless
-  // of persistence outcome so listeners see the in-memory change.
+  // Persist the current snapshot, emit `subagents:settings_changed`, and surface
+  // the right toast. Successful saves show info; persistence failures downgrade
+  // to warning so users aren't silently reverted on restart. Event fires regardless
+  // of outcome so listeners see the in-memory change.
   function notifyApplied(ctx: ExtensionCommandContext, successMsg: string) {
-    const snapshot = snapshotSettings();
-    const persisted = saveSettings(snapshot);
-    pi.events.emit("subagents:settings_changed", { settings: snapshot, persisted });
-    const { message, level } = persistToastFor(successMsg, persisted);
+    const { message, level } = saveAndEmitChanged(
+      snapshotSettings(),
+      successMsg,
+      (event, payload) => pi.events.emit(event, payload),
+    );
     ctx.ui.notify(message, level);
   }
 

--- a/src/index.ts
+++ b/src/index.ts
@@ -25,6 +25,7 @@ import { GroupJoinManager } from "./group-join.js";
 import { resolveAgentInvocationConfig, resolveJoinMode } from "./invocation-config.js";
 import { type ModelRegistry, resolveModel } from "./model-resolver.js";
 import { createOutputFilePath, streamToOutputFile, writeInitialEntry } from "./output-file.js";
+import { applySettings, loadSettings, persistToastFor, type SubagentsSettings, saveSettings } from "./settings.js";
 import { type AgentConfig, type AgentRecord, type JoinMode, type NotificationDetails, type SubagentType } from "./types.js";
 import {
   type AgentActivity,
@@ -547,6 +548,17 @@ export default function (pi: ExtensionAPI) {
   }
 
   const typeListText = buildTypeListText();
+
+  // Apply persisted settings on startup (global + project merged; missing → defaults;
+  // corrupt file emits a warning to stderr and falls back to defaults)
+  const loadedSettings = loadSettings();
+  applySettings(loadedSettings, {
+    setMaxConcurrent: (n) => manager.setMaxConcurrent(n),
+    setDefaultMaxTurns,
+    setGraceTurns,
+    setDefaultJoinMode,
+  });
+  pi.events.emit("subagents:settings_loaded", { settings: loadedSettings });
 
   // ---- Agent tool ----
 
@@ -1605,6 +1617,15 @@ ${systemPrompt}
     ctx.ui.notify(`Created ${targetPath}`, "info");
   }
 
+  function snapshotSettings(): SubagentsSettings {
+    return {
+      maxConcurrent: manager.getMaxConcurrent(),
+      defaultMaxTurns: getDefaultMaxTurns() ?? 0, // 0 = unlimited
+      graceTurns: getGraceTurns(),
+      defaultJoinMode: getDefaultJoinMode(),
+    };
+  }
+
   async function showSettings(ctx: ExtensionCommandContext) {
     const choice = await ctx.ui.select("Settings", [
       `Max concurrency (current: ${manager.getMaxConcurrent()})`,
@@ -1620,7 +1641,7 @@ ${systemPrompt}
         const n = parseInt(val, 10);
         if (n >= 1) {
           manager.setMaxConcurrent(n);
-          ctx.ui.notify(`Max concurrency set to ${n}`, "info");
+          notifyApplied(ctx, `Max concurrency set to ${n}`);
         } else {
           ctx.ui.notify("Must be a positive integer.", "warning");
         }
@@ -1631,10 +1652,10 @@ ${systemPrompt}
         const n = parseInt(val, 10);
         if (n === 0) {
           setDefaultMaxTurns(undefined);
-          ctx.ui.notify("Default max turns set to unlimited", "info");
+          notifyApplied(ctx, "Default max turns set to unlimited");
         } else if (n >= 1) {
           setDefaultMaxTurns(n);
-          ctx.ui.notify(`Default max turns set to ${n}`, "info");
+          notifyApplied(ctx, `Default max turns set to ${n}`);
         } else {
           ctx.ui.notify("Must be 0 (unlimited) or a positive integer.", "warning");
         }
@@ -1645,7 +1666,7 @@ ${systemPrompt}
         const n = parseInt(val, 10);
         if (n >= 1) {
           setGraceTurns(n);
-          ctx.ui.notify(`Grace turns set to ${n}`, "info");
+          notifyApplied(ctx, `Grace turns set to ${n}`);
         } else {
           ctx.ui.notify("Must be a positive integer.", "warning");
         }
@@ -1659,9 +1680,21 @@ ${systemPrompt}
       if (val) {
         const mode = val.split(" ")[0] as JoinMode;
         setDefaultJoinMode(mode);
-        ctx.ui.notify(`Default join mode set to ${mode}`, "info");
+        notifyApplied(ctx, `Default join mode set to ${mode}`);
       }
     }
+  }
+
+  // Persist current settings snapshot, emit the changed-event, and surface the
+  // right toast — successful saves show info; persistence failures downgrade to
+  // warning so users aren't silently reverted on restart. Event fires regardless
+  // of persistence outcome so listeners see the in-memory change.
+  function notifyApplied(ctx: ExtensionCommandContext, successMsg: string) {
+    const snapshot = snapshotSettings();
+    const persisted = saveSettings(snapshot);
+    pi.events.emit("subagents:settings_changed", { settings: snapshot, persisted });
+    const { message, level } = persistToastFor(successMsg, persisted);
+    ctx.ui.notify(message, level);
   }
 
   pi.registerCommand("agents", {

--- a/src/settings.ts
+++ b/src/settings.ts
@@ -9,7 +9,11 @@ import type { JoinMode } from "./types.js";
 
 export interface SubagentsSettings {
   maxConcurrent?: number;
-  /** 0 = unlimited (matches normalizeMaxTurns in agent-runner.ts and the /agents UI). */
+  /**
+   * 0 = unlimited — the extension's single source of truth for that convention:
+   * `normalizeMaxTurns()` in agent-runner.ts treats 0 → `undefined`, and the
+   * `/agents` → Settings input prompt explicitly says "0 = unlimited".
+   */
   defaultMaxTurns?: number;
   graceTurns?: number;
   defaultJoinMode?: JoinMode;
@@ -23,20 +27,42 @@ export interface SettingsAppliers {
   setDefaultJoinMode: (mode: JoinMode) => void;
 }
 
+/** Emit callback — a subset of `pi.events.emit` to keep helpers testable. */
+export type SettingsEmit = (event: string, payload: unknown) => void;
+
 const VALID_JOIN_MODES: ReadonlySet<string> = new Set<JoinMode>(["async", "group", "smart"]);
+
+// Sanity ceilings — prevent hand-edited configs from asking for values that
+// make no operational sense (e.g. 1e6 concurrent subagents). Permissive enough
+// that any realistic power-user setting passes through.
+const MAX_CONCURRENT_CEILING = 1024;
+const MAX_TURNS_CEILING = 10_000;
+const GRACE_TURNS_CEILING = 1_000;
 
 /** Drop fields that don't match the expected shape. Silent — garbage becomes absent. */
 function sanitize(raw: unknown): SubagentsSettings {
   if (!raw || typeof raw !== "object") return {};
   const r = raw as Record<string, unknown>;
   const out: SubagentsSettings = {};
-  if (Number.isInteger(r.maxConcurrent) && (r.maxConcurrent as number) >= 1) {
+  if (
+    Number.isInteger(r.maxConcurrent) &&
+    (r.maxConcurrent as number) >= 1 &&
+    (r.maxConcurrent as number) <= MAX_CONCURRENT_CEILING
+  ) {
     out.maxConcurrent = r.maxConcurrent as number;
   }
-  if (Number.isInteger(r.defaultMaxTurns) && (r.defaultMaxTurns as number) >= 0) {
+  if (
+    Number.isInteger(r.defaultMaxTurns) &&
+    (r.defaultMaxTurns as number) >= 0 &&
+    (r.defaultMaxTurns as number) <= MAX_TURNS_CEILING
+  ) {
     out.defaultMaxTurns = r.defaultMaxTurns as number;
   }
-  if (Number.isInteger(r.graceTurns) && (r.graceTurns as number) >= 1) {
+  if (
+    Number.isInteger(r.graceTurns) &&
+    (r.graceTurns as number) >= 1 &&
+    (r.graceTurns as number) <= GRACE_TURNS_CEILING
+  ) {
     out.graceTurns = r.graceTurns as number;
   }
   if (typeof r.defaultJoinMode === "string" && VALID_JOIN_MODES.has(r.defaultJoinMode)) {
@@ -110,4 +136,37 @@ export function persistToastFor(
   return persisted
     ? { message: successMsg, level: "info" }
     : { message: `${successMsg} (session only; failed to persist)`, level: "warning" };
+}
+
+/**
+ * Load merged settings, apply them to in-memory state, and emit the
+ * `subagents:settings_loaded` lifecycle event. Returns the loaded settings so
+ * callers can log/inspect. Extension init wires this once.
+ */
+export function applyAndEmitLoaded(
+  appliers: SettingsAppliers,
+  emit: SettingsEmit,
+  cwd: string = process.cwd(),
+): SubagentsSettings {
+  const settings = loadSettings(cwd);
+  applySettings(settings, appliers);
+  emit("subagents:settings_loaded", { settings });
+  return settings;
+}
+
+/**
+ * Persist a settings snapshot, emit the `subagents:settings_changed` event
+ * (regardless of persist outcome so listeners see the in-memory change), and
+ * return the toast the UI should display. Event payload carries the `persisted`
+ * flag so listeners can react to write failures.
+ */
+export function saveAndEmitChanged(
+  snapshot: SubagentsSettings,
+  successMsg: string,
+  emit: SettingsEmit,
+  cwd: string = process.cwd(),
+): { message: string; level: "info" | "warning" } {
+  const persisted = saveSettings(snapshot, cwd);
+  emit("subagents:settings_changed", { settings: snapshot, persisted });
+  return persistToastFor(successMsg, persisted);
 }

--- a/src/settings.ts
+++ b/src/settings.ts
@@ -1,0 +1,113 @@
+// Persistence for pi-subagents operational settings.
+// - Global:  ~/.pi/agent/subagents.json (via getAgentDir()) — manual defaults, never written here
+// - Project: <cwd>/.pi/subagents.json — written by /agents → Settings; overrides global on load
+
+import { existsSync, mkdirSync, readFileSync, writeFileSync } from "node:fs";
+import { dirname, join } from "node:path";
+import { getAgentDir } from "@mariozechner/pi-coding-agent";
+import type { JoinMode } from "./types.js";
+
+export interface SubagentsSettings {
+  maxConcurrent?: number;
+  /** 0 = unlimited (matches normalizeMaxTurns in agent-runner.ts and the /agents UI). */
+  defaultMaxTurns?: number;
+  graceTurns?: number;
+  defaultJoinMode?: JoinMode;
+}
+
+/** Setter hooks used by applySettings to wire persisted values into in-memory state. */
+export interface SettingsAppliers {
+  setMaxConcurrent: (n: number) => void;
+  setDefaultMaxTurns: (n: number) => void;
+  setGraceTurns: (n: number) => void;
+  setDefaultJoinMode: (mode: JoinMode) => void;
+}
+
+const VALID_JOIN_MODES: ReadonlySet<string> = new Set<JoinMode>(["async", "group", "smart"]);
+
+/** Drop fields that don't match the expected shape. Silent — garbage becomes absent. */
+function sanitize(raw: unknown): SubagentsSettings {
+  if (!raw || typeof raw !== "object") return {};
+  const r = raw as Record<string, unknown>;
+  const out: SubagentsSettings = {};
+  if (Number.isInteger(r.maxConcurrent) && (r.maxConcurrent as number) >= 1) {
+    out.maxConcurrent = r.maxConcurrent as number;
+  }
+  if (Number.isInteger(r.defaultMaxTurns) && (r.defaultMaxTurns as number) >= 0) {
+    out.defaultMaxTurns = r.defaultMaxTurns as number;
+  }
+  if (Number.isInteger(r.graceTurns) && (r.graceTurns as number) >= 1) {
+    out.graceTurns = r.graceTurns as number;
+  }
+  if (typeof r.defaultJoinMode === "string" && VALID_JOIN_MODES.has(r.defaultJoinMode)) {
+    out.defaultJoinMode = r.defaultJoinMode as JoinMode;
+  }
+  return out;
+}
+
+function globalPath(): string {
+  return join(getAgentDir(), "subagents.json");
+}
+
+function projectPath(cwd: string): string {
+  return join(cwd, ".pi", "subagents.json");
+}
+
+/**
+ * Read a settings file. Missing file is silent (returns `{}`). A file that
+ * exists but can't be parsed emits a warning to stderr so users aren't
+ * silently reverted to defaults — and still returns `{}` so startup proceeds.
+ */
+function readSettingsFile(path: string): SubagentsSettings {
+  if (!existsSync(path)) return {};
+  try {
+    return sanitize(JSON.parse(readFileSync(path, "utf-8")));
+  } catch (err) {
+    const reason = err instanceof Error ? err.message : String(err);
+    console.warn(`[pi-subagents] Ignoring malformed settings at ${path}: ${reason}`);
+    return {};
+  }
+}
+
+/** Load merged settings: global provides defaults, project overrides. */
+export function loadSettings(cwd: string = process.cwd()): SubagentsSettings {
+  return { ...readSettingsFile(globalPath()), ...readSettingsFile(projectPath(cwd)) };
+}
+
+/**
+ * Write project-local settings. Global is never touched from code.
+ * Returns `true` on success, `false` if the write (or mkdir) failed so the
+ * caller can surface a warning — persistence isn't fatal but isn't silent.
+ */
+export function saveSettings(s: SubagentsSettings, cwd: string = process.cwd()): boolean {
+  const path = projectPath(cwd);
+  try {
+    mkdirSync(dirname(path), { recursive: true });
+    writeFileSync(path, JSON.stringify(s, null, 2), "utf-8");
+    return true;
+  } catch {
+    return false;
+  }
+}
+
+/** Apply persisted settings to the in-memory state via caller-supplied setters. */
+export function applySettings(s: SubagentsSettings, appliers: SettingsAppliers): void {
+  if (typeof s.maxConcurrent === "number") appliers.setMaxConcurrent(s.maxConcurrent);
+  if (typeof s.defaultMaxTurns === "number") appliers.setDefaultMaxTurns(s.defaultMaxTurns);
+  if (typeof s.graceTurns === "number") appliers.setGraceTurns(s.graceTurns);
+  if (s.defaultJoinMode) appliers.setDefaultJoinMode(s.defaultJoinMode);
+}
+
+/**
+ * Format the user-facing toast for a settings mutation. Pure function —
+ * routes the success/failure of `saveSettings` into the right message + level
+ * so the UI layer (index.ts) stays a thin wire between input and notification.
+ */
+export function persistToastFor(
+  successMsg: string,
+  persisted: boolean,
+): { message: string; level: "info" | "warning" } {
+  return persisted
+    ? { message: successMsg, level: "info" }
+    : { message: `${successMsg} (session only; failed to persist)`, level: "warning" };
+}

--- a/test/settings.test.ts
+++ b/test/settings.test.ts
@@ -1,0 +1,297 @@
+import { existsSync, mkdirSync, mkdtempSync, readFileSync, rmSync, writeFileSync } from "node:fs";
+import { tmpdir } from "node:os";
+import { join } from "node:path";
+import { afterEach, beforeEach, describe, expect, it, vi } from "vitest";
+import { applySettings, loadSettings, persistToastFor, type SettingsAppliers, saveSettings } from "../src/settings.js";
+
+/**
+ * Tests for persistent settings. Uses two tmp directories:
+ * - `globalDir`: redirected via PI_CODING_AGENT_DIR so getAgentDir() returns it.
+ *   Simulates `~/.pi/agent/` — the global scope.
+ * - `projectDir`: passed explicitly as cwd to load/save.
+ *   Simulates the user's project root. Settings live at `<projectDir>/.pi/subagents.json`.
+ */
+describe("settings persistence", () => {
+  let globalDir: string;
+  let projectDir: string;
+  let originalAgentDirEnv: string | undefined;
+
+  const globalFile = () => join(globalDir, "subagents.json");
+  const projectFile = () => join(projectDir, ".pi", "subagents.json");
+
+  beforeEach(() => {
+    globalDir = mkdtempSync(join(tmpdir(), "pi-settings-global-"));
+    projectDir = mkdtempSync(join(tmpdir(), "pi-settings-project-"));
+    originalAgentDirEnv = process.env.PI_CODING_AGENT_DIR;
+    process.env.PI_CODING_AGENT_DIR = globalDir;
+  });
+
+  afterEach(() => {
+    if (originalAgentDirEnv == null) delete process.env.PI_CODING_AGENT_DIR;
+    else process.env.PI_CODING_AGENT_DIR = originalAgentDirEnv;
+    rmSync(globalDir, { recursive: true, force: true });
+    rmSync(projectDir, { recursive: true, force: true });
+  });
+
+  function writeGlobal(obj: unknown) {
+    writeFileSync(globalFile(), JSON.stringify(obj));
+  }
+
+  function writeProject(obj: unknown) {
+    mkdirSync(join(projectDir, ".pi"), { recursive: true });
+    writeFileSync(projectFile(), JSON.stringify(obj));
+  }
+
+  it("returns {} when both files are missing", () => {
+    expect(loadSettings(projectDir)).toEqual({});
+  });
+
+  it("returns {} when both files are malformed JSON", () => {
+    writeFileSync(globalFile(), "not json {{");
+    mkdirSync(join(projectDir, ".pi"), { recursive: true });
+    writeFileSync(projectFile(), "also not json");
+    expect(loadSettings(projectDir)).toEqual({});
+  });
+
+  it("loads from global when no project file", () => {
+    writeGlobal({ maxConcurrent: 16, graceTurns: 10 });
+    expect(loadSettings(projectDir)).toEqual({ maxConcurrent: 16, graceTurns: 10 });
+  });
+
+  it("loads from project when no global file", () => {
+    writeProject({ maxConcurrent: 8, defaultJoinMode: "group" });
+    expect(loadSettings(projectDir)).toEqual({ maxConcurrent: 8, defaultJoinMode: "group" });
+  });
+
+  it("merges global + project with project winning on conflicts", () => {
+    writeGlobal({ maxConcurrent: 16, graceTurns: 10, defaultJoinMode: "async" });
+    writeProject({ maxConcurrent: 4, defaultMaxTurns: 50 });
+    expect(loadSettings(projectDir)).toEqual({
+      maxConcurrent: 4, // project wins
+      graceTurns: 10, // from global
+      defaultJoinMode: "async", // from global
+      defaultMaxTurns: 50, // from project only
+    });
+  });
+
+  it("round-trips values: saveSettings then loadSettings", () => {
+    const settings = {
+      maxConcurrent: 7,
+      defaultMaxTurns: 30,
+      graceTurns: 3,
+      defaultJoinMode: "smart" as const,
+    };
+    saveSettings(settings, projectDir);
+    expect(loadSettings(projectDir)).toEqual(settings);
+  });
+
+  it("saveSettings writes only to the project file; global is untouched", () => {
+    writeGlobal({ maxConcurrent: 16 });
+    saveSettings({ maxConcurrent: 2 }, projectDir);
+
+    // Project file contains the new value
+    expect(JSON.parse(readFileSync(projectFile(), "utf-8"))).toEqual({ maxConcurrent: 2 });
+    // Global file unchanged
+    expect(JSON.parse(readFileSync(globalFile(), "utf-8"))).toEqual({ maxConcurrent: 16 });
+  });
+
+  it("saveSettings creates <cwd>/.pi/ when missing", () => {
+    expect(existsSync(join(projectDir, ".pi"))).toBe(false);
+    saveSettings({ maxConcurrent: 4 }, projectDir);
+    expect(existsSync(projectFile())).toBe(true);
+  });
+
+  it("round-trips defaultMaxTurns: 0 (unlimited marker)", () => {
+    saveSettings({ defaultMaxTurns: 0 }, projectDir);
+    expect(loadSettings(projectDir)).toEqual({ defaultMaxTurns: 0 });
+  });
+
+  it("ignores unknown extra fields on load (forward-compat)", () => {
+    writeProject({ maxConcurrent: 2, futureField: "ignored" });
+    const loaded = loadSettings(projectDir);
+    expect(loaded.maxConcurrent).toBe(2);
+    // Unknown fields are stripped by the sanitizer — old versions won't persist garbage
+    expect((loaded as Record<string, unknown>).futureField).toBeUndefined();
+  });
+
+  it("composes partial global + partial project correctly", () => {
+    writeGlobal({ graceTurns: 10 });
+    writeProject({ maxConcurrent: 2 });
+    expect(loadSettings(projectDir)).toEqual({ graceTurns: 10, maxConcurrent: 2 });
+  });
+
+  describe("sanitizer", () => {
+    it("drops maxConcurrent < 1", () => {
+      writeProject({ maxConcurrent: 0, graceTurns: 5 });
+      expect(loadSettings(projectDir)).toEqual({ graceTurns: 5 });
+    });
+
+    it("drops negative maxConcurrent", () => {
+      writeProject({ maxConcurrent: -3 });
+      expect(loadSettings(projectDir)).toEqual({});
+    });
+
+    it("drops non-integer maxConcurrent (floats, NaN, strings)", () => {
+      writeProject({ maxConcurrent: 3.5 });
+      expect(loadSettings(projectDir).maxConcurrent).toBeUndefined();
+      writeProject({ maxConcurrent: "four" });
+      expect(loadSettings(projectDir).maxConcurrent).toBeUndefined();
+      writeProject({ maxConcurrent: null });
+      expect(loadSettings(projectDir).maxConcurrent).toBeUndefined();
+    });
+
+    it("accepts defaultMaxTurns: 0 (explicit unlimited)", () => {
+      writeProject({ defaultMaxTurns: 0 });
+      expect(loadSettings(projectDir)).toEqual({ defaultMaxTurns: 0 });
+    });
+
+    it("drops negative defaultMaxTurns", () => {
+      writeProject({ defaultMaxTurns: -1 });
+      expect(loadSettings(projectDir)).toEqual({});
+    });
+
+    it("drops graceTurns < 1", () => {
+      writeProject({ graceTurns: 0 });
+      expect(loadSettings(projectDir)).toEqual({});
+    });
+
+    it("drops invalid defaultJoinMode values", () => {
+      writeProject({ defaultJoinMode: "invalid" });
+      expect(loadSettings(projectDir)).toEqual({});
+      writeProject({ defaultJoinMode: 42 });
+      expect(loadSettings(projectDir)).toEqual({});
+      writeProject({ defaultJoinMode: "" });
+      expect(loadSettings(projectDir)).toEqual({});
+    });
+
+    it("accepts all three valid join modes", () => {
+      for (const mode of ["async", "group", "smart"] as const) {
+        writeProject({ defaultJoinMode: mode });
+        expect(loadSettings(projectDir)).toEqual({ defaultJoinMode: mode });
+      }
+    });
+
+    it("returns {} when the JSON root is not an object (array, string, null)", () => {
+      mkdirSync(join(projectDir, ".pi"), { recursive: true });
+      writeFileSync(projectFile(), '["not", "an", "object"]');
+      expect(loadSettings(projectDir)).toEqual({});
+      writeFileSync(projectFile(), '"just a string"');
+      expect(loadSettings(projectDir)).toEqual({});
+      writeFileSync(projectFile(), "null");
+      expect(loadSettings(projectDir)).toEqual({});
+    });
+
+    it("keeps valid fields while dropping invalid siblings", () => {
+      writeProject({
+        maxConcurrent: 4, // ok
+        defaultMaxTurns: -5, // dropped
+        graceTurns: 3, // ok
+        defaultJoinMode: "nope", // dropped
+      });
+      expect(loadSettings(projectDir)).toEqual({ maxConcurrent: 4, graceTurns: 3 });
+    });
+  });
+
+  describe("save result + corrupt-file warning", () => {
+    it("saveSettings returns true on success", () => {
+      expect(saveSettings({ maxConcurrent: 2 }, projectDir)).toBe(true);
+      expect(JSON.parse(readFileSync(projectFile(), "utf-8"))).toEqual({ maxConcurrent: 2 });
+    });
+
+    it("saveSettings returns false when the target dir cannot be created", () => {
+      // Place a regular file where the parent of the settings file would go —
+      // mkdirSync + writeFileSync both fail with ENOTDIR / EEXIST.
+      const filePosingAsCwd = join(tmpdir(), `pi-settings-notdir-${Date.now()}`);
+      writeFileSync(filePosingAsCwd, "");
+      try {
+        expect(saveSettings({ maxConcurrent: 1 }, filePosingAsCwd)).toBe(false);
+      } finally {
+        rmSync(filePosingAsCwd, { force: true });
+      }
+    });
+
+    it("warns to console.warn when an existing file is malformed", () => {
+      const spy = vi.spyOn(console, "warn").mockImplementation(() => {});
+      mkdirSync(join(projectDir, ".pi"), { recursive: true });
+      writeFileSync(projectFile(), "not valid json {{{");
+      try {
+        expect(loadSettings(projectDir)).toEqual({});
+        expect(spy).toHaveBeenCalledTimes(1);
+        expect(String(spy.mock.calls[0][0])).toMatch(/Ignoring malformed settings/);
+      } finally {
+        spy.mockRestore();
+      }
+    });
+
+    it("does NOT warn when a file is simply missing", () => {
+      const spy = vi.spyOn(console, "warn").mockImplementation(() => {});
+      try {
+        expect(loadSettings(projectDir)).toEqual({});
+        expect(spy).not.toHaveBeenCalled();
+      } finally {
+        spy.mockRestore();
+      }
+    });
+  });
+
+  describe("applySettings", () => {
+    let appliers: SettingsAppliers;
+
+    beforeEach(() => {
+      appliers = {
+        setMaxConcurrent: vi.fn(),
+        setDefaultMaxTurns: vi.fn(),
+        setGraceTurns: vi.fn(),
+        setDefaultJoinMode: vi.fn(),
+      };
+    });
+
+    it("is a no-op on an empty settings object", () => {
+      applySettings({}, appliers);
+      expect(appliers.setMaxConcurrent).not.toHaveBeenCalled();
+      expect(appliers.setDefaultMaxTurns).not.toHaveBeenCalled();
+      expect(appliers.setGraceTurns).not.toHaveBeenCalled();
+      expect(appliers.setDefaultJoinMode).not.toHaveBeenCalled();
+    });
+
+    it("applies only the fields that are present", () => {
+      applySettings({ maxConcurrent: 4, graceTurns: 3 }, appliers);
+      expect(appliers.setMaxConcurrent).toHaveBeenCalledWith(4);
+      expect(appliers.setGraceTurns).toHaveBeenCalledWith(3);
+      expect(appliers.setDefaultMaxTurns).not.toHaveBeenCalled();
+      expect(appliers.setDefaultJoinMode).not.toHaveBeenCalled();
+    });
+
+    it("applies all four fields when all are present", () => {
+      applySettings(
+        { maxConcurrent: 8, defaultMaxTurns: 50, graceTurns: 7, defaultJoinMode: "group" },
+        appliers,
+      );
+      expect(appliers.setMaxConcurrent).toHaveBeenCalledWith(8);
+      expect(appliers.setDefaultMaxTurns).toHaveBeenCalledWith(50);
+      expect(appliers.setGraceTurns).toHaveBeenCalledWith(7);
+      expect(appliers.setDefaultJoinMode).toHaveBeenCalledWith("group");
+    });
+
+    it("applies defaultMaxTurns: 0 as the explicit unlimited marker", () => {
+      applySettings({ defaultMaxTurns: 0 }, appliers);
+      expect(appliers.setDefaultMaxTurns).toHaveBeenCalledWith(0);
+    });
+  });
+
+  describe("persistToastFor", () => {
+    it("returns info-level toast with the plain message on success", () => {
+      expect(persistToastFor("Max concurrency set to 7", true)).toEqual({
+        message: "Max concurrency set to 7",
+        level: "info",
+      });
+    });
+
+    it("returns warning-level toast with session-only suffix on failure", () => {
+      expect(persistToastFor("Max concurrency set to 7", false)).toEqual({
+        message: "Max concurrency set to 7 (session only; failed to persist)",
+        level: "warning",
+      });
+    });
+  });
+});

--- a/test/settings.test.ts
+++ b/test/settings.test.ts
@@ -2,7 +2,15 @@ import { existsSync, mkdirSync, mkdtempSync, readFileSync, rmSync, writeFileSync
 import { tmpdir } from "node:os";
 import { join } from "node:path";
 import { afterEach, beforeEach, describe, expect, it, vi } from "vitest";
-import { applySettings, loadSettings, persistToastFor, type SettingsAppliers, saveSettings } from "../src/settings.js";
+import {
+  applyAndEmitLoaded,
+  applySettings,
+  loadSettings,
+  persistToastFor,
+  type SettingsAppliers,
+  saveAndEmitChanged,
+  saveSettings,
+} from "../src/settings.js";
 
 /**
  * Tests for persistent settings. Uses two tmp directories:
@@ -190,6 +198,29 @@ describe("settings persistence", () => {
       });
       expect(loadSettings(projectDir)).toEqual({ maxConcurrent: 4, graceTurns: 3 });
     });
+
+    it("accepts values at the ceiling (maxConcurrent=1024, defaultMaxTurns=10000, graceTurns=1000)", () => {
+      writeProject({ maxConcurrent: 1024, defaultMaxTurns: 10_000, graceTurns: 1_000 });
+      expect(loadSettings(projectDir)).toEqual({
+        maxConcurrent: 1024,
+        defaultMaxTurns: 10_000,
+        graceTurns: 1_000,
+      });
+    });
+
+    it("drops values above the ceiling", () => {
+      writeProject({ maxConcurrent: 1025 });
+      expect(loadSettings(projectDir).maxConcurrent).toBeUndefined();
+      writeProject({ defaultMaxTurns: 10_001 });
+      expect(loadSettings(projectDir).defaultMaxTurns).toBeUndefined();
+      writeProject({ graceTurns: 1_001 });
+      expect(loadSettings(projectDir).graceTurns).toBeUndefined();
+    });
+
+    it("drops absurdly large values (e.g. 1e6)", () => {
+      writeProject({ maxConcurrent: 1_000_000, defaultMaxTurns: 1_000_000, graceTurns: 1_000_000 });
+      expect(loadSettings(projectDir)).toEqual({});
+    });
   });
 
   describe("save result + corrupt-file warning", () => {
@@ -292,6 +323,94 @@ describe("settings persistence", () => {
         message: "Max concurrency set to 7 (session only; failed to persist)",
         level: "warning",
       });
+    });
+  });
+
+  describe("applyAndEmitLoaded", () => {
+    let appliers: SettingsAppliers;
+
+    beforeEach(() => {
+      appliers = {
+        setMaxConcurrent: vi.fn(),
+        setDefaultMaxTurns: vi.fn(),
+        setGraceTurns: vi.fn(),
+        setDefaultJoinMode: vi.fn(),
+      };
+    });
+
+    it("loads, applies, and emits subagents:settings_loaded with merged settings", () => {
+      writeGlobal({ maxConcurrent: 16 });
+      writeProject({ graceTurns: 7 });
+      const emit = vi.fn();
+
+      const result = applyAndEmitLoaded(appliers, emit, projectDir);
+
+      expect(appliers.setMaxConcurrent).toHaveBeenCalledWith(16);
+      expect(appliers.setGraceTurns).toHaveBeenCalledWith(7);
+      expect(appliers.setDefaultMaxTurns).not.toHaveBeenCalled();
+      expect(appliers.setDefaultJoinMode).not.toHaveBeenCalled();
+
+      expect(emit).toHaveBeenCalledTimes(1);
+      expect(emit).toHaveBeenCalledWith("subagents:settings_loaded", {
+        settings: { maxConcurrent: 16, graceTurns: 7 },
+      });
+      expect(result).toEqual({ maxConcurrent: 16, graceTurns: 7 });
+    });
+
+    it("still emits the event when both files are missing (payload carries {})", () => {
+      const emit = vi.fn();
+
+      const result = applyAndEmitLoaded(appliers, emit, projectDir);
+
+      expect(emit).toHaveBeenCalledWith("subagents:settings_loaded", { settings: {} });
+      expect(result).toEqual({});
+      // No setters fired — defaults preserved
+      expect(appliers.setMaxConcurrent).not.toHaveBeenCalled();
+      expect(appliers.setDefaultMaxTurns).not.toHaveBeenCalled();
+      expect(appliers.setGraceTurns).not.toHaveBeenCalled();
+      expect(appliers.setDefaultJoinMode).not.toHaveBeenCalled();
+    });
+  });
+
+  describe("saveAndEmitChanged", () => {
+    it("persists, emits with persisted=true, and returns info toast on success", () => {
+      const emit = vi.fn();
+      const snapshot = { maxConcurrent: 5, graceTurns: 2 };
+
+      const toast = saveAndEmitChanged(snapshot, "Max concurrency set to 5", emit, projectDir);
+
+      expect(emit).toHaveBeenCalledTimes(1);
+      expect(emit).toHaveBeenCalledWith("subagents:settings_changed", {
+        settings: snapshot,
+        persisted: true,
+      });
+      expect(toast).toEqual({ message: "Max concurrency set to 5", level: "info" });
+      // File actually written
+      expect(JSON.parse(readFileSync(projectFile(), "utf-8"))).toEqual(snapshot);
+    });
+
+    it("emits with persisted=false and returns warning toast on save failure", () => {
+      const filePosingAsCwd = join(tmpdir(), `pi-settings-notdir-${Date.now()}`);
+      writeFileSync(filePosingAsCwd, "");
+      const emit = vi.fn();
+      try {
+        const toast = saveAndEmitChanged(
+          { maxConcurrent: 5 },
+          "Max concurrency set to 5",
+          emit,
+          filePosingAsCwd,
+        );
+        expect(emit).toHaveBeenCalledWith("subagents:settings_changed", {
+          settings: { maxConcurrent: 5 },
+          persisted: false,
+        });
+        expect(toast).toEqual({
+          message: "Max concurrency set to 5 (session only; failed to persist)",
+          level: "warning",
+        });
+      } finally {
+        rmSync(filePosingAsCwd, { force: true });
+      }
     });
   });
 });


### PR DESCRIPTION
  Global ~/.pi/agent/subagents.json provides machine-wide defaults
  (manual edit only); project <cwd>/.pi/subagents.json is written by
  /agents → Settings and overrides global on load.

  - sanitize() drops invalid fields per-field at the read boundary
  - console.warn on malformed file, silent on legitimate ENOENT
  - saveSettings returns boolean; persistToastFor routes failure to a warning-level "session only; failed to persist" toast
  - applySettings extracted for unit testability (SettingsAppliers seam)
  - subagents:settings_loaded + subagents:settings_changed events so other extensions can react to tuning changes

  Closes #24