### PR TITLE
fix: encode Windows paths correctly in output file directory (#27)

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -7,6 +7,9 @@ and this project adheres to [Semantic Versioning](https://semver.org/spec/v2.0.0
 
 ## [Unreleased]
 
+### Fixed
+- **`Agent` tool fails on Windows with `ENOENT` creating output directory** ([#27](https://github.com/tintinweb/pi-subagents/issues/27) — thanks [@sixnathan](https://github.com/sixnathan) for the diagnosis). The cwd-encoding regex in `output-file.ts` only handled POSIX `/` separators, so on Windows `cwd = "C:\\Users\\foo\\project"` survived unchanged and `path.join(tmpRoot, encoded, …)` produced an invalid nested-absolute path. Now extracts a small `encodeCwd()` helper that handles both `/` and `\\` separators, strips the Windows drive-letter prefix, and preserves UNC server/share segments. Also wraps the `chmodSync(root, 0o700)` call in a try/catch since chmod is a no-op on Windows and can throw on some filesystems.
+
 ## [0.6.1] - 2026-04-25
 
 ### Added

--- a/src/output-file.ts
+++ b/src/output-file.ts
@@ -10,13 +10,32 @@ import { tmpdir } from "node:os";
 import { join } from "node:path";
 import type { AgentSession, AgentSessionEvent } from "@mariozechner/pi-coding-agent";
 
+/**
+ * Encode a cwd path as a filesystem-safe directory name. Handles:
+ *   - POSIX:   "/home/user/project"        → "home-user-project"
+ *   - Windows: "C:\Users\foo\project"      → "Users-foo-project"
+ *   - UNC:     "\\\\server\\share\\project"  → "server-share-project"
+ */
+export function encodeCwd(cwd: string): string {
+  return cwd
+    .replace(/[/\\]/g, "-")        // both separators → dash
+    .replace(/^[A-Za-z]:-/, "")    // strip Windows drive prefix ("C:-")
+    .replace(/^-+/, "");           // strip leading dashes (POSIX root, UNC)
+}
+
 /** Create the output file path, ensuring the directory exists.
  *  Mirrors Claude Code's layout: /tmp/{prefix}-{uid}/{encoded-cwd}/{sessionId}/tasks/{agentId}.output */
 export function createOutputFilePath(cwd: string, agentId: string, sessionId: string): string {
-  const encoded = cwd.replace(/\//g, "-").replace(/^-/, "");
+  const encoded = encodeCwd(cwd);
   const root = join(tmpdir(), `pi-subagents-${process.getuid?.() ?? 0}`);
   mkdirSync(root, { recursive: true, mode: 0o700 });
-  chmodSync(root, 0o700);
+  // chmod is a no-op on Windows and throws on some Windows filesystems.
+  // On Unix we still want to enforce 0o700 past umask, so only swallow on Windows.
+  try {
+    chmodSync(root, 0o700);
+  } catch (err) {
+    if (process.platform !== "win32") throw err;
+  }
   const dir = join(root, encoded, sessionId, "tasks");
   mkdirSync(dir, { recursive: true });
   return join(dir, `${agentId}.output`);

--- a/test/output-file.test.ts
+++ b/test/output-file.test.ts
@@ -1,0 +1,44 @@
+import { describe, expect, it } from "vitest";
+import { encodeCwd } from "../src/output-file.js";
+
+describe("encodeCwd", () => {
+  it("encodes a POSIX absolute path by stripping the leading slash and replacing separators", () => {
+    expect(encodeCwd("/home/user/project")).toBe("home-user-project");
+  });
+
+  it("handles a POSIX root path", () => {
+    expect(encodeCwd("/")).toBe("");
+  });
+
+  it("encodes a Windows drive-letter path by stripping the drive prefix", () => {
+    expect(encodeCwd("C:\\Users\\foo\\project")).toBe("Users-foo-project");
+  });
+
+  it("handles lowercase Windows drives", () => {
+    expect(encodeCwd("c:\\foo")).toBe("foo");
+  });
+
+  it("handles a Windows path written with forward slashes", () => {
+    expect(encodeCwd("C:/Users/foo/project")).toBe("Users-foo-project");
+  });
+
+  it("preserves server and share for UNC paths", () => {
+    expect(encodeCwd("\\\\server\\share\\project")).toBe("server-share-project");
+  });
+
+  it("handles mixed separators", () => {
+    expect(encodeCwd("/home\\user/project")).toBe("home-user-project");
+  });
+
+  it("collapses runs of leading dashes after separator replacement", () => {
+    expect(encodeCwd("///foo")).toBe("foo");
+  });
+
+  it("returns an empty string for an empty cwd", () => {
+    expect(encodeCwd("")).toBe("");
+  });
+
+  it("leaves a relative-looking path with no leading separator alone", () => {
+    expect(encodeCwd("foo/bar")).toBe("foo-bar");
+  });
+});


### PR DESCRIPTION
fix: encode Windows paths correctly in output file directory (#27)  
The cwd-encoding regex in output-file.ts only handled POSIX `/`
  separators, so on Windows `cwd = "C:\Users\foo\project"` survived
  unchanged and `path.join(tmpRoot, encoded, ...)` produced an invalid
  nested-absolute path that mkdirSync rejected with ENOENT.

  - Extract encodeCwd() helper handling both / and \ separators, the Windows drive-letter prefix, and UNC server/share preservation.
  - Wrap chmodSync(root, 0o700) in try/catch — chmod is a no-op on Windows and throws on some Windows filesystems.
  - 10 new tests covering POSIX/Windows/UNC/edge cases.

  Closes #27. Thanks @sixnathan for the diagnosis.