### PR TITLE
Set SessionName

### DIFF
--- a/src/agent-manager.ts
+++ b/src/agent-manager.ts
@@ -180,6 +180,7 @@ export class AgentManager {
 
     const promise = runAgent(ctx, type, prompt, {
       pi,
+      agentId: id,
       model: options.model,
       maxTurns: options.maxTurns,
       isolated: options.isolated,

--- a/src/agent-runner.ts
+++ b/src/agent-runner.ts
@@ -88,6 +88,8 @@ export interface ToolActivity {
 export interface RunOptions {
   /** ExtensionAPI instance — used for pi.exec() instead of execSync. */
   pi: ExtensionAPI;
+  /** Manager-assigned id; suffixes session name to disambiguate parallel spawns (e.g. `Explore#a1b2c3d4`). */
+  agentId?: string;
   model?: Model<any>;
   maxTurns?: number;
   signal?: AbortSignal;
@@ -280,7 +282,10 @@ export async function runAgent(
 
   const { session } = await createAgentSession(sessionOpts);
 
-  session.setSessionName(agentConfig?.name ?? type);
+  const baseSessionName = agentConfig?.name ?? type;
+  session.setSessionName(
+    options.agentId ? `${baseSessionName}#${options.agentId.slice(0, 8)}` : baseSessionName,
+  );
 
   // Build disallowed tools set from agent config
   const disallowedSet = agentConfig?.disallowedTools

--- a/src/agent-runner.ts
+++ b/src/agent-runner.ts
@@ -280,6 +280,8 @@ export async function runAgent(
 
   const { session } = await createAgentSession(sessionOpts);
 
+  session.setSessionName(agentConfig?.name ?? type);
+
   // Build disallowed tools set from agent config
   const disallowedSet = agentConfig?.disallowedTools
     ? new Set(agentConfig.disallowedTools)

--- a/test/agent-runner.test.ts
+++ b/test/agent-runner.test.ts
@@ -186,7 +186,21 @@ describe("agent-runner final output capture", () => {
 
     expect(result).toBe("RESUMED");
   });
+
+  it("sets the agent name as session name before binding extensions", async () => {
+    const { session } = createSession("NAMED");
+    createAgentSession.mockResolvedValue({ session });
+
+    await runAgent(ctx, "Explore", "go", { pi });
+
+    expect(session.setSessionName).toHaveBeenCalledWith("Explore");
+    const setOrder = session.setSessionName.mock.invocationCallOrder[0];
+    const bindOrder = session.bindExtensions.mock.invocationCallOrder[0];
+    expect(setOrder).toBeLessThan(bindOrder);
+  });
 });
+
+
 
 // ─── message_end → onAssistantUsage wiring (issue #38) ─────────────────
 // Both runAgent and resumeAgent dispatch usage to the caller via this

--- a/test/agent-runner.test.ts
+++ b/test/agent-runner.test.ts
@@ -91,6 +91,7 @@ function createSession(finalText: string) {
     steer: vi.fn(),
     getActiveToolNames: vi.fn(() => ["read"]),
     setActiveToolsByName: vi.fn(),
+    setSessionName: vi.fn(),
     bindExtensions: vi.fn(async () => {}),
   };
   return { session, listeners };

--- a/test/agent-runner.test.ts
+++ b/test/agent-runner.test.ts
@@ -200,8 +200,6 @@ describe("agent-runner final output capture", () => {
   });
 });
 
-
-
 // ─── message_end → onAssistantUsage wiring (issue #38) ─────────────────
 // Both runAgent and resumeAgent dispatch usage to the caller via this
 // callback. The callback feeds the AgentRecord lifetime accumulator, which

--- a/test/agent-runner.test.ts
+++ b/test/agent-runner.test.ts
@@ -198,6 +198,15 @@ describe("agent-runner final output capture", () => {
     const bindOrder = session.bindExtensions.mock.invocationCallOrder[0];
     expect(setOrder).toBeLessThan(bindOrder);
   });
+
+  it("suffixes the session name with a short agentId so parallel spawns are distinguishable", async () => {
+    const { session } = createSession("NAMED");
+    createAgentSession.mockResolvedValue({ session });
+
+    await runAgent(ctx, "Explore", "go", { pi, agentId: "a1b2c3d4e5f6" });
+
+    expect(session.setSessionName).toHaveBeenCalledWith("Explore#a1b2c3d4");
+  });
 });
 
 // ─── message_end → onAssistantUsage wiring (issue #38) ─────────────────


### PR DESCRIPTION
Set the session name to be able to find out which agent is running in the session in an extension (e.g. agent-guardrails).