### PR TITLE
Allow subagents to habe additional extensions

### DIFF
--- a/src/agent-runner.ts
+++ b/src/agent-runner.ts
@@ -247,7 +247,9 @@ export async function runAgent(
     cwd: effectiveCwd,
     agentDir,
     noExtensions: extensions === false,
-    additionalExtensionPaths: agentConfig?.additionalExtensionPaths,
+    additionalExtensionPaths: extensions !== false
+      ? agentConfig?.additionalExtensionPaths
+      : undefined,
     noSkills,
     noPromptTemplates: true,
     noThemes: true,

--- a/src/agent-runner.ts
+++ b/src/agent-runner.ts
@@ -247,6 +247,7 @@ export async function runAgent(
     cwd: effectiveCwd,
     agentDir,
     noExtensions: extensions === false,
+    additionalExtensionPaths: agentConfig?.additionalExtensionPaths,
     noSkills,
     noPromptTemplates: true,
     noThemes: true,

--- a/src/custom-agents.ts
+++ b/src/custom-agents.ts
@@ -3,6 +3,7 @@
  */
 
 import { existsSync, readdirSync, readFileSync } from "node:fs";
+import { homedir } from "node:os";
 import { basename, join } from "node:path";
 import { getAgentDir, parseFrontmatter } from "@mariozechner/pi-coding-agent";
 import { BUILTIN_TOOL_NAMES } from "./agent-types.js";
@@ -70,6 +71,7 @@ function loadFromDir(dir: string, agents: Map<string, AgentConfig>, source: "pro
       isolation: fm.isolation === "worktree" ? "worktree" : undefined,
       enabled: fm.enabled !== false,  // default true; explicitly false disables
       source,
+      additionalExtensionPaths: parseExtensionPaths(fm.additional_extensions),
     });
   }
 }
@@ -122,6 +124,15 @@ function csvListOptional(val: unknown): string[] | undefined {
 function parseMemory(val: unknown): MemoryScope | undefined {
   if (val === "user" || val === "project" || val === "local") return val;
   return undefined;
+}
+
+/**
+ * Parse additional_extensions field: CSV of paths, ~ expanded to homedir.
+ */
+function parseExtensionPaths(val: unknown): string[] | undefined {
+  const items = parseCsvField(val);
+  if (!items) return undefined;
+  return items.map(p => p.startsWith("~/") ? join(homedir(), p.slice(2)) : p);
 }
 
 /**

--- a/src/custom-agents.ts
+++ b/src/custom-agents.ts
@@ -128,11 +128,16 @@ function parseMemory(val: unknown): MemoryScope | undefined {
 
 /**
  * Parse additional_extensions field: CSV of paths, ~ expanded to homedir.
+ * Relative paths (neither absolute nor tilde-prefixed) are passed through
+ * as-is; the upstream DefaultResourceLoader resolves them relative to cwd.
  */
 function parseExtensionPaths(val: unknown): string[] | undefined {
   const items = parseCsvField(val);
   if (!items) return undefined;
-  return items.map(p => p.startsWith("~/") ? join(homedir(), p.slice(2)) : p);
+  return items.map(p => {
+    if (p.startsWith("~/")) return join(homedir(), p.slice(2));
+    return p;
+  });
 }
 
 /**

--- a/src/types.ts
+++ b/src/types.ts
@@ -53,6 +53,8 @@ export interface AgentConfig {
   enabled?: boolean;
   /** Where this agent was loaded from */
   source?: "default" | "project" | "global";
+  /** Additional extension paths loaded only for this agent (e.g. ~/extensions/my-guard.ts). */
+  additionalExtensionPaths?: string[];
 }
 
 export type JoinMode = 'async' | 'group' | 'smart';

--- a/test/agent-runner.test.ts
+++ b/test/agent-runner.test.ts
@@ -72,6 +72,7 @@ vi.mock("../src/skill-loader.js", () => ({
 }));
 
 import { resumeAgent, runAgent } from "../src/agent-runner.js";
