### PR TITLE
Add new feature to force following the defined scoped models by user

### DIFF
--- a/.gitignore
+++ b/.gitignore
@@ -31,3 +31,9 @@ Thumbs.db
 .claude
 .vscode
 .gitnexus
+.pi/subagents.json
+
+# Pi internal files
+progress.md
+AGENTS.md
+CLAUDE.md

--- a/.gitignore
+++ b/.gitignore
@@ -30,3 +30,4 @@ Thumbs.db
 .pi/readcache
 .claude
 .vscode
+.gitnexus

--- a/package-lock.json
+++ b/package-lock.json
@@ -13,6 +13,7 @@
       },
       "devDependencies": {
         "@biomejs/biome": "^2.3.5",
+        "@types/minimatch": "^5.1.0",
         "@types/node": "^25.5.0",
         "typescript": "^6.0.0",
         "vitest": "^4.0.18"
@@ -20,7 +21,13 @@
       "peerDependencies": {
         "@mariozechner/pi-ai": ">=0.70.5",
         "@mariozechner/pi-coding-agent": ">=0.70.5",
-        "@mariozechner/pi-tui": ">=0.70.5"
+        "@mariozechner/pi-tui": ">=0.70.5",
+        "minimatch": ">=3.0.0"
+      },
+      "peerDependenciesMeta": {
+        "minimatch": {
+          "optional": true
+        }
       }
     },
     "node_modules/@anthropic-ai/sdk": {
@@ -2578,6 +2585,13 @@
       "integrity": "sha512-lfU4b34HOri+kAY5UheuFMWPDOI+OPceBSHZKp69gEyTL/mmJ4cnU6Y/rlme3UL3GyOn6Y42hyIEw0/q8sWx5w==",
       "license": "MIT",
       "peer": true
+    },
+    "node_modules/@types/minimatch": {
+      "version": "5.1.2",
+      "resolved": "https://registry.npmjs.org/@types/minimatch/-/minimatch-5.1.2.tgz",
+      "integrity": "sha512-K0VQKziLUWkVKiRVrx4a40iPaxTUefQmjtkQofBkYRcoaaL/8rhwDWww9qWbrgicNOgnpIsMxyNIUM4+n6dUIA==",
+      "dev": true,
+      "license": "MIT"
     },
     "node_modules/@types/node": {
       "version": "25.6.0",

--- a/src/enabled-models.ts
+++ b/src/enabled-models.ts
@@ -1,0 +1,137 @@
+/**
+ * Reads enabledModels from ~/.pi/agent/settings.json and resolves
+ * exact model strings to concrete model IDs for scope validation.
+ *
+ * Ref: pi-coding-agent resolves enabledModels at startup via:
+ *   main.js:439  modelPatterns = parsed.models ?? settingsManager.getEnabledModels()
+ *   main.js:440  scopedModels = resolveModelScope(modelPatterns, modelRegistry)
+ *
+ * pi only writes exact "provider/modelId" entries to enabledModels — no globs,
+ * no wildcards. We do the same: exact match only.
+ *
+ * Example: enabledModels = ["llama-swap/Qwen3.6-27B-Q4:precise", "anthropic/claude-sonnet-4-6"]
+ *   → resolves to {"llama-swap/qwen3.6-27b-q4:precise", "anthropic/claude-sonnet-4-6"}
+ */
+
+import { existsSync, readFileSync, statSync } from "node:fs";
+import { join } from "node:path";
+import { getAgentDir } from "@mariozechner/pi-coding-agent";
+import type { ModelEntry } from "./model-resolver.js";
+
+/** Minimal registry shape — only the methods resolveEnabledModels actually calls. */
+export interface ModelRegistryRef {
+  getAll(): unknown[];
+  getAvailable?(): unknown[];
+}
+
+/** Read enabledModels from global pi settings. Undefined when file missing or field absent. */
+export function readEnabledModels(): string[] | undefined {
+  const path = join(getAgentDir(), "settings.json");
+  if (!existsSync(path)) return undefined;
+  try {
+    const raw = JSON.parse(readFileSync(path, "utf-8"));
+    if (Array.isArray(raw?.enabledModels)) return raw.enabledModels as string[];
+  } catch {
+    /* corrupt file — silent */
+  }
+  return undefined;
+}
+
+/**
+ * Resolve enabledModels patterns → Set<"provider/modelId"> (lowercase keys).
+ *
+ * Matching (mirrors pi-coding-agent resolveModelScope → tryMatchModel):
+ *   1. Exact "provider/modelId"  (slash present, case-insensitive)
+ *   2. Bare "modelId"            (no slash, exact id match)
+ *
+ * No fuzzy matching, no globs — pi only writes exact provider/modelId to enabledModels.
+ * Colons are part of the model ID (e.g. "llama-swap/model:precise").
+ *
+ * Cache: keyed on settings.json mtime+size + patterns key. Re-reads only when
+ * the file or patterns change. The model registry is static per session, so it
+ * is not part of the cache key.
+ *
+ * Example: "llama-swap/Qwen3.6-27B-Q4:precise"
+ *   → provider="llama-swap", modelId="Qwen3.6-27B-Q4:precise"
+ *
+ * Returns undefined when no patterns or no matches (scope check becomes no-op).
+ */
+
+// Module-level cache — invalidated when settings.json changes or patterns differ.
+let cachedAllowed: Set<string> | undefined;
+let cachedHash = "";
+let cachedPatternsKey = "";
+
+export function resolveEnabledModels(
+  patterns: string[] | undefined,
+  registry: ModelRegistryRef,
+): Set<string> | undefined {
+  // Fast path: check cache
+  const patternsKey = JSON.stringify(patterns);
+  const settingsPath = join(getAgentDir(), "settings.json");
+  let fileHash: string;
+  try {
+    const stat = statSync(settingsPath);
+    fileHash = `${stat.mtimeMs}-${stat.size}`;
+  } catch {
+    fileHash = "missing";
+  }
+
+  if (fileHash === cachedHash && patternsKey === cachedPatternsKey) {
+    return cachedAllowed;
+  }
+
+  // Cache miss — resolve
+  if (!patterns || patterns.length === 0) {
+    cachedHash = fileHash;
+    cachedPatternsKey = patternsKey;
+    cachedAllowed = undefined;
+    return undefined;
+  }
+
+  const available = (registry.getAvailable?.() ?? registry.getAll()) as ModelEntry[];
+  const allowed = new Set<string>();
+
+  for (const pattern of patterns) {
+    const trimmed = pattern.trim();
+    if (!trimmed) continue;  // skip empty/whitespace
+    resolveExact(trimmed, available, allowed);
+  }
+
+  const result = allowed.size > 0 ? allowed : undefined;
+  cachedHash = fileHash;
+  cachedPatternsKey = patternsKey;
+  cachedAllowed = result;
+  return result;
+}
+
+
+
+/**
+ * Resolve exact pattern: provider/modelId only.
+ *
+ * Ref: pi-coding-agent writes only exact "provider/modelId" to enabledModels.
+ * No bare modelId, no fuzzy — pi never writes either.
+ *
+ * Example: "google/gemma-4-31b-it" → exact match
+ */
+function resolveExact(
+  pattern: string,
+  available: ModelEntry[],
+  allowed: Set<string>,
+): void {
+  // "provider/modelId" — exact (colon is part of id, not split)
+  const slashIdx = pattern.indexOf("/");
+  if (slashIdx === -1) return; // bare modelId not supported
+
+  const provider = pattern.slice(0, slashIdx).toLowerCase();
+  const modelId = pattern.slice(slashIdx + 1).toLowerCase();
+  const exact = available.find(
+    m => m.provider.toLowerCase() === provider && m.id.toLowerCase() === modelId,
+  );
+  if (exact) {
+    allowed.add(`${exact.provider}/${exact.id}`.toLowerCase());
+  }
+}
+
+

--- a/src/enabled-models.ts
+++ b/src/enabled-models.ts
@@ -6,11 +6,10 @@
  *   main.js:439  modelPatterns = parsed.models ?? settingsManager.getEnabledModels()
  *   main.js:440  scopedModels = resolveModelScope(modelPatterns, modelRegistry)
  *
- * pi only writes exact "provider/modelId" entries to enabledModels — no globs,
- * no wildcards. We do the same: exact match only.
+ * pi writes exact "provider/modelId" entries to enabledModels
  *
- * Example: enabledModels = ["llama-swap/Qwen3.6-27B-Q4:precise", "anthropic/claude-sonnet-4-6"]
- *   → resolves to {"llama-swap/qwen3.6-27b-q4:precise", "anthropic/claude-sonnet-4-6"}
+ * Example: enabledModels = ["anthropic/claude-sonnet-4-6", "anthropic/claude-opus-4-6"]
+ *   → resolves to {"anthropic/claude-sonnet-4-6", "anthropic/claude-opus-4-6"}
  */
 
 import { existsSync, readFileSync, statSync } from "node:fs";
@@ -44,15 +43,12 @@ export function readEnabledModels(): string[] | undefined {
  *   1. Exact "provider/modelId"  (slash present, case-insensitive)
  *   2. Bare "modelId"            (no slash, exact id match)
  *
- * No fuzzy matching, no globs — pi only writes exact provider/modelId to enabledModels.
- * Colons are part of the model ID (e.g. "llama-swap/model:precise").
  *
  * Cache: keyed on settings.json mtime+size + patterns key. Re-reads only when
- * the file or patterns change. The model registry is static per session, so it
- * is not part of the cache key.
+ * the file or patterns change.
  *
- * Example: "llama-swap/Qwen3.6-27B-Q4:precise"
- *   → provider="llama-swap", modelId="Qwen3.6-27B-Q4:precise"
+ * Example: "anthropic/claude-sonnet-4-6"
+ *   → provider="anthropic", modelId="claude-sonnet-4-6"
  *
  * Returns undefined when no patterns or no matches (scope check becomes no-op).
  */
@@ -108,12 +104,7 @@ export function resolveEnabledModels(
 
 
 /**
- * Resolve exact pattern: provider/modelId only.
- *
- * Ref: pi-coding-agent writes only exact "provider/modelId" to enabledModels.
- * No bare modelId, no fuzzy — pi never writes either.
- *
- * Example: "google/gemma-4-31b-it" → exact match
+ * Resolve exact model pattern. Example: "google/gemma-4-31b-it".
  */
 function resolveExact(
   pattern: string,

--- a/src/index.ts
+++ b/src/index.ts
@@ -775,7 +775,7 @@ Guidelines:
 
       // Scope validation: check resolved model against enabledModels from ~/.pi/agent/settings.json
       // Ref: pi-coding-agent main.js:439-440 — resolveModelScope(enabledModels, registry) → scopedModels
-      // User params → hard error with list. Config/frontmatter → warn + fallback to parent.
+      // Main agent calls out-of-scope → hard error with list. Config/frontmatter → warn + fallback to parent.
       if (isScopeModelsEnabled() && model) {
         const patterns = readEnabledModels();
         const allowed = resolveEnabledModels(patterns, ctx.modelRegistry);
@@ -1680,21 +1680,21 @@ ${systemPrompt}
         {
           id: "maxConcurrent",
           label: "Max concurrency",
-          description: "Max concurrent background agents (Enter to type, Space to cycle)",
+          description: "Max concurrent background agents (Enter to type)",
           currentValue: String(mc),
           values: [String(mc)],
         },
         {
           id: "defaultMaxTurns",
           label: "Default max turns",
-          description: "Default max turns before wrap-up (0 = unlimited, Enter to type, Space to cycle)",
+          description: "Default max turns before wrap-up (0 = unlimited, Enter to type)",
           currentValue: String(dmt),
           values: [String(dmt)],
         },
         {
           id: "graceTurns",
           label: "Grace turns",
-          description: "Grace turns after wrap-up steer (Enter to type, Space to cycle)",
+          description: "Grace turns after wrap-up steer (Enter to type)",
           currentValue: String(gt),
           values: [String(gt)],
         },
@@ -1708,7 +1708,7 @@ ${systemPrompt}
         {
           id: "scopeModels",
           label: "Scope models",
-          description: "Validate subagent models against enabledModels from settings",
+          description: "Validate subagent models against scoped models (/scoped-models)",
           currentValue: isScopeModelsEnabled() ? "on" : "off",
           values: ["on", "off"],
         },

--- a/src/index.ts
+++ b/src/index.ts
@@ -13,7 +13,7 @@
 import { existsSync, mkdirSync, readFileSync, unlinkSync } from "node:fs";
 import { join } from "node:path";
 import { defineTool, type ExtensionAPI, type ExtensionCommandContext, type ExtensionContext, getAgentDir, getSettingsListTheme } from "@mariozechner/pi-coding-agent";
-import { Container, type SettingItem, SettingsList, Spacer, Text } from "@mariozechner/pi-tui";
+import { Container, Key, matchesKey, type SettingItem, SettingsList, Spacer, Text } from "@mariozechner/pi-tui";
 import { Type } from "@sinclair/typebox";
 import { AgentManager } from "./agent-manager.js";
 import { getAgentConversation, getDefaultMaxTurns, getGraceTurns, normalizeMaxTurns, setDefaultMaxTurns, setGraceTurns, steerAgent } from "./agent-runner.js";
@@ -1668,100 +1668,99 @@ ${systemPrompt}
     };
   }
 
+  const NUMERIC_IDS = new Set(["maxConcurrent", "defaultMaxTurns", "graceTurns"]);
+
   async function showSettings(ctx: ExtensionCommandContext) {
-    const items: SettingItem[] = [
-      {
-        id: "maxConcurrent",
-        label: "Max concurrency",
-        description: "Max concurrent background agents (press Enter to change)",
-        currentValue: String(manager.getMaxConcurrent()),
-      },
-      {
-        id: "defaultMaxTurns",
-        label: "Default max turns",
-        description: "Default max turns before wrap-up (0 = unlimited, Enter to change)",
-        currentValue: String(getDefaultMaxTurns() ?? 0),
-      },
-      {
-        id: "graceTurns",
-        label: "Grace turns",
-        description: "Grace turns after wrap-up steer (Enter to change)",
-        currentValue: String(getGraceTurns()),
-      },
-      {
-        id: "joinMode",
-        label: "Join mode",
-        description: "Default join mode for background agents",
-        currentValue: getDefaultJoinMode(),
-        values: ["smart", "async", "group"],
-      },
-      {
-        id: "scopeModels",
-        label: "Scope models",
-        description: "Validate subagent models against enabledModels from settings",
-        currentValue: isScopeModelsEnabled() ? "on" : "off",
-        values: ["on", "off"],
-      },
-    ];
+    function buildItems(): SettingItem[] {
+      const mc = manager.getMaxConcurrent();
+      const dmt = getDefaultMaxTurns() ?? 0;
+      const gt = getGraceTurns();
+
+      return [
+        {
+          id: "maxConcurrent",
+          label: "Max concurrency",
+          description: "Max concurrent background agents (Enter to type, Space to cycle)",
+          currentValue: String(mc),
+          values: [String(mc)],
+        },
+        {
+          id: "defaultMaxTurns",
+          label: "Default max turns",
+          description: "Default max turns before wrap-up (0 = unlimited, Enter to type, Space to cycle)",
+          currentValue: String(dmt),
+          values: [String(dmt)],
+        },
+        {
+          id: "graceTurns",
+          label: "Grace turns",
+          description: "Grace turns after wrap-up steer (Enter to type, Space to cycle)",
+          currentValue: String(gt),
+          values: [String(gt)],
+        },
+        {
+          id: "joinMode",
+          label: "Join mode",
+          description: "Default join mode for background agents",
+          currentValue: getDefaultJoinMode(),
+          values: ["smart", "async", "group"],
+        },
+        {
+          id: "scopeModels",
+          label: "Scope models",
+          description: "Validate subagent models against enabledModels from settings",
+          currentValue: isScopeModelsEnabled() ? "on" : "off",
+          values: ["on", "off"],
+        },
+      ];
+    }
+
+    function applyValue(id: string, value: string) {
+      if (id === "maxConcurrent") {
+        const n = parseInt(value, 10);
+        if (n >= 1) {
+          manager.setMaxConcurrent(n);
+          notifyApplied(ctx, `Max concurrency set to ${n}`);
+        }
+      } else if (id === "defaultMaxTurns") {
+        const n = parseInt(value, 10);
+        if (n === 0) {
+          setDefaultMaxTurns(undefined);
+          notifyApplied(ctx, "Default max turns set to unlimited");
+        } else if (n >= 1) {
+          setDefaultMaxTurns(n);
+          notifyApplied(ctx, `Default max turns set to ${n}`);
+        }
+      } else if (id === "graceTurns") {
+        const n = parseInt(value, 10);
+        if (n >= 1) {
+          setGraceTurns(n);
+          notifyApplied(ctx, `Grace turns set to ${n}`);
+        }
+      } else if (id === "joinMode") {
+        setDefaultJoinMode(value as JoinMode);
+        notifyApplied(ctx, `Default join mode set to ${value}`);
+      } else if (id === "scopeModels") {
+        const enabled = value === "on";
+        setScopeModelsEnabled(enabled);
+        notifyApplied(ctx, `Scope models ${enabled ? "enabled" : "disabled"}`);
+      }
+    }
 
     let list: SettingsList;
+    // Track current selection index directly (SettingsList doesn't expose it).
+    // Updated on arrow keys so Enter knows which field is selected immediately.
+    let currentIndex = 0;
 
-    await ctx.ui.custom((_tui, _theme, _kb, done) => {
+    const result = await ctx.ui.custom<string | undefined>((_tui, _theme, _kb, done) => {
+      const items = buildItems();
+
       list = new SettingsList(
         items,
         items.length + 2,
         getSettingsListTheme(),
-        async (id, newValue) => {
-          if (id === "maxConcurrent") {
-            const val = await ctx.ui.input("Max concurrent background agents", newValue);
-            if (val) {
-              const n = parseInt(val, 10);
-              if (n >= 1) {
-                manager.setMaxConcurrent(n);
-                list.updateValue(id, String(n));
-                notifyApplied(ctx, `Max concurrency set to ${n}`);
-              } else {
-                ctx.ui.notify("Must be a positive integer.", "warning");
-              }
-            }
-          } else if (id === "defaultMaxTurns") {
-            const val = await ctx.ui.input("Default max turns (0 = unlimited)", newValue);
-            if (val) {
-              const n = parseInt(val, 10);
-              if (n === 0) {
-                setDefaultMaxTurns(undefined);
-                list.updateValue(id, "0");
-                notifyApplied(ctx, "Default max turns set to unlimited");
-              } else if (n >= 1) {
-                setDefaultMaxTurns(n);
-                list.updateValue(id, String(n));
-                notifyApplied(ctx, `Default max turns set to ${n}`);
-              } else {
-                ctx.ui.notify("Must be 0 (unlimited) or a positive integer.", "warning");
-              }
-            }
-          } else if (id === "graceTurns") {
-            const val = await ctx.ui.input("Grace turns after wrap-up steer", newValue);
-            if (val) {
-              const n = parseInt(val, 10);
-              if (n >= 1) {
-                setGraceTurns(n);
-                list.updateValue(id, String(n));
-                notifyApplied(ctx, `Grace turns set to ${n}`);
-              } else {
-                ctx.ui.notify("Must be a positive integer.", "warning");
-              }
-            }
-          } else if (id === "joinMode") {
-            setDefaultJoinMode(newValue as JoinMode);
-            list.updateValue("joinMode", newValue);
-            notifyApplied(ctx, `Default join mode set to ${newValue}`);
-          } else if (id === "scopeModels") {
-            const enabled = newValue === "on";
-            setScopeModelsEnabled(enabled);
-            list.updateValue("scopeModels", newValue);
-            notifyApplied(ctx, `Scope models ${enabled ? "enabled" : "disabled"}`);
-          }
+        (id, newValue) => {
+          applyValue(id, newValue);
         },
         () => done(undefined as undefined),
       );
@@ -1774,9 +1773,53 @@ ${systemPrompt}
       return {
         render: (w: number) => container.render(w),
         invalidate: () => container.invalidate(),
-        handleInput: (data: string) => list.handleInput?.(data),
+        handleInput: (data: string) => {
+          // Track navigation so Enter knows the current field
+          if (matchesKey(data, "up")) {
+            currentIndex = Math.max(0, currentIndex - 1);
+          } else if (matchesKey(data, "down")) {
+            currentIndex = Math.min(items.length - 1, currentIndex + 1);
+          }
+
+          // Enter on numeric field → close and prompt for typed input
+          if (matchesKey(data, Key.enter) && NUMERIC_IDS.has(items[currentIndex].id)) {
+            done(items[currentIndex].id);
+            return;
+          }
+          list.handleInput?.(data);
+        },
       };
     });
+
+    // If a numeric field ID was returned, prompt for typed input
+    if (result && NUMERIC_IDS.has(result)) {
+      const current = result === "maxConcurrent"
+        ? String(manager.getMaxConcurrent())
+        : result === "defaultMaxTurns"
+          ? String(getDefaultMaxTurns() ?? 0)
+          : String(getGraceTurns());
+
+      const label = result === "maxConcurrent"
+        ? "Max concurrency (1+)"
+        : result === "defaultMaxTurns"
+          ? "Default max turns (0 = unlimited)"
+          : "Grace turns (1+)";
+
+      // Loop until user enters a valid integer or cancels (Esc / null).
+      // Silently trims whitespace; rejects non-numeric input by re-prompting.
+      let input: string | undefined = await ctx.ui.input(label, current);
+      while (input != null) {
+        const trimmed = input.trim();
+        const n = Number(trimmed);
+        if (trimmed !== "" && Number.isInteger(n)) {
+          applyValue(result, String(n));
+          await showSettings(ctx);
+          return;
+        }
+        // Invalid — re-prompt with the user's last entry so they can edit it
+        input = await ctx.ui.input(label, trimmed);
+      }
+    }
   }
 
   // Persist the current snapshot, emit `subagents:settings_changed`, and surface

--- a/src/index.ts
+++ b/src/index.ts
@@ -12,14 +12,15 @@
 
 import { existsSync, mkdirSync, readFileSync, unlinkSync } from "node:fs";
 import { join } from "node:path";
-import { defineTool, type ExtensionAPI, type ExtensionCommandContext, type ExtensionContext, getAgentDir } from "@mariozechner/pi-coding-agent";
-import { Text } from "@mariozechner/pi-tui";
+import { defineTool, type ExtensionAPI, type ExtensionCommandContext, type ExtensionContext, getAgentDir, getSettingsListTheme } from "@mariozechner/pi-coding-agent";
+import { Container, type SettingItem, SettingsList, Spacer, Text } from "@mariozechner/pi-tui";
 import { Type } from "@sinclair/typebox";
 import { AgentManager } from "./agent-manager.js";
 import { getAgentConversation, getDefaultMaxTurns, getGraceTurns, normalizeMaxTurns, setDefaultMaxTurns, setGraceTurns, steerAgent } from "./agent-runner.js";
 import { BUILTIN_TOOL_NAMES, getAgentConfig, getAllTypes, getAvailableTypes, getDefaultAgentNames, getUserAgentNames, registerAgents, resolveType } from "./agent-types.js";
 import { registerRpcHandlers } from "./cross-extension-rpc.js";
 import { loadCustomAgents } from "./custom-agents.js";
+import { readEnabledModels, resolveEnabledModels } from "./enabled-models.js";
 import { GroupJoinManager } from "./group-join.js";
 import { resolveAgentInvocationConfig, resolveJoinMode } from "./invocation-config.js";
 import { type ModelRegistry, resolveModel } from "./model-resolver.js";
@@ -464,6 +465,13 @@ export default function (pi: ExtensionAPI) {
   function getDefaultJoinMode(): JoinMode { return defaultJoinMode; }
   function setDefaultJoinMode(mode: JoinMode) { defaultJoinMode = mode; }
 
+  // ---- Scope models configuration ----
+  // When enabled, subagent model choices are validated against enabledModels
+  // from ~/.pi/agent/settings.json. Off by default — not standardised behaviour.
+  let scopeModelsEnabled = false;
+  function isScopeModelsEnabled(): boolean { return scopeModelsEnabled; }
+  function setScopeModelsEnabled(enabled: boolean): void { scopeModelsEnabled = enabled; }
+
   // ---- Batch tracking for smart join mode ----
   // Collects background agent IDs spawned in the current turn for smart grouping.
   // Uses a debounced timer: each new agent resets the 100ms window so that all
@@ -557,6 +565,7 @@ export default function (pi: ExtensionAPI) {
       setDefaultMaxTurns,
       setGraceTurns,
       setDefaultJoinMode,
+      setScopeModels: setScopeModelsEnabled,
     },
     (event, payload) => pi.events.emit(event, payload),
   );
@@ -761,6 +770,34 @@ Guidelines:
           // config-specified: silent fallback to parent
         } else {
           model = resolved;
+        }
+      }
+
+      // Scope validation: check resolved model against enabledModels from ~/.pi/agent/settings.json
+      // Ref: pi-coding-agent main.js:439-440 — resolveModelScope(enabledModels, registry) → scopedModels
+      // User params → hard error with list. Config/frontmatter → warn + fallback to parent.
+      if (isScopeModelsEnabled() && model) {
+        const patterns = readEnabledModels();
+        const allowed = resolveEnabledModels(patterns, ctx.modelRegistry);
+        if (allowed) {
+          const modelKey = `${model.provider}/${model.id}`.toLowerCase();
+          const isInScope = allowed.has(modelKey);  // O(1) — keys stored lowercase
+          if (!isInScope) {
+            if (resolvedConfig.modelFromParams) {
+              const list = [...allowed].sort().map(m => `  ${m}`).join("\n");
+              return textResult(
+                `Model not in scope: "${resolvedConfig.modelInput}".\n\n` +
+                `Allowed models (from enabledModels):\n${list}`,
+              );
+            }
+            // config/frontmatter-specified: warn + fallback to parent model
+            const agentLabel = customConfig?.displayName ?? subagentType;
+            ctx.ui.notify(
+              `Agent "${agentLabel}" model "${resolvedConfig.modelInput}" not in scope — using parent model`,
+              "warning",
+            );
+            model = ctx.model;
+          }
         }
       }
 
@@ -1627,66 +1664,119 @@ ${systemPrompt}
       defaultMaxTurns: getDefaultMaxTurns() ?? 0,
       graceTurns: getGraceTurns(),
       defaultJoinMode: getDefaultJoinMode(),
+      scopeModels: isScopeModelsEnabled(),
     };
   }
 
   async function showSettings(ctx: ExtensionCommandContext) {
-    const choice = await ctx.ui.select("Settings", [
-      `Max concurrency (current: ${manager.getMaxConcurrent()})`,
-      `Default max turns (current: ${getDefaultMaxTurns() ?? "unlimited"})`,
-      `Grace turns (current: ${getGraceTurns()})`,
-      `Join mode (current: ${getDefaultJoinMode()})`,
-    ]);
-    if (!choice) return;
+    const items: SettingItem[] = [
+      {
+        id: "maxConcurrent",
+        label: "Max concurrency",
+        description: "Max concurrent background agents (press Enter to change)",
+        currentValue: String(manager.getMaxConcurrent()),
+      },
+      {
+        id: "defaultMaxTurns",
+        label: "Default max turns",
+        description: "Default max turns before wrap-up (0 = unlimited, Enter to change)",
+        currentValue: String(getDefaultMaxTurns() ?? 0),
+      },
+      {
+        id: "graceTurns",
+        label: "Grace turns",
+        description: "Grace turns after wrap-up steer (Enter to change)",
+        currentValue: String(getGraceTurns()),
+      },
+      {
+        id: "joinMode",
+        label: "Join mode",
+        description: "Default join mode for background agents",
+        currentValue: getDefaultJoinMode(),
+        values: ["smart", "async", "group"],
+      },
+      {
+        id: "scopeModels",
+        label: "Scope models",
+        description: "Validate subagent models against enabledModels from settings",
+        currentValue: isScopeModelsEnabled() ? "on" : "off",
+        values: ["on", "off"],
+      },
+    ];
 
-    if (choice.startsWith("Max concurrency")) {
-      const val = await ctx.ui.input("Max concurrent background agents", String(manager.getMaxConcurrent()));
-      if (val) {
-        const n = parseInt(val, 10);
-        if (n >= 1) {
-          manager.setMaxConcurrent(n);
-          notifyApplied(ctx, `Max concurrency set to ${n}`);
-        } else {
-          ctx.ui.notify("Must be a positive integer.", "warning");
-        }
-      }
-    } else if (choice.startsWith("Default max turns")) {
-      const val = await ctx.ui.input("Default max turns before wrap-up (0 = unlimited)", String(getDefaultMaxTurns() ?? 0));
-      if (val) {
-        const n = parseInt(val, 10);
-        if (n === 0) {
-          setDefaultMaxTurns(undefined);
-          notifyApplied(ctx, "Default max turns set to unlimited");
-        } else if (n >= 1) {
-          setDefaultMaxTurns(n);
-          notifyApplied(ctx, `Default max turns set to ${n}`);
-        } else {
-          ctx.ui.notify("Must be 0 (unlimited) or a positive integer.", "warning");
-        }
-      }
-    } else if (choice.startsWith("Grace turns")) {
-      const val = await ctx.ui.input("Grace turns after wrap-up steer", String(getGraceTurns()));
-      if (val) {
-        const n = parseInt(val, 10);
-        if (n >= 1) {
-          setGraceTurns(n);
-          notifyApplied(ctx, `Grace turns set to ${n}`);
-        } else {
-          ctx.ui.notify("Must be a positive integer.", "warning");
-        }
-      }
-    } else if (choice.startsWith("Join mode")) {
-      const val = await ctx.ui.select("Default join mode for background agents", [
-        "smart — auto-group 2+ agents in same turn (default)",
-        "async — always notify individually",
-        "group — always group background agents",
-      ]);
-      if (val) {
-        const mode = val.split(" ")[0] as JoinMode;
-        setDefaultJoinMode(mode);
-        notifyApplied(ctx, `Default join mode set to ${mode}`);
-      }
-    }
+    let list: SettingsList;
+
+    await ctx.ui.custom((_tui, _theme, _kb, done) => {
+      list = new SettingsList(
+        items,
+        items.length + 2,
+        getSettingsListTheme(),
+        async (id, newValue) => {
+          if (id === "maxConcurrent") {
+            const val = await ctx.ui.input("Max concurrent background agents", newValue);
+            if (val) {
+              const n = parseInt(val, 10);
+              if (n >= 1) {
+                manager.setMaxConcurrent(n);
+                list.updateValue(id, String(n));
+                notifyApplied(ctx, `Max concurrency set to ${n}`);
+              } else {
+                ctx.ui.notify("Must be a positive integer.", "warning");
+              }
+            }
+          } else if (id === "defaultMaxTurns") {
+            const val = await ctx.ui.input("Default max turns (0 = unlimited)", newValue);
+            if (val) {
+              const n = parseInt(val, 10);
+              if (n === 0) {
+                setDefaultMaxTurns(undefined);
+                list.updateValue(id, "0");
+                notifyApplied(ctx, "Default max turns set to unlimited");
+              } else if (n >= 1) {
+                setDefaultMaxTurns(n);
+                list.updateValue(id, String(n));
+                notifyApplied(ctx, `Default max turns set to ${n}`);
+              } else {
+                ctx.ui.notify("Must be 0 (unlimited) or a positive integer.", "warning");
+              }
+            }
+          } else if (id === "graceTurns") {
+            const val = await ctx.ui.input("Grace turns after wrap-up steer", newValue);
+            if (val) {
+              const n = parseInt(val, 10);
+              if (n >= 1) {
+                setGraceTurns(n);
+                list.updateValue(id, String(n));
+                notifyApplied(ctx, `Grace turns set to ${n}`);
+              } else {
+                ctx.ui.notify("Must be a positive integer.", "warning");
+              }
+            }
+          } else if (id === "joinMode") {
+            setDefaultJoinMode(newValue as JoinMode);
+            list.updateValue("joinMode", newValue);
+            notifyApplied(ctx, `Default join mode set to ${newValue}`);
+          } else if (id === "scopeModels") {
+            const enabled = newValue === "on";
+            setScopeModelsEnabled(enabled);
+            list.updateValue("scopeModels", newValue);
+            notifyApplied(ctx, `Scope models ${enabled ? "enabled" : "disabled"}`);
+          }
+        },
+        () => done(undefined as undefined),
+      );
+
+      const container = new Container();
+      container.addChild(new Text("⚙  Subagent Settings", 0, 0));
+      container.addChild(new Spacer(1));
+      container.addChild(list);
+
+      return {
+        render: (w: number) => container.render(w),
+        invalidate: () => container.invalidate(),
+        handleInput: (data: string) => list.handleInput?.(data),
+      };
+    });
   }
 
   // Persist the current snapshot, emit `subagents:settings_changed`, and surface

--- a/src/invocation-config.ts
+++ b/src/invocation-config.ts
@@ -24,8 +24,8 @@ export function resolveAgentInvocationConfig(
   isolation?: IsolationMode;
 } {
   return {
-    modelInput: agentConfig?.model ?? params.model,
-    modelFromParams: agentConfig?.model == null && params.model != null,
+    modelInput: params.model ?? agentConfig?.model,
+    modelFromParams: params.model != null,
     thinking: (agentConfig?.thinking ?? params.thinking) as ThinkingLevel | undefined,
     maxTurns: agentConfig?.maxTurns ?? params.max_turns,
     inheritContext: agentConfig?.inheritContext ?? params.inherit_context ?? false,

--- a/src/settings.ts
+++ b/src/settings.ts
@@ -17,6 +17,12 @@ export interface SubagentsSettings {
   defaultMaxTurns?: number;
   graceTurns?: number;
   defaultJoinMode?: JoinMode;
+  /**
+   * When true (default), subagent model choices are validated against the
+   * available models from the model registry. Models outside the scope are
+   * rejected with an error listing the available models.
+   */
+  scopeModels?: boolean;
 }
 
 /** Setter hooks used by applySettings to wire persisted values into in-memory state. */
@@ -25,6 +31,7 @@ export interface SettingsAppliers {
   setDefaultMaxTurns: (n: number) => void;
   setGraceTurns: (n: number) => void;
   setDefaultJoinMode: (mode: JoinMode) => void;
+  setScopeModels: (enabled: boolean) => void;
 }
 
 /** Emit callback — a subset of `pi.events.emit` to keep helpers testable. */
@@ -67,6 +74,9 @@ function sanitize(raw: unknown): SubagentsSettings {
   }
   if (typeof r.defaultJoinMode === "string" && VALID_JOIN_MODES.has(r.defaultJoinMode)) {
     out.defaultJoinMode = r.defaultJoinMode as JoinMode;
+  }
+  if (typeof r.scopeModels === "boolean") {
+    out.scopeModels = r.scopeModels;
   }
   return out;
 }
@@ -122,6 +132,7 @@ export function applySettings(s: SubagentsSettings, appliers: SettingsAppliers):
   if (typeof s.defaultMaxTurns === "number") appliers.setDefaultMaxTurns(s.defaultMaxTurns);
   if (typeof s.graceTurns === "number") appliers.setGraceTurns(s.graceTurns);
   if (s.defaultJoinMode) appliers.setDefaultJoinMode(s.defaultJoinMode);
+  if (typeof s.scopeModels === "boolean") appliers.setScopeModels(s.scopeModels);
 }
 
 /**

--- a/src/settings.ts
+++ b/src/settings.ts
@@ -18,9 +18,9 @@ export interface SubagentsSettings {
   graceTurns?: number;
   defaultJoinMode?: JoinMode;
   /**
-   * When true (default), subagent model choices are validated against the
-   * available models from the model registry. Models outside the scope are
-   * rejected with an error listing the available models.
+   * When true, subagent model choices are validated against enabledModels.
+   * Models outside the scope are rejected with an error listing allowed models.
+   * Defaults to false — subagents may use any model by default.
    */
   scopeModels?: boolean;
 }

--- a/test/enabled-models.test.ts
+++ b/test/enabled-models.test.ts
@@ -7,9 +7,8 @@ import { type ModelRegistryRef, readEnabledModels, resolveEnabledModels } from "
 /** Mock models matching typical registry shape. */
 const MODELS = [
   { id: "gemma-4-31b-it", name: "Gemma 4 31B", provider: "google" },
-  { id: "speed", name: "Speed", provider: "vllm" },
-  { id: "Qwen3.6-35B-A3B-UD-IQ4_NL-mmproj:precise", name: "Qwen3.6 35B", provider: "llama-swap" },
-  { id: "Qwen3.6-27B-Q4_K_M-mmproj-ik:precise", name: "Qwen3.6 27B", provider: "llama-swap" },
+  { id: "claude-opus-4-6", name: "Claude Opus 4.6", provider: "anthropic" },
+  { id: "claude-opus-4-5", name: "Claude Opus 4.5", provider: "anthropic" },
   { id: "claude-haiku-4-5", name: "Claude Haiku 4.5", provider: "anthropic" },
   { id: "claude-sonnet-4-6", name: "Claude Sonnet 4.6", provider: "anthropic" },
 ];
@@ -109,10 +108,10 @@ describe("resolveEnabledModels", () => {
 
     it("resolves model id with colon (part of id, not split)", () => {
       const result = resolveEnabledModels(
-        ["llama-swap/Qwen3.6-35B-A3B-UD-IQ4_NL-mmproj:precise"],
+        ["anthropic/claude-opus-4-6"],
         makeRegistry(),
       );
-      expect(result).toEqual(new Set(["llama-swap/qwen3.6-35b-a3b-ud-iq4_nl-mmproj:precise"]));
+      expect(result).toEqual(new Set(["anthropic/claude-opus-4-6"]));
     });
 
     it("is case-insensitive", () => {
@@ -123,12 +122,12 @@ describe("resolveEnabledModels", () => {
 
   describe("no bare modelId or fuzzy matching", () => {
     it("returns undefined for bare id (pi always writes provider/modelId)", () => {
-      const result = resolveEnabledModels(["speed"], makeRegistry());
+      const result = resolveEnabledModels(["gemma-4-31b-it"], makeRegistry());
       expect(result).toBeUndefined();
     });
 
     it("returns undefined for bare substring patterns", () => {
-      const result = resolveEnabledModels(["Qwen"], makeRegistry());
+      const result = resolveEnabledModels(["Opus"], makeRegistry());
       expect(result).toBeUndefined();
     });
   });
@@ -144,8 +143,8 @@ describe("resolveEnabledModels", () => {
       expect(result!.has("google/gemma-4-31b-it".toLowerCase())).toBe(true);
       expect(result!.has("anthropic/claude-haiku-4-5".toLowerCase())).toBe(true);
       expect(result!.has("anthropic/claude-sonnet-4-6".toLowerCase())).toBe(true);
-      expect(result!.has("vllm/speed".toLowerCase())).toBe(false);
-      expect(result!.has("llama-swap/qwen3.6-35b-a3b-ud-iq4_nl-mmproj:precise".toLowerCase())).toBe(false);
+      expect(result!.has("google/gemini-2.5-pro".toLowerCase())).toBe(false);
+      expect(result!.has("anthropic/claude-opus-4-6".toLowerCase())).toBe(false);
     });
   });
 

--- a/test/enabled-models.test.ts
+++ b/test/enabled-models.test.ts
@@ -1,0 +1,165 @@
+import { mkdtempSync, rmSync, writeFileSync } from "node:fs";
+import { tmpdir } from "node:os";
+import { join } from "node:path";
+import { afterEach, beforeEach, describe, expect, it } from "vitest";
+import { type ModelRegistryRef, readEnabledModels, resolveEnabledModels } from "../src/enabled-models.js";
+
+/** Mock models matching typical registry shape. */
+const MODELS = [
+  { id: "gemma-4-31b-it", name: "Gemma 4 31B", provider: "google" },
+  { id: "speed", name: "Speed", provider: "vllm" },
+  { id: "Qwen3.6-35B-A3B-UD-IQ4_NL-mmproj:precise", name: "Qwen3.6 35B", provider: "llama-swap" },
+  { id: "Qwen3.6-27B-Q4_K_M-mmproj-ik:precise", name: "Qwen3.6 27B", provider: "llama-swap" },
+  { id: "claude-haiku-4-5", name: "Claude Haiku 4.5", provider: "anthropic" },
+  { id: "claude-sonnet-4-6", name: "Claude Sonnet 4.6", provider: "anthropic" },
+];
+
+function makeRegistry(models = MODELS, available?: typeof MODELS): ModelRegistryRef {
+  return {
+    getAll() { return models; },
+    getAvailable: available ? () => available : undefined,
+  };
+}
+
+describe("readEnabledModels", () => {
+  let agentDir: string;
+  let originalEnv: string | undefined;
+
+  beforeEach(() => {
+    agentDir = mkdtempSync(join(tmpdir(), "pi-em-"));
+    originalEnv = process.env.PI_CODING_AGENT_DIR;
+    process.env.PI_CODING_AGENT_DIR = agentDir;
+  });
+
+  afterEach(() => {
+    if (originalEnv == null) delete process.env.PI_CODING_AGENT_DIR;
+    else process.env.PI_CODING_AGENT_DIR = originalEnv;
+    rmSync(agentDir, { recursive: true, force: true });
+  });
+
+  it("returns undefined when settings file missing", () => {
+    expect(readEnabledModels()).toBeUndefined();
+  });
+
+  it("returns undefined when field absent", () => {
+    writeFileSync(join(agentDir, "settings.json"), JSON.stringify({ defaultProvider: "openai" }));
+    expect(readEnabledModels()).toBeUndefined();
+  });
+
+  it("returns enabledModels array", () => {
+    writeFileSync(join(agentDir, "settings.json"), JSON.stringify({
+      enabledModels: ["anthropic/claude-sonnet-4-6", "google/gemma-4-31b-it"],
+    }));
+    expect(readEnabledModels()).toEqual(["anthropic/claude-sonnet-4-6", "google/gemma-4-31b-it"]);
+  });
+
+  it("returns undefined for corrupt JSON", () => {
+    writeFileSync(join(agentDir, "settings.json"), "not json {{{");
+    expect(readEnabledModels()).toBeUndefined();
+  });
+
+  it("returns undefined when enabledModels is not an array", () => {
+    writeFileSync(join(agentDir, "settings.json"), JSON.stringify({ enabledModels: "anthropic/claude-sonnet-4-6" }));
+    expect(readEnabledModels()).toBeUndefined();
+  });
+});
+
+describe("resolveEnabledModels", () => {
+  it("returns undefined for empty patterns", () => {
+    expect(resolveEnabledModels([], makeRegistry())).toBeUndefined();
+    expect(resolveEnabledModels(undefined, makeRegistry())).toBeUndefined();
+  });
+
+  it("returns undefined when no matches", () => {
+    expect(resolveEnabledModels(["nonexistent/foo"], makeRegistry())).toBeUndefined();
+  });
+
+  it("skips empty string patterns", () => {
+    const result = resolveEnabledModels(["", "anthropic/claude-haiku-4-5", "anthropic/claude-sonnet-4-6"], makeRegistry());
+    // Empty string should not match — only exact patterns should match
+    expect(result!.size).toBe(2);
+  });
+
+  it("skips whitespace-only patterns", () => {
+    const result = resolveEnabledModels(["  ", "google/gemma-4-31b-it"], makeRegistry());
+    expect(result).toEqual(new Set(["google/gemma-4-31b-it"]));
+  });
+
+  it("returns undefined when getAvailable returns empty array", () => {
+    const result = resolveEnabledModels(
+      ["anthropic/claude-haiku-4-5"],
+      makeRegistry(MODELS, []),
+    );
+    expect(result).toBeUndefined();
+  });
+
+  it("deduplicates duplicate patterns", () => {
+    const result = resolveEnabledModels(
+      ["anthropic/claude-haiku-4-5", "anthropic/claude-haiku-4-5"],
+      makeRegistry(),
+    );
+    expect(result!.size).toBe(1); // duplicate resolves to one entry
+  });
+
+  describe("exact provider/modelId", () => {
+    it("resolves exact match (key stored lowercase)", () => {
+      const result = resolveEnabledModels(["google/gemma-4-31b-it"], makeRegistry());
+      expect(result).toEqual(new Set(["google/gemma-4-31b-it"]));
+    });
+
+    it("resolves model id with colon (part of id, not split)", () => {
+      const result = resolveEnabledModels(
+        ["llama-swap/Qwen3.6-35B-A3B-UD-IQ4_NL-mmproj:precise"],
+        makeRegistry(),
+      );
+      expect(result).toEqual(new Set(["llama-swap/qwen3.6-35b-a3b-ud-iq4_nl-mmproj:precise"]));
+    });
+
+    it("is case-insensitive", () => {
+      const result = resolveEnabledModels(["GOOGLE/GEMMA-4-31B-IT"], makeRegistry());
+      expect(result).toEqual(new Set(["google/gemma-4-31b-it"]));
+    });
+  });
+
+  describe("no bare modelId or fuzzy matching", () => {
+    it("returns undefined for bare id (pi always writes provider/modelId)", () => {
+      const result = resolveEnabledModels(["speed"], makeRegistry());
+      expect(result).toBeUndefined();
+    });
+
+    it("returns undefined for bare substring patterns", () => {
+      const result = resolveEnabledModels(["Qwen"], makeRegistry());
+      expect(result).toBeUndefined();
+    });
+  });
+
+
+
+  describe("mixed patterns", () => {
+    it("combines multiple exact provider/modelId in one call", () => {
+      const result = resolveEnabledModels(
+        ["google/gemma-4-31b-it", "anthropic/claude-haiku-4-5", "anthropic/claude-sonnet-4-6"],
+        makeRegistry(),
+      );
+      expect(result!.has("google/gemma-4-31b-it".toLowerCase())).toBe(true);
+      expect(result!.has("anthropic/claude-haiku-4-5".toLowerCase())).toBe(true);
+      expect(result!.has("anthropic/claude-sonnet-4-6".toLowerCase())).toBe(true);
+      expect(result!.has("vllm/speed".toLowerCase())).toBe(false);
+      expect(result!.has("llama-swap/qwen3.6-35b-a3b-ud-iq4_nl-mmproj:precise".toLowerCase())).toBe(false);
+    });
+  });
+
+  describe("getAvailable filtering", () => {
+    it("resolves only against available models when getAvailable present", () => {
+      const available = [MODELS[0], MODELS[4]]; // google + haiku only
+      const result = resolveEnabledModels(
+        ["anthropic/claude-haiku-4-5", "anthropic/claude-sonnet-4-6", "google/gemma-4-31b-it"],
+        makeRegistry(MODELS, available),
+      );
+      // haiku and google are available; sonnet is not
+      expect(result!.has("anthropic/claude-haiku-4-5".toLowerCase())).toBe(true);
+      expect(result!.has("anthropic/claude-sonnet-4-6".toLowerCase())).toBe(false); // not available
+      expect(result!.has("google/gemma-4-31b-it".toLowerCase())).toBe(true);
+    });
+  });
+});

--- a/test/settings.test.ts
+++ b/test/settings.test.ts
@@ -366,6 +366,7 @@ describe("settings persistence", () => {
         setDefaultMaxTurns: vi.fn(),
         setGraceTurns: vi.fn(),
         setDefaultJoinMode: vi.fn(),
+        setScopeModels: vi.fn(),
       };
     });
 

--- a/test/settings.test.ts
+++ b/test/settings.test.ts
@@ -179,6 +179,22 @@ describe("settings persistence", () => {
       }
     });
 
+    it("accepts scopeModels boolean (true and false)", () => {
+      writeProject({ scopeModels: true });
+      expect(loadSettings(projectDir)).toEqual({ scopeModels: true });
+      writeProject({ scopeModels: false });
+      expect(loadSettings(projectDir)).toEqual({ scopeModels: false });
+    });
+
+    it("drops non-boolean scopeModels", () => {
+      writeProject({ scopeModels: "yes" });
+      expect(loadSettings(projectDir).scopeModels).toBeUndefined();
+      writeProject({ scopeModels: 1 });
+      expect(loadSettings(projectDir).scopeModels).toBeUndefined();
+      writeProject({ scopeModels: null });
+      expect(loadSettings(projectDir).scopeModels).toBeUndefined();
+    });
+
     it("returns {} when the JSON root is not an object (array, string, null)", () => {
       mkdirSync(join(projectDir, ".pi"), { recursive: true });
       writeFileSync(projectFile(), '["not", "an", "object"]');
@@ -274,6 +290,7 @@ describe("settings persistence", () => {
         setDefaultMaxTurns: vi.fn(),
         setGraceTurns: vi.fn(),
         setDefaultJoinMode: vi.fn(),
+        setScopeModels: vi.fn(),
       };
     });
 
@@ -283,6 +300,7 @@ describe("settings persistence", () => {
       expect(appliers.setDefaultMaxTurns).not.toHaveBeenCalled();
       expect(appliers.setGraceTurns).not.toHaveBeenCalled();
       expect(appliers.setDefaultJoinMode).not.toHaveBeenCalled();
+      expect(appliers.setScopeModels).not.toHaveBeenCalled();
     });
 
     it("applies only the fields that are present", () => {
@@ -291,17 +309,30 @@ describe("settings persistence", () => {
       expect(appliers.setGraceTurns).toHaveBeenCalledWith(3);
       expect(appliers.setDefaultMaxTurns).not.toHaveBeenCalled();
       expect(appliers.setDefaultJoinMode).not.toHaveBeenCalled();
+      expect(appliers.setScopeModels).not.toHaveBeenCalled();
     });
 
-    it("applies all four fields when all are present", () => {
+    it("applies all fields when all are present", () => {
       applySettings(
-        { maxConcurrent: 8, defaultMaxTurns: 50, graceTurns: 7, defaultJoinMode: "group" },
+        {
+          maxConcurrent: 8,
+          defaultMaxTurns: 50,
+          graceTurns: 7,
+          defaultJoinMode: "group",
+          scopeModels: true,
+        },
         appliers,
       );
       expect(appliers.setMaxConcurrent).toHaveBeenCalledWith(8);
       expect(appliers.setDefaultMaxTurns).toHaveBeenCalledWith(50);
       expect(appliers.setGraceTurns).toHaveBeenCalledWith(7);
       expect(appliers.setDefaultJoinMode).toHaveBeenCalledWith("group");
+      expect(appliers.setScopeModels).toHaveBeenCalledWith(true);
+    });
+
+    it("applies scopeModels: false", () => {
+      applySettings({ scopeModels: false }, appliers);
+      expect(appliers.setScopeModels).toHaveBeenCalledWith(false);
     });
 
     it("applies defaultMaxTurns: 0 as the explicit unlimited marker", () => {


### PR DESCRIPTION
### Summary

Adds `scopeModels` setting which is an opt-in validation that restricts subagent model choices to those listed in `enabledModels` from `~/.pi/agent/settings.json` which is selected via `/scoped-models`. 

This PR also has some UX improvements for the settings menu - `SettingsList` UI with numeric input support.

### Changes

**New module:** `src/enabled-models.ts` (+128 lines)
* `readEnabledModels()` - reads `enabledModels` array from global pi settings file (since it's not exposed in the API)
* `resolveEnabledModels()` - resolves exact provider/modelId patterns against the model registry (caches the list by `settings.json` mtime)

**Scope validation in** `src/index.ts` (+172/-39 lines)
* On agent spawn, resolved model is checked against `enabledModels`
* Agent's `params` -> hard error with allowed models listed
* Config/frontmatter -> warning to user + graceful fallback to parent/twin model to prevent interrupting the flow

**Settings:** `src/settings.ts` (+11 lines)
* Added `scopeModels?: boolean` to `SubagentsSettings` with sanitization and persistence

**Settings dialog rewrite:** `src/index.ts`
* Replaced `ctx.ui.select` menu with native `SettingsList` (`@mariozechner/pi-tui`)
* Numeric fields (`maxConcurrent`, `defaultMaxTurns`, `graceTurns`) support direct input via `ctx.ui.input` with validation
* Added `scopeModels` toggle to settings menu

**Tests**
* `test/enabled-models.test.ts` - 165 new lines, covers resolution, caching, edge cases (empty patterns, whitespace, corrupt JSON, deduplication, `getAvailable` filtering)
* `test/settings.test.ts` - 36 new lines for settings persistence