### PR TITLE
Fix: abort signal now properly working during agent

### DIFF
--- a/src/agent-manager.ts
+++ b/src/agent-manager.ts
@@ -37,6 +37,8 @@ interface SpawnOptions {
   isBackground?: boolean;
   /** Isolation mode — "worktree" creates a temp git worktree for the agent. */
   isolation?: IsolationMode;
+  /** Parent abort signal — when aborted, the subagent is also stopped. */
+  signal?: AbortSignal;
   /** Called on tool start/end with activity info (for streaming progress to UI). */
   onToolActivity?: (activity: ToolActivity) => void;
   /** Called on streaming text deltas from the assistant response. */
@@ -121,6 +123,15 @@ export class AgentManager {
     if (options.isBackground) this.runningBackground++;
     this.onStart?.(record);
 
+    // Wire parent abort signal to stop the subagent when the parent is interrupted
+    let detachParentSignal: (() => void) | undefined;
+    if (options.signal) {
+      const onParentAbort = () => this.abort(id);
+      options.signal.addEventListener("abort", onParentAbort, { once: true });
+      detachParentSignal = () => options.signal!.removeEventListener("abort", onParentAbort);
+    }
+    const detach = () => { detachParentSignal?.(); detachParentSignal = undefined; };
+
     // Worktree isolation: create a temporary git worktree if requested
     let worktreeCwd: string | undefined;
     let worktreeWarning = "";
@@ -173,6 +184,8 @@ export class AgentManager {
         record.session = session;
         record.completedAt ??= Date.now();
 
+        detach();
+
         // Final flush of streaming output file
         if (record.outputCleanup) {
           try { record.outputCleanup(); } catch { /* ignore */ }
@@ -203,6 +216,8 @@ export class AgentManager {
         }
         record.error = err instanceof Error ? err.message : String(err);
         record.completedAt ??= Date.now();
+
+        detach();
 
         // Final flush of streaming output file on error
         if (record.outputCleanup) {

--- a/src/index.ts
+++ b/src/index.ts
@@ -944,6 +944,7 @@ Guidelines:
         inheritContext,
         thinkingLevel: thinking,
         isolation,
+        signal,
         ...fgCallbacks,
       });
 


### PR DESCRIPTION
 ### Problem

 When a foreground Agent tool is executing, pressing esc has no effect — the subagent keeps running until
 it finishes naturally or hits max_turns.

 Pi's interrupt mechanism works by:
 1. esc → agent.abort() on the parent
 2. An AbortSignal is passed to every tool's execute(toolCallId, params, signal, ...)

 But the Agent tool's execute receives signal and never forwards it to the subagent. The subagent runs on
 its own independent AbortController inside AgentManager, so the parent abort is invisible to it.

 ### Fix

 Wire the parent's AbortSignal to AgentManager.abort(id) so that aborting the parent also stops the
 subagent.

 src/agent-manager.ts
 - Add signal?: AbortSignal to SpawnOptions
 - In startAgent(), listen for "abort" on the parent signal and call this.abort(id)
 - Local detach() cleanup in both .then() / .catch() handlers prevents listener leak if the signal never
 fires

 src/index.ts
 - Forward the signal parameter from the Agent tool's execute through to manager.spawnAndWait()
