### PR TITLE
fix(invocation-config): explicit model param overrides agent config model

### DIFF
--- a/src/index.ts
+++ b/src/index.ts
@@ -829,7 +829,7 @@ Guidelines:
 
       const resolvedConfig = resolveAgentInvocationConfig(customConfig, params);
 
-      // Resolve model from agent config first; tool-call params only fill gaps.
+      // Resolve model: explicit tool-call param wins, agent config is fallback.
       let model = ctx.model;
       if (resolvedConfig.modelInput) {
         const resolved = resolveModel(resolvedConfig.modelInput, ctx.modelRegistry);

--- a/src/invocation-config.ts
+++ b/src/invocation-config.ts
@@ -24,8 +24,8 @@ export function resolveAgentInvocationConfig(
   isolation?: IsolationMode;
 } {
   return {
-    modelInput: agentConfig?.model ?? params.model,
-    modelFromParams: agentConfig?.model == null && params.model != null,
+    modelInput: params.model ?? agentConfig?.model,
+    modelFromParams: params.model != null,
     thinking: (agentConfig?.thinking ?? params.thinking) as ThinkingLevel | undefined,
     maxTurns: agentConfig?.maxTurns ?? params.max_turns,
     inheritContext: agentConfig?.inheritContext ?? params.inherit_context ?? false,


### PR DESCRIPTION
Previously `resolveAgentInvocationConfig` used `agentConfig?.model ?? params.model` — the agent config's model always won. This meant calling `Agent({ model: "sonnet" })` on an agent configured with `model: haiku` silently used haiku.

This PR flips priority: explicit tool-call params win, agent config is the fallback. The caller's intent at the callsite takes precedence over the agent's default config.

**Changes:** 2 files, +3/-3

- `src/invocation-config.ts`: `params.model ?? agentConfig?.model` instead of `agentConfig?.model ?? params.model`
- `src/index.ts`: updated comment to match

The `modelFromParams` flag is now `params.model != null` (was: `agentConfig?.model == null && params.model != null`), correctly reflecting that any explicit param counts as 'from params.'