### PR TITLE
fix(skills): preload Pi skill directories

### DIFF
--- a/README.md
+++ b/README.md
@@ -25,7 +25,7 @@ https://github.com/user-attachments/assets/8685261b-9338-4fea-8dfe-1c590d5df543
 - **Context inheritance** — optionally fork the parent conversation into a sub-agent so it knows what's been discussed
 - **Persistent agent memory** — three scopes (project, local, user) with automatic read-only fallback for agents without write tools
 - **Git worktree isolation** — run agents in isolated repo copies; changes auto-committed to branches on completion
-- **Skill preloading** — inject named skill files from `.pi/skills/` into agent system prompts
+- **Skill preloading** — inject named Pi skill files from project or global skill locations into agent system prompts
 - **Tool denylist** — block specific tools via `disallowed_tools` frontmatter
 - **Styled completion notifications** — background agent results render as themed, compact notification boxes (icon, stats, result preview) instead of raw XML. Expandable to show full output. Group completions render each agent individually
 - **Event bus** — lifecycle events (`subagents:created`, `started`, `completed`, `failed`, `steered`, `compacted`) emitted via `pi.events`, enabling other extensions to react to sub-agent activity
@@ -195,7 +195,7 @@ All fields are optional — sensible defaults for everything.
 | `display_name` | — | Display name for UI (e.g. widget, agent list) |
 | `tools` | all 7 | Comma-separated built-in tools: read, bash, edit, write, grep, find, ls. `none` for no tools |
 | `extensions` | `true` | Inherit MCP/extension tools. `false` to disable |
-| `skills` | `true` | Inherit skills from parent. Can be a comma-separated list of skill names to preload from `.pi/skills/` |
+| `skills` | `true` | Inherit skills from parent. Can be a comma-separated list of skill names to preload from Pi skill locations |
 | `memory` | — | Persistent agent memory scope: `project`, `local`, or `user`. Auto-detects read-only agents |
 | `disallowed_tools` | — | Comma-separated tools to deny even if extensions provide them |
 | `isolation` | — | Set to `worktree` to run in an isolated git worktree |
