### PR TITLE
Fix: `isolation: "worktree"` should fail loud instead of silent fallback         

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -7,6 +7,12 @@ and this project adheres to [Semantic Versioning](https://semver.org/spec/v2.0.0
 
 ## [Unreleased]
 
+> **Heads-up — behavior change:**
+> - `isolation: "worktree"` now fails loud (returns an error) instead of silently falling back to the main tree. Affects users running pi in a non-git directory or a fresh repo with no commits.
+
+### Changed
+- **`isolation: "worktree"` now fails loud instead of silently falling back.** Previously when `createWorktree` returned undefined (not a git repo, no commits yet, or `git worktree add` failed), the agent ran in the main `cwd` with a `[WARNING: ...]` block prepended to its prompt — visible only to the LLM, never surfaced to the caller. Now the failure throws a structured error that propagates back to the `Agent` tool response; no agent record is created. Failed scheduled fires are recorded as `lastStatus: "error"` with the reason in the `subagents:scheduled` error event. Queued background spawns whose worktree creation fails when they dequeue are marked terminal-error and don't block the rest of the queue.
+
 ## [0.7.0] - 2026-05-04
 
 > **Heads-up — behavior changes:**

--- a/README.md
+++ b/README.md
@@ -453,7 +453,7 @@ The agent gets a full, isolated copy of the repository. On completion:
 - **No changes:** worktree is cleaned up automatically
 - **Changes made:** changes are committed to a new branch (`pi-agent-<id>`) and returned in the result
 
-If the worktree cannot be created (not a git repo, no commits), the agent falls back to the main working directory with a warning.
+If the worktree cannot be created (not a git repo, no commits, or `git worktree add` fails), the `Agent` tool returns a clear error instead of running unisolated — `isolation: "worktree"` is a strict guarantee, not a hint. Initialize git and commit at least once, or omit `isolation`.
 
 ## Skill Preloading
 

--- a/src/agent-manager.ts
+++ b/src/agent-manager.ts
@@ -134,12 +134,35 @@ export class AgentManager {
       return id;
     }
 
-    this.startAgent(id, record, args);
+    // startAgent can throw (e.g. strict worktree-isolation failure) — clean
+    // up the record so callers don't see an orphan in `listAgents()`.
+    try {
+      this.startAgent(id, record, args);
+    } catch (err) {
+      this.agents.delete(id);
+      throw err;
+    }
     return id;
   }
 
   /** Actually start an agent (called immediately or from queue drain). */
   private startAgent(id: string, record: AgentRecord, { pi, ctx, type, prompt, options }: SpawnArgs) {
+    // Worktree isolation: try to create a temporary git worktree. Strict —
+    // fail loud if not possible (no silent fallback to main tree). Done
+    // BEFORE state mutation so a throw doesn't leave the record half-running.
+    let worktreeCwd: string | undefined;
+    if (options.isolation === "worktree") {
+      const wt = createWorktree(ctx.cwd, id);
+      if (!wt) {
+        throw new Error(
+          'Cannot run with isolation: "worktree" — not a git repo, no commits yet, or `git worktree add` failed. ' +
+          'Initialize git and commit at least once, or omit `isolation`.',
+        );
+      }
+      record.worktree = wt;
+      worktreeCwd = wt.path;
+    }
+
     record.status = "running";
     record.startedAt = Date.now();
     if (options.isBackground) this.runningBackground++;
@@ -154,23 +177,7 @@ export class AgentManager {
     }
     const detach = () => { detachParentSignal?.(); detachParentSignal = undefined; };
 
-    // Worktree isolation: create a temporary git worktree if requested
-    let worktreeCwd: string | undefined;
-    let worktreeWarning = "";
-    if (options.isolation === "worktree") {
-      const wt = createWorktree(ctx.cwd, id);
-      if (wt) {
-        record.worktree = wt;
-        worktreeCwd = wt.path;
-      } else {
-        worktreeWarning = "\n\n[WARNING: Worktree isolation was requested but failed (not a git repo, or no commits yet). Running in the main working directory instead.]";
-      }
-    }
-
-    // Prepend worktree warning to prompt if isolation failed
-    const effectivePrompt = worktreeWarning ? worktreeWarning + "\n\n" + prompt : prompt;
-
-    const promise = runAgent(ctx, type, effectivePrompt, {
+    const promise = runAgent(ctx, type, prompt, {
       pi,
       model: options.model,
       maxTurns: options.maxTurns,
@@ -281,7 +288,16 @@ export class AgentManager {
       const next = this.queue.shift()!;
       const record = this.agents.get(next.id);
       if (!record || record.status !== "queued") continue;
-      this.startAgent(next.id, record, next.args);
+      try {
+        this.startAgent(next.id, record, next.args);
+      } catch (err) {
+        // Late failure (e.g. strict worktree-isolation) — surface on the record
+        // so the user/agent can see it via /agents, then keep draining.
+        record.status = "error";
+        record.error = err instanceof Error ? err.message : String(err);
+        record.completedAt = Date.now();
+        this.onComplete?.(record);
+      }
     }
   }
 

--- a/src/index.ts
+++ b/src/index.ts
@@ -946,17 +946,21 @@ Guidelines:
           }
         };
 
-        id = manager.spawn(pi, ctx, subagentType, params.prompt, {
-          description: params.description,
-          model,
-          maxTurns: effectiveMaxTurns,
-          isolated,
-          inheritContext,
-          thinkingLevel: thinking,
-          isBackground: true,
-          isolation,
-          ...bgCallbacks,
-        });
+        try {
+          id = manager.spawn(pi, ctx, subagentType, params.prompt, {
+            description: params.description,
+            model,
+            maxTurns: effectiveMaxTurns,
+            isolated,
+            inheritContext,
+            thinkingLevel: thinking,
+            isBackground: true,
+            isolation,
+            ...bgCallbacks,
+          });
+        } catch (err) {
+          return textResult(err instanceof Error ? err.message : String(err));
+        }
 
         // Set output file + join mode synchronously after spawn, before the
         // event loop yields — onSessionCreated is async so this is safe.
@@ -1054,17 +1058,23 @@ Guidelines:
 
       streamUpdate();
 
-      const record = await manager.spawnAndWait(pi, ctx, subagentType, params.prompt, {
-        description: params.description,
-        model,
-        maxTurns: effectiveMaxTurns,
-        isolated,
-        inheritContext,
-        thinkingLevel: thinking,
-        isolation,
-        signal,
-        ...fgCallbacks,
-      });
+      let record: AgentRecord;
+      try {
+        record = await manager.spawnAndWait(pi, ctx, subagentType, params.prompt, {
+          description: params.description,
+          model,
+          maxTurns: effectiveMaxTurns,
+          isolated,
+          inheritContext,
+          thinkingLevel: thinking,
+          isolation,
+          signal,
+          ...fgCallbacks,
+        });
+      } catch (err) {
+        clearInterval(spinnerInterval);
+        return textResult(err instanceof Error ? err.message : String(err));
+      }
 
       clearInterval(spinnerInterval);
 

--- a/test/agent-manager.test.ts
+++ b/test/agent-manager.test.ts
@@ -317,3 +317,31 @@ describe("AgentManager — lifetime usage + compaction count are eagerly initial
     expect(manager.getRecord(id)!.compactionCount).toBe(1);
   });
 });
