### PR TITLE
Fix: headless pi --print hangs/crashes with subagents

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -13,6 +13,13 @@ and this project adheres to [Semantic Versioning](https://semver.org/spec/v2.0.0
 ### Changed
 - **`isolation: "worktree"` now fails loud instead of silently falling back.** Previously when `createWorktree` returned undefined (not a git repo, no commits yet, or `git worktree add` failed), the agent ran in the main `cwd` with a `[WARNING: ...]` block prepended to its prompt — visible only to the LLM, never surfaced to the caller. Now the failure throws a structured error that propagates back to the `Agent` tool response; no agent record is created. Failed scheduled fires are recorded as `lastStatus: "error"` with the reason in the `subagents:scheduled` error event. Queued background spawns whose worktree creation fails when they dequeue are marked terminal-error and don't block the rest of the queue.
 
+### Fixed
+
+- **Headless `pi --print` runs no longer hang or crash after background
+subagents complete.** Cleanup timers no longer keep the process alive, and
+stale completion notifications are treated as best-effort shutdown side
+effects.
+
 ## [0.7.0] - 2026-05-04
 
 > **Heads-up — behavior changes:**

--- a/src/agent-manager.ts
+++ b/src/agent-manager.ts
@@ -87,6 +87,7 @@ export class AgentManager {
     this.maxConcurrent = maxConcurrent;
     // Cleanup completed agents after 10 minutes (but keep sessions for resume)
     this.cleanupInterval = setInterval(() => this.cleanup(), 60_000);
+    this.cleanupInterval.unref();
   }
 
   /** Update the max concurrent background agents limit. */

--- a/src/agent-manager.ts
+++ b/src/agent-manager.ts
@@ -243,7 +243,7 @@ export class AgentManager {
 
         if (options.isBackground) {
           this.runningBackground--;
-          this.onComplete?.(record);
+          try { this.onComplete?.(record); } catch { /* ignore completion side-effect errors */ }
           this.drainQueue();
         }
         return responseText;

--- a/src/index.ts
+++ b/src/index.ts
@@ -275,7 +275,7 @@ export default function (pi: ExtensionAPI) {
     cancelNudge(key);
     pendingNudges.set(key, setTimeout(() => {
       pendingNudges.delete(key);
-      send();
+      try { send(); } catch { /* ignore stale completion side-effect errors */ }
     }, delay));
   }
 

--- a/test/agent-manager.test.ts
+++ b/test/agent-manager.test.ts
@@ -108,6 +108,20 @@ describe("AgentManager — Bug 1 race condition (resultConsumed vs onComplete)",
   });
 });
 
+describe("AgentManager — cleanup timer", () => {
+  let manager: AgentManager;
+
+  afterEach(() => {
+    manager?.dispose();
+  });
+
+  it("does not keep the process alive on its own", () => {
+    manager = new AgentManager();
+
+    expect((manager as any).cleanupInterval.hasRef()).toBe(false);
+  });
+});
+
 describe("AgentManager — Bug 3 clearCompleted", () => {
   let manager: AgentManager;
 

--- a/test/agent-manager.test.ts
+++ b/test/agent-manager.test.ts
@@ -108,6 +108,29 @@ describe("AgentManager — Bug 1 race condition (resultConsumed vs onComplete)",
   });
 });
 
+describe("AgentManager — completion callbacks", () => {
+  let manager: AgentManager;
+
+  afterEach(() => {
+    manager?.dispose();
+  });
+
+  it("does not let onComplete errors turn a completed agent into a failed run", async () => {
+    manager = new AgentManager(() => {
+      throw new Error("stale extension context");
+    });
+    resolvedRun();
+
+    const id = manager.spawn(mockPi, mockCtx, "general-purpose", "test", {
+      description: "test",
+      isBackground: true,
+    });
+    await expect(manager.getRecord(id)!.promise).resolves.toBe("done");
+
+    expect(manager.getRecord(id)!.status).toBe("completed");
+  });
+});
+
 describe("AgentManager — cleanup timer", () => {
   let manager: AgentManager;
 

--- a/test/print-mode.test.ts
+++ b/test/print-mode.test.ts
@@ -1,0 +1,106 @@
+import { afterEach, describe, expect, it, vi } from "vitest";
+
+vi.mock("../src/agent-runner.js", async () => {
+  const actual = await vi.importActual<typeof import("../src/agent-runner.js")>("../src/agent-runner.js");
+  return {
+    ...actual,
+    runAgent: vi.fn(),
+  };
+});
+
+import { runAgent } from "../src/agent-runner.js";
+import subagentsExtension from "../src/index.js";
+
+function makePi() {
+  const tools = new Map<string, any>();
+  const handlers = new Map<string, any>();
+  const eventHandlers = new Map<string, any>();
+
+  return {
+    pi: {
+      registerMessageRenderer: vi.fn(),
+      registerTool: vi.fn((tool: any) => {
+        tools.set(tool.name, tool);
+      }),
+      registerCommand: vi.fn(),
+      on: vi.fn((event: string, handler: any) => {
+        handlers.set(event, handler);
+      }),
+      events: {
+        emit: vi.fn(),
+        on: vi.fn((event: string, handler: any) => {
+          eventHandlers.set(event, handler);
+          return vi.fn();
+        }),
+      },
+      appendEntry: vi.fn(),
+      sendMessage: vi.fn(() => {
+        throw new Error("stale extension context");
+      }),
+    } as any,
+    tools,
+    handlers,
+  };
+}
+
+function makeHeadlessCtx() {
+  return {
+    hasUI: false,
+    ui: {
+      setStatus: vi.fn(),
+      setWidget: vi.fn(),
+    },
+    cwd: "/tmp",
+    model: undefined,
+    modelRegistry: {
+      find: vi.fn(),
+      getAvailable: vi.fn(() => []),
+    },
+    sessionManager: {
+      getSessionId: vi.fn(() => "session-1"),
+      getBranch: vi.fn(() => []),
+    },
+    getSystemPrompt: vi.fn(() => "parent prompt"),
+  } as any;
+}
+
+describe("print mode background notifications", () => {
+  afterEach(() => {
+    vi.restoreAllMocks();
+    vi.useRealTimers();
+  });
+
+  it("ignores stale-context errors from delayed completion nudges", async () => {
+    vi.mocked(runAgent).mockResolvedValue({
+      responseText: "done",
+      session: { dispose: vi.fn() } as any,
+      aborted: false,
+      steered: false,
+    });
+
+    const { pi, tools, handlers } = makePi();
+    subagentsExtension(pi);
+    vi.useFakeTimers();
+
+    const agentTool = tools.get("Agent");
+    await agentTool.execute(
+      "tool-call-1",
+      {
+        prompt: "reply done",
+        description: "tiny child",
+        subagent_type: "general-purpose",
+        run_in_background: true,
+      },
+      undefined,
+      undefined,
+      makeHeadlessCtx(),
+    );
+
+    await vi.advanceTimersByTimeAsync(100); // smart-join batch debounce
+    await vi.advanceTimersByTimeAsync(200); // notification hold window
+
+    expect(pi.sendMessage).toHaveBeenCalled();
+
+    await handlers.get("session_shutdown")?.({}, makeHeadlessCtx());
+  });
+});


### PR DESCRIPTION
Fix two headless `pi --print` lifecycle issues around background subagents.

I found my pi --print processes would hang indefinitely when they used subagents. These fixes resolve the problem.

The commit messages include reproduction scripts that can be used to replicate the issue on master and show that the issue is resolved on this branch.

Happy to make any adjustments to the PR if helpful.

P.S. Thanks for this project -- it's exactly the subagent support I was looking for!