@@ -457,7 +457,7 @@ If the worktree cannot be created (not a git repo, no commits, or `git worktree 
 
 ## Skill Preloading
 
-Skills can be preloaded as named files from `.pi/skills/` or `~/.pi/skills/`:
+Skills can be preloaded by name from Pi filesystem skill locations:
 
 ```yaml
 ---
@@ -465,7 +465,16 @@ skills: api-conventions, error-handling
 ---
 ```
 
-Skill files (`.md`, `.txt`, or extensionless) are read and injected into the agent's system prompt. Project-level skills take priority over global ones. Symlinked skill files are rejected for security.
+Supported layouts:
+
+- `.pi/skills/<name>/SKILL.md`
+- `.pi/skills/<name>.md`, `.txt`, or extensionless legacy files
+- `.agents/skills/<name>/SKILL.md`
+- `$PI_CODING_AGENT_DIR/skills/<name>/SKILL.md` (default: `~/.pi/agent/skills/<name>/SKILL.md`)
+- `~/.agents/skills/<name>/SKILL.md`
+- `~/.pi/skills/<name>.md`, `.txt`, or extensionless legacy files
+
+Project-level skills take priority over global ones, and nearer project directories take priority over ancestors. Symlinked skill files are rejected for security.
 
 ## Tool Denylist
 
@@ -494,7 +503,7 @@ src/
   group-join.ts       # Group join manager: batched completion notifications with timeout
   custom-agents.ts    # Load user-defined agents from .pi/agents/*.md
   memory.ts           # Persistent agent memory (resolve, read, build prompt blocks)
-  skill-loader.ts     # Preload skill files from .pi/skills/
+  skill-loader.ts     # Preload skill files from Pi skill locations
   output-file.ts      # Streaming output file transcripts for agent sessions
   worktree.ts         # Git worktree isolation (create, cleanup, prune)
   prompts.ts          # Config-driven system prompt builder

--- a/src/skill-loader.ts
+++ b/src/skill-loader.ts
@@ -1,22 +1,30 @@
 /**
  * skill-loader.ts — Preload specific skill files and inject their content into the system prompt.
  *
- * When skills is a string[], reads each named skill from .pi/skills/ or ~/.pi/skills/
- * and returns their content for injection into the agent's system prompt.
+ * When skills is a string[], reads each named skill from Pi's filesystem skill locations
+ * and returns their content for injection into the agent system prompt.
  */
 
+import type { Dirent } from "node:fs";
+import { existsSync, readdirSync } from "node:fs";
 import { homedir } from "node:os";
-import { join } from "node:path";
-import { isUnsafeName, safeReadFile } from "./memory.js";
+import { dirname, join } from "node:path";
+import { getAgentDir } from "@mariozechner/pi-coding-agent";
+import { isSymlink, isUnsafeName, safeReadFile } from "./memory.js";
 
 export interface PreloadedSkill {
   name: string;
   content: string;
 }
 
+interface SkillSearchDir {
+  path: string;
+  flatFiles: boolean;
+}
+
 /**
  * Attempt to load named skills from project and global skill directories.
- * Looks for: <dir>/<name>.md, <dir>/<name>.txt, <dir>/<name>
+ * Supports Pi's standard <name>/SKILL.md layout and legacy flat skill files.
  *
  * @param skillNames  List of skill names to preload.
  * @param cwd         Working directory for project-level skills.
@@ -37,7 +45,7 @@ export function preloadSkills(skillNames: string[], cwd: string): PreloadedSkill
       results.push({ name, content });
     } else {
       // Include a note about missing skills so the agent knows it was requested but not found
-      results.push({ name, content: `(Skill "${name}" not found in .pi/skills/ or ~/.pi/skills/)` });
+      results.push({ name, content: `(Skill "${name}" not found in Pi filesystem skill locations)` });
     }
   }
 
@@ -46,14 +54,10 @@ export function preloadSkills(skillNames: string[], cwd: string): PreloadedSkill
 
 /**
  * Search for a skill file in project and global directories.
- * Project-level takes priority over global.
+ * Project-level locations take priority over global locations.
  */
 function findAndReadSkill(name: string, cwd: string): string | undefined {
-  const projectDir = join(cwd, ".pi", "skills");
-  const globalDir = join(homedir(), ".pi", "skills");
-
-  // Try project first, then global
-  for (const dir of [projectDir, globalDir]) {
+  for (const dir of skillSearchDirs(cwd)) {
     const content = tryReadSkillFile(dir, name);
     if (content !== undefined) return content;
   }
@@ -61,19 +65,102 @@ function findAndReadSkill(name: string, cwd: string): string | undefined {
   return undefined;
 }
 
-/**
- * Try to read a skill file from a directory.
- * Tries extensions in order: .md, .txt, (no extension)
- */
-function tryReadSkillFile(dir: string, name: string): string | undefined {
-  const extensions = [".md", ".txt", ""];
+/** Return skill roots in Pi discovery precedence order. */
+function skillSearchDirs(cwd: string): SkillSearchDir[] {
+  const dirs: SkillSearchDir[] = [];
+  for (const dir of ancestorDirs(cwd)) {
+    dirs.push({ path: join(dir, ".pi", "skills"), flatFiles: true });
+    dirs.push({ path: join(dir, ".agents", "skills"), flatFiles: false });
+  }
+  dirs.push({ path: join(getAgentDir(), "skills"), flatFiles: true });
+  dirs.push({ path: join(homedir(), ".agents", "skills"), flatFiles: false });
+  dirs.push({ path: join(homedir(), ".pi", "skills"), flatFiles: true }); // Backward-compatible legacy location.
+  return dedupeDirs(dirs);
+}
 
-  for (const ext of extensions) {
-    const path = join(dir, name + ext);
-    // safeReadFile rejects symlinks to prevent reading arbitrary files
+function ancestorDirs(cwd: string): string[] {
+  const dirs: string[] = [];
+  let current = cwd;
+  while (true) {
+    dirs.push(current);
+    const parent = dirname(current);
+    if (parent === current) return dirs;
+    current = parent;
+  }
+}
+
+function dedupeDirs(values: SkillSearchDir[]): SkillSearchDir[] {
+  const seen = new Set<string>();
+  const result: SkillSearchDir[] = [];
+  for (const value of values) {
+    if (seen.has(value.path)) continue;
+    seen.add(value.path);
+    result.push(value);
+  }
+  return result;
+}
+
+/**
+ * Try to read a skill file from a root directory.
+ * Tries standard directory skills before legacy flat files.
+ */
+function tryReadSkillFile(dir: SkillSearchDir, name: string): string | undefined {
+  const directDirectorySkill = tryReadSkillDirectory(join(dir.path, name));
+  if (directDirectorySkill !== undefined) return directDirectorySkill;
+
+  if (dir.flatFiles) {
+    const flatSkill = tryReadFlatSkill(dir.path, name);
+    if (flatSkill !== undefined) return flatSkill;
+  }
+
+  for (const skillDir of recursiveSkillDirs(dir.path, name)) {
+    const content = tryReadSkillDirectory(skillDir);
+    if (content !== undefined) return content;
+  }
+
+  return undefined;
+}
+
+function tryReadSkillDirectory(skillDir: string): string | undefined {
+  if (isSymlink(skillDir)) return undefined;
+  return safeReadFile(join(skillDir, "SKILL.md"))?.trim();
+}
+
+function tryReadFlatSkill(dir: string, name: string): string | undefined {
+  const candidates = [join(dir, `${name}.md`), join(dir, `${name}.txt`), join(dir, name)];
+
+  for (const path of candidates) {
+    // safeReadFile rejects symlinked files to prevent reading arbitrary files
     const content = safeReadFile(path);
     if (content !== undefined) return content.trim();
   }
 
   return undefined;
+}
+
+function recursiveSkillDirs(dir: string, name: string): string[] {
+  if (!existsSync(dir)) return [];
+  const candidates: string[] = [];
+  const stack = [dir];
+
+  while (stack.length > 0) {
+    const current = stack.pop();
+    if (current === undefined) continue;
+
+    let entries: Dirent<string>[];
+    try {
+      entries = readdirSync(current, { withFileTypes: true });
+    } catch {
+      continue;
+    }
+
+    for (const entry of entries) {
+      if (!entry.isDirectory()) continue;
+      const path = join(current, entry.name);
+      if (entry.name === name) candidates.push(path);
+      if (path !== join(dir, name)) stack.push(path);
+    }
+  }
+
+  return candidates;
 }

--- a/test/skill-loader.test.ts
+++ b/test/skill-loader.test.ts
@@ -6,19 +6,36 @@ import { preloadSkills } from "../src/skill-loader.js";
 
 describe("preloadSkills", () => {
   let tmpDir: string;
+  let originalAgentDir: string | undefined;
 
   beforeEach(() => {
     tmpDir = mkdtempSync(join(tmpdir(), "pi-skill-test-"));
+    originalAgentDir = process.env.PI_CODING_AGENT_DIR;
+    process.env.PI_CODING_AGENT_DIR = join(tmpDir, "user-agent-dir");
   });
 
   afterEach(() => {
+    if (originalAgentDir === undefined) {
+      delete process.env.PI_CODING_AGENT_DIR;
+    } else {
+      process.env.PI_CODING_AGENT_DIR = originalAgentDir;
+    }
     rmSync(tmpDir, { recursive: true, force: true });
   });
 
   function writeSkill(name: string, content: string, ext = ".md") {
-    const dir = join(tmpDir, ".pi", "skills");
+    writeFlatSkill(join(tmpDir, ".pi", "skills"), name, content, ext);
+  }
+
+  function writeFlatSkill(root: string, name: string, content: string, ext = ".md") {
+    mkdirSync(root, { recursive: true });
+    writeFileSync(join(root, name + ext), content);
+  }
+
+  function writeDirectorySkill(root: string, name: string, content: string) {
+    const dir = join(root, name);
     mkdirSync(dir, { recursive: true });
-    writeFileSync(join(dir, name + ext), content);
+    writeFileSync(join(dir, "SKILL.md"), content);
   }
 
   it("returns empty array for empty skill list", () => {
@@ -32,6 +49,50 @@ describe("preloadSkills", () => {
     expect(result).toHaveLength(1);
     expect(result[0].name).toBe("api-conventions");
     expect(result[0].content).toContain("API Conventions");
+  });
+
+  it("loads a Pi-standard project skill directory", () => {
+    writeDirectorySkill(join(tmpDir, ".pi", "skills"), "writing-go", "# Writing Go\nUse gofmt.");
+    const result = preloadSkills(["writing-go"], tmpDir);
+    expect(result[0].content).toContain("Writing Go");
+  });
+
+  it("loads a Pi-standard global skill directory from PI_CODING_AGENT_DIR", () => {
+    writeDirectorySkill(join(process.env.PI_CODING_AGENT_DIR!, "skills"), "writing-python", "# Writing Python\nUse uv.");
+    const result = preloadSkills(["writing-python"], tmpDir);
+    expect(result[0].content).toContain("Writing Python");
+  });
+
+  it("loads a skill from ancestor .agents/skills", () => {
+    const childCwd = join(tmpDir, "packages", "api");
+    mkdirSync(childCwd, { recursive: true });
+    writeDirectorySkill(join(tmpDir, ".agents", "skills"), "searching-code", "# Searching Code\nUse rg.");
+    const result = preloadSkills(["searching-code"], childCwd);
+    expect(result[0].content).toContain("Searching Code");
+  });
+
+  it("ignores flat markdown files in .agents/skills", () => {
+    const childCwd = join(tmpDir, "packages", "api");
+    mkdirSync(childCwd, { recursive: true });
+    writeFlatSkill(join(tmpDir, ".agents", "skills"), "flat-agent-skill", "should not load");
+    const result = preloadSkills(["flat-agent-skill"], childCwd);
+    expect(result[0].content).toContain("not found");
+  });
+
+  it("prefers nearest project skill over ancestor and global skills", () => {
+    const childCwd = join(tmpDir, "packages", "api");
+    mkdirSync(childCwd, { recursive: true });
+    writeDirectorySkill(join(tmpDir, ".pi", "skills"), "reviewing-code", "ancestor");
+    writeDirectorySkill(join(process.env.PI_CODING_AGENT_DIR!, "skills"), "reviewing-code", "global");
+    writeDirectorySkill(join(childCwd, ".pi", "skills"), "reviewing-code", "nearest");
+    const result = preloadSkills(["reviewing-code"], childCwd);
+    expect(result[0].content).toBe("nearest");
+  });
+
+  it("loads recursively nested Pi-standard skill directories", () => {
+    writeDirectorySkill(join(tmpDir, ".pi", "skills", "dev-tools"), "using-modern-cli", "# Modern CLI\nUse rg.");
+    const result = preloadSkills(["using-modern-cli"], tmpDir);
+    expect(result[0].content).toContain("Modern CLI");
   });
 
   it("loads a .txt skill file", () => {
@@ -103,6 +164,19 @@ describe("preloadSkills", () => {
     writeFileSync(secretFile, "TOP SECRET CONTENT");
     symlinkSync(secretFile, join(dir, "evil-skill.md"));
     const result = preloadSkills(["evil-skill"], tmpDir);
+    expect(result).toHaveLength(1);
+    expect(result[0].content).toContain("not found");
+    expect(result[0].content).not.toContain("TOP SECRET");
+  });
+
+  it("rejects symlinked skill directories", () => {
+    const dir = join(tmpDir, ".pi", "skills");
+    const realSkillDir = join(tmpDir, "real-skill");
+    mkdirSync(realSkillDir, { recursive: true });
+    mkdirSync(dir, { recursive: true });
+    writeFileSync(join(realSkillDir, "SKILL.md"), "TOP SECRET CONTENT");
+    symlinkSync(realSkillDir, join(dir, "evil-dir-skill"));
+    const result = preloadSkills(["evil-dir-skill"], tmpDir);
     expect(result).toHaveLength(1);
     expect(result[0].content).toContain("not found");
     expect(result[0].content).not.toContain("TOP SECRET");


### PR DESCRIPTION
## Why

Pi stores normal skills as `<name>/SKILL.md` under places like `.pi/skills` and `~/.pi/agent/skills`. Subagents only looked for flat files in `.pi/skills` and `~/.pi/skills`, so `skills:` preloading missed the common Pi layout.

## What changed

- Load directory skills from project `.pi/skills` and `.agents/skills` ancestors.
- Load global skills from `$PI_CODING_AGENT_DIR/skills` and `~/.agents/skills`.
- Keep existing flat-file support for `.pi/skills` and legacy `~/.pi/skills`.
- Reject symlinked skill dirs/files. No surprises.
- Update README and tests.

## Tested

```bash
PI_CODING_AGENT_DIR=$(mktemp -d) npm run typecheck
PI_CODING_AGENT_DIR=$(mktemp -d) npm test
PI_CODING_AGENT_DIR=$(mktemp -d) npm run lint
```