+
+// Regression: `isolation: "worktree"` MUST fail loud when the cwd can't host
+// a worktree. The previous behavior silently fell back to the main tree and
+// injected a warning into the LLM's prompt — invisible to the caller.
+describe("AgentManager — isolation: worktree fails loud, no silent fallback", () => {
+  let manager: AgentManager;
+
+  afterEach(() => {
+    manager?.dispose();
+  });
+
+  it("spawn() throws when createWorktree returns undefined; no orphan record left behind", async () => {
+    const { createWorktree } = await import("../src/worktree.js");
+    vi.mocked(createWorktree).mockReturnValueOnce(undefined);
+    vi.mocked(runAgent).mockClear();
+
+    manager = new AgentManager();
+    expect(() => manager.spawn(mockPi, mockCtx, "general-purpose", "test", {
+      description: "test",
+      isolation: "worktree",
+    })).toThrow(/isolation: "worktree"/);
+
+    // Cleaned up — no orphan in listAgents()
+    expect(manager.listAgents()).toEqual([]);
+    // runAgent never invoked — strict, no silent fallback
+    expect(runAgent).not.toHaveBeenCalled();
+  });
+});


### PR DESCRIPTION
### Problem                                                                                                                                                 
                                                                                                                                                              
  When `createWorktree` returned undefined (not a git repo, no commits, or `git worktree add` failed), the agent silently ran in the main `cwd` with a         `[WARNING: ...]` block prepended to its prompt — visible only to the LLM, never surfaced to the caller. The `worktree` UI tag rendered regardless. Callers    requesting isolation got an **unisolated run** without realizing it.
                                                                                                                                                              
  ### Fix         
                                                                                                                                                              
  `startAgent` now throws on worktree creation failure. No silent fallback. The throw propagates as a clean error through every reachable path:
                                          
  | Path | Surface |                          
  |---|---|                                                                                                                                                   
  | Foreground `Agent` | `textResult` with error message |
  | Background `Agent` | `textResult`; orphan record cleaned up |                                                                                             
  | Queued background | record marked `error`, queue keeps draining |
  | Scheduled fire | `lastStatus: "error"` + `subagents:scheduled` error event |                                                                              
                                          
  ### Behavior change                                                                                                                                         
                                                                                                                                                              
  Anyone running pi in a non-git directory and passing `isolation: "worktree"` will now see a clear error instead of silent main-tree execution. `isolation:    "worktree"` is now a strict guarantee, not a hint.                                                                                                          
                  
  ### Diff                                                                                                                                                    
                                                                                                              
                                                                                                                                                              
  - `src/agent-manager.ts` — worktree-first reorder + throw, orphan cleanup in `spawn`, queue resilience in `drainQueue`
  - `src/index.ts` — try/catch around foreground & background spawn calls; foreground also clears the spinner timer on throw                                  
  - `test/agent-manager.test.ts` — regression test (throws + no orphan + `runAgent` not invoked)
  - `CHANGELOG.md` + `README.md` — documented        