+import { getAgentConfig, getConfig } from "../src/agent-types.js";
 
 function createSession(finalText: string) {
   const listeners: Array<(event: any) => void> = [];
@@ -302,8 +303,6 @@ describe("agent-runner usage callback wiring", () => {
 });
 
 // ─── additionalExtensionPaths wiring ────────────────────────────────────────
-import { getAgentConfig } from "../src/agent-types.js";
-
 describe("agent-runner additionalExtensionPaths wiring", () => {
   it("passes additionalExtensionPaths from agentConfig to DefaultResourceLoader when extensions are enabled", async () => {
     const { session } = createSession("OK");
@@ -324,7 +323,6 @@ describe("agent-runner additionalExtensionPaths wiring", () => {
       additionalExtensionPaths: ["/home/user/extensions/guard.ts"],
     } as any);
     // getConfig must also reflect extensions: true so that extensions !== false
-    const { getConfig } = await import("../src/agent-types.js");
     vi.mocked(getConfig).mockReturnValueOnce({
       displayName: "Explore",
       description: "Explore",
@@ -344,13 +342,30 @@ describe("agent-runner additionalExtensionPaths wiring", () => {
     );
   });
 
-  it("sets noExtensions: true when isolated: true, regardless of additionalExtensionPaths", async () => {
+  it("sets noExtensions: true and suppresses additionalExtensionPaths when isolated: true", async () => {
     const { session } = createSession("OK");
     createAgentSession.mockResolvedValue({ session });
+
+    // Give the agentConfig a non-empty additionalExtensionPaths so the guard
+    // is actually exercised, not just vacuously true.
+    vi.mocked(getAgentConfig).mockReturnValueOnce({
+      name: "Explore",
+      description: "Explore",
+      builtinToolNames: ["read"],
+      extensions: true,
+      skills: false,
+      systemPrompt: "You are Explore.",
+      promptMode: "replace",
+      inheritContext: false,
+      runInBackground: false,
+      isolated: false,
+      additionalExtensionPaths: ["/home/user/extensions/guard.ts"],
+    } as any);
 
     await runAgent(ctx, "Explore", "go", { pi, isolated: true });
 
     const ctorArgs = defaultResourceLoaderCtor.mock.calls[0][0];
     expect(ctorArgs.noExtensions).toBe(true);
+    expect(ctorArgs.additionalExtensionPaths).toBeUndefined();
   });
 });

--- a/test/agent-runner.test.ts
+++ b/test/agent-runner.test.ts
@@ -300,3 +300,57 @@ describe("agent-runner usage callback wiring", () => {
     expect(seen).toEqual([{ reason: "threshold", tokensBefore: 12345 }]);
   });
 });
+
+// ─── additionalExtensionPaths wiring ────────────────────────────────────────
+import { getAgentConfig } from "../src/agent-types.js";
+
+describe("agent-runner additionalExtensionPaths wiring", () => {
+  it("passes additionalExtensionPaths from agentConfig to DefaultResourceLoader when extensions are enabled", async () => {
+    const { session } = createSession("OK");
+    createAgentSession.mockResolvedValue({ session });
+
+    // Provide an agentConfig with extensions enabled and additionalExtensionPaths set
+    vi.mocked(getAgentConfig).mockReturnValueOnce({
+      name: "Explore",
+      description: "Explore",
+      builtinToolNames: ["read"],
+      extensions: true,
+      skills: false,
+      systemPrompt: "You are Explore.",
+      promptMode: "replace",
+      inheritContext: false,
+      runInBackground: false,
+      isolated: false,
+      additionalExtensionPaths: ["/home/user/extensions/guard.ts"],
+    } as any);
+    // getConfig must also reflect extensions: true so that extensions !== false
+    const { getConfig } = await import("../src/agent-types.js");
+    vi.mocked(getConfig).mockReturnValueOnce({
+      displayName: "Explore",
+      description: "Explore",
+      builtinToolNames: ["read"],
+      extensions: true,
+      skills: false,
+      promptMode: "replace",
+    } as any);
+
+    await runAgent(ctx, "Explore", "go", { pi });
+
+    expect(defaultResourceLoaderCtor).toHaveBeenCalledWith(
+      expect.objectContaining({
+        noExtensions: false,
+        additionalExtensionPaths: ["/home/user/extensions/guard.ts"],
+      }),
+    );
+  });
+
+  it("sets noExtensions: true when isolated: true, regardless of additionalExtensionPaths", async () => {
+    const { session } = createSession("OK");
+    createAgentSession.mockResolvedValue({ session });
+
+    await runAgent(ctx, "Explore", "go", { pi, isolated: true });
+
+    const ctorArgs = defaultResourceLoaderCtor.mock.calls[0][0];
+    expect(ctorArgs.noExtensions).toBe(true);
+  });
+});

--- a/test/custom-agents.test.ts
+++ b/test/custom-agents.test.ts
@@ -437,6 +437,57 @@ Bad isolation.`);
     expect(result.get("bad-isolation")!.isolation).toBeUndefined();
   });
 
+  it("parses additional_extensions with ~ expansion", () => {
+    writeAgent("ext-agent", `---
+additional_extensions: ~/extensions/my-guard.ts
+---
+
+Agent with additional extensions.`);
+
+    const result = loadCustomAgents(tmpDir);
+    const agent = result.get("ext-agent")!;
+    const home = require("node:os").homedir();
+    expect(agent.additionalExtensionPaths).toEqual([`${home}/extensions/my-guard.ts`]);
+  });
+
+  it("parses multiple additional_extensions via CSV", () => {
+    writeAgent("multi-ext", `---
+additional_extensions: ~/extensions/a.ts, ~/extensions/b.ts
+---
+
+Multiple extensions.`);
+
+    const result = loadCustomAgents(tmpDir);
+    const agent = result.get("multi-ext")!;
+    const home = require("node:os").homedir();
+    expect(agent.additionalExtensionPaths).toEqual([
+      `${home}/extensions/a.ts`,
+      `${home}/extensions/b.ts`,
+    ]);
+  });
+
+  it("returns undefined for additionalExtensionPaths when field is omitted", () => {
+    writeAgent("no-ext", `---
+description: No extra extensions
+---
+
+No additional extensions.`);
+
+    const result = loadCustomAgents(tmpDir);
+    expect(result.get("no-ext")!.additionalExtensionPaths).toBeUndefined();
+  });
+
+  it("passes through absolute paths in additional_extensions unchanged", () => {
+    writeAgent("abs-ext", `---
+additional_extensions: /absolute/path/ext.ts
+---
+
+Absolute extension path.`);
+
+    const result = loadCustomAgents(tmpDir);
+    expect(result.get("abs-ext")!.additionalExtensionPaths).toEqual(["/absolute/path/ext.ts"]);
+  });
+
   it("honors PI_CODING_AGENT_DIR for global custom agent discovery", () => {
     const altAgentDir = mkdtempSync(join(tmpdir(), "pi-alt-agent-"));
     const originalEnv = process.env.PI_CODING_AGENT_DIR;

--- a/test/custom-agents.test.ts
+++ b/test/custom-agents.test.ts
@@ -1,5 +1,5 @@
 import { mkdirSync, mkdtempSync, rmSync, writeFileSync } from "node:fs";
-import { tmpdir } from "node:os";
+import { homedir, tmpdir } from "node:os";
 import { join } from "node:path";
 import { afterEach, beforeEach, describe, expect, it } from "vitest";
 import { BUILTIN_TOOL_NAMES } from "../src/agent-types.js";
@@ -446,8 +446,7 @@ Agent with additional extensions.`);
 
     const result = loadCustomAgents(tmpDir);
     const agent = result.get("ext-agent")!;
-    const home = require("node:os").homedir();
-    expect(agent.additionalExtensionPaths).toEqual([`${home}/extensions/my-guard.ts`]);
+    expect(agent.additionalExtensionPaths).toEqual([`${homedir()}/extensions/my-guard.ts`]);
   });
 
   it("parses multiple additional_extensions via CSV", () => {
@@ -459,10 +458,9 @@ Multiple extensions.`);
 
     const result = loadCustomAgents(tmpDir);
     const agent = result.get("multi-ext")!;
-    const home = require("node:os").homedir();
     expect(agent.additionalExtensionPaths).toEqual([
-      `${home}/extensions/a.ts`,
-      `${home}/extensions/b.ts`,
+      `${homedir()}/extensions/a.ts`,
+      `${homedir()}/extensions/b.ts`,
     ]);
   });
 


### PR DESCRIPTION
Allow the use of additional non global extensions via the md files.
e.g.:

```
---
name: tdd-builder
description: Implements a slice
tools: read, write, edit, bash
additional_extensions: ~/extensions/tdd-shared-guard.ts, ~/extensions/tdd-builder-guard.ts
---
```