### PR TITLE
fix(nudge): route completion notifications through sendUserMessage to fire before_agent_start

### DIFF
--- a/src/index.ts
+++ b/src/index.ts
@@ -287,19 +287,38 @@ export default function (pi: ExtensionAPI) {
     }
   }
 
-  // ---- Individual nudge helper (async join mode) ----
+  // ---- Completion nudge delivery ----
+  //
+  // Do not use sendMessage({ triggerTurn: true }): it calls agent.prompt() directly,
+  // bypassing AgentSession.prompt() and skipping before_agent_start. Extensions that
+  // rely on before_agent_start for per-turn setup will cause the provider to reject
+  // the turn with an error and the orchestrator goes silent.
+  //
+  // When idle: display the notification widget, then trigger via sendUserMessage() so
+  // AgentSession.prompt() is called and before_agent_start fires.
+  // When streaming: queue locally and flush automatically in agent_end once idle.
+
+  const queuedCompletionNudges: Array<{ content: string; details: NotificationDetails }> = [];
+
+  function deliverCompletionNudge(content: string, details: NotificationDetails) {
+    if (currentCtx?.isIdle?.() === true) {
+      pi.sendMessage<NotificationDetails>(
+        { customType: "subagent-notification", content, display: true, details }
+      );
+      pi.sendUserMessage("Background subagent completed. Review the notification above and continue.");
+    } else {
+      queuedCompletionNudges.push({ content, details });
+    }
+  }
+
   function emitIndividualNudge(record: AgentRecord) {
     if (record.resultConsumed) return;  // re-check at send time
-
     const notification = formatTaskNotification(record, 500);
     const footer = record.outputFile ? `\nFull transcript available at: ${record.outputFile}` : '';
-
-    pi.sendMessage<NotificationDetails>({
-      customType: "subagent-notification",
-      content: notification + footer,
-      display: true,
-      details: buildNotificationDetails(record, 500, agentActivity.get(record.id)),
-    }, { deliverAs: "followUp", triggerTurn: true });
+    deliverCompletionNudge(
+      notification + footer,
+      buildNotificationDetails(record, 500, agentActivity.get(record.id))
+    );
   }
 
   function sendIndividualNudge(record: AgentRecord) {
@@ -331,12 +350,10 @@ export default function (pi: ExtensionAPI) {
           details.others = rest.map(r => buildNotificationDetails(r, 300, agentActivity.get(r.id)));
         }
 
-        pi.sendMessage<NotificationDetails>({
-          customType: "subagent-notification",
-          content: `Background agent group completed: ${label}\n\n${notifications}\n\nUse get_subagent_result for full output.`,
-          display: true,
-          details,
-        }, { deliverAs: "followUp", triggerTurn: true });
+        deliverCompletionNudge(
+          `Background agent group completed: ${label}\n\n${notifications}\n\nUse get_subagent_result for full output.`,
+          details
+        );
       });
       widget.update();
     },
@@ -486,6 +503,16 @@ export default function (pi: ExtensionAPI) {
 
   // On shutdown, abort all agents immediately and clean up.
   // If the session is going down, there's nothing left to consume agent results.
+  // Flush queued completion nudges when the orchestrator becomes idle.
+  pi.on("agent_end", async (_event, ctx) => {
+    currentCtx = ctx;
+    if (ctx.isIdle?.() === true && queuedCompletionNudges.length > 0) {
+      for (const nudge of queuedCompletionNudges.splice(0)) {
+        deliverCompletionNudge(nudge.content, nudge.details);
+      }
+    }
+  });
+
   pi.on("session_shutdown", async () => {
     unsubSpawnRpc();
     unsubStopRpc();


### PR DESCRIPTION
## Problem

`sendMessage({ triggerTurn: true })` calls `agent.prompt()` directly on the underlying SDK agent, bypassing `AgentSession.prompt()` and therefore the `before_agent_start` extension event.

Extensions that rely on `before_agent_start` for per-turn setup (for example, injecting billing or auth context into the provider request) will fail to fire when the orchestrator turn is triggered this way. The result is that the provider rejects the turn with an error and the orchestrator goes silent after a background agent completes. The user has to manually type something to recover.

This happens in both cases:
- **Orchestrator idle**: `sendMessage({ triggerTurn: true })` calls `agent.prompt()` directly, no `before_agent_start`.
- **Orchestrator streaming**: `deliverAs: "followUp"` queues a continuation via `runAgentLoopContinue`, which also skips `before_agent_start`.

## Fix

When the orchestrator is idle, send the notification widget and then call `pi.sendUserMessage()`. This goes through `AgentSession.prompt()`, which fires `before_agent_start` correctly.

When the orchestrator is streaming, queue the notification with `deliverAs: "nextTurn"` so it is included in the next user-initiated turn, which fires `before_agent_start` naturally. The pi-subagents widget already provides immediate visual feedback in the streaming case.