### PR TITLE
feat(agent-tool): generate routing guidelines dynamically from agent descriptions

### DIFF
--- a/src/index.ts
+++ b/src/index.ts
@@ -601,6 +601,19 @@ export default function (pi: ExtensionAPI) {
 
   const typeListText = buildTypeListText();
 
+  /** Build routing guidelines dynamically from all available agent descriptions. */
+  const buildGuidelinesText = (): string => {
+    const allNames = [...getDefaultAgentNames(), ...getUserAgentNames()];
+    const routingLines = allNames.map((name) => {
+      const cfg = getAgentConfig(name);
+      const desc = cfg?.description ?? name;
+      return `- Use ${name} for: ${desc.replace(/\.$/, "").toLowerCase()}`;
+    });
+    return routingLines.join("\n");
+  };
+
+  const guidelinesText = buildGuidelinesText();
+
   // Apply persisted settings on startup and emit `subagents:settings_loaded`.
   // Global + project merged; missing → defaults; corrupt file emits a warning
   // to stderr and falls back to defaults.
@@ -650,10 +663,10 @@ Available agent types:
 ${typeListText}
 
 Guidelines:
+Agent selection — pick the most specific type for the task:
+${guidelinesText}
+
 - For parallel work, use run_in_background: true on each agent. Foreground calls run sequentially — only one executes at a time.
-- Use Explore for codebase searches and code understanding.
-- Use Plan for architecture and implementation planning.
-- Use general-purpose for complex tasks that need file editing.
 - Provide clear, detailed prompts so the agent can work autonomously.
 - Agent results are returned as text — summarize them for the user.
 - Use run_in_background for work you don't need immediately. You will be notified when it completes.


### PR DESCRIPTION
The Agent tool currently has hardcoded routing hints in its description ("Use Explore for... Use Plan for..."). This PR makes the routing guidelines dynamic by reading all registered agent configs (default + custom) and generating hints from their descriptions.

**Change:** 1 file, +16/-3

**Before:** Static routing lines for Explore, Plan, general-purpose
**After:** Dynamic guidelines built from `getDefaultAgentNames()` and `getUserAgentNames()`, so custom agents (e.g. worker, reviewer) appear automatically in the LLM's routing hints.

Custom agents with descriptions get `- Use <name> for: <description>` lines. Built-ins without explicit descriptions keep their existing behavior via the default agent configs.