### PR TITLE
feat(skills): add Pi-standard skill layout support

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -7,6 +7,23 @@ and this project adheres to [Semantic Versioning](https://semver.org/spec/v2.0.0
 
 ## [Unreleased]
 
+> **Heads-up — behavior changes in skill preloading:**
+> - **`.txt` and extensionless flat skill files are no longer loaded.** Only `<name>.md` flat files and `<name>/SKILL.md` directory skills resolve now. Rename any `<name>.txt` or extensionless skill files to `<name>.md`.
+
+### Added
+- **Pi-standard `<name>/SKILL.md` directory layout** is now discovered alongside flat `<name>.md` files. Top-level and nested matches both resolve via BFS — for skill `foo`, the loader checks `<root>/foo/SKILL.md`, then recursively descends looking for `*/.../foo/SKILL.md`. Recursion skips dotfile directories and `node_modules`; a directory that itself contains `SKILL.md` is treated as a single skill (Pi's "skills don't nest" rule).
+- **Five discovery roots**, checked in precedence order:
+  - `<cwd>/.pi/skills/` (project, Pi)
+  - `<cwd>/.agents/skills/` (project, [Agent Skills spec](https://agentskills.io/integrate-skills))
+  - `$PI_CODING_AGENT_DIR/skills/` — default `~/.pi/agent/skills/` (user, Pi)
+  - `~/.agents/skills/` (user, Agent Skills spec)
+  - `~/.pi/skills/` (legacy global, kept for backward compatibility)
+- **Symlink rejection broadened** to the new layouts: symlinked skill roots, nested skill directories, and `SKILL.md` files inside otherwise-real directories are all rejected (intentional deviation from Pi, which follows symlinks).
+- **Deterministic traversal order** — entries are sorted byte-order so collisions resolve identically across filesystems. Pi's iteration order is `readdirSync`-dependent.
+
+### Changed
+- **`.txt` and extensionless flat skill files are no longer loaded.** Pi only supports `.md`; we now match. **Migration:** rename any `<name>.txt` / `<name>` skill files to `<name>.md`.
+
 ## [0.7.1] - 2026-05-07
 
 > **Heads-up — behavior change:**

--- a/README.md
+++ b/README.md
@@ -25,7 +25,7 @@ https://github.com/user-attachments/assets/8685261b-9338-4fea-8dfe-1c590d5df543
 - **Context inheritance** — optionally fork the parent conversation into a sub-agent so it knows what's been discussed
 - **Persistent agent memory** — three scopes (project, local, user) with automatic read-only fallback for agents without write tools
 - **Git worktree isolation** — run agents in isolated repo copies; changes auto-committed to branches on completion
-- **Skill preloading** — inject named skill files from `.pi/skills/` into agent system prompts
+- **Skill preloading** — inject named skills into agent system prompts, discovered from `.pi/skills/`, `.agents/skills/`, and global locations (Pi-standard `<name>/SKILL.md` directory layout supported)
 - **Tool denylist** — block specific tools via `disallowed_tools` frontmatter
 - **Styled completion notifications** — background agent results render as themed, compact notification boxes (icon, stats, result preview) instead of raw XML. Expandable to show full output. Group completions render each agent individually
 - **Event bus** — lifecycle events (`subagents:created`, `started`, `completed`, `failed`, `steered`, `compacted`) emitted via `pi.events`, enabling other extensions to react to sub-agent activity
@@ -195,7 +195,7 @@ All fields are optional — sensible defaults for everything.
 | `display_name` | — | Display name for UI (e.g. widget, agent list) |
 | `tools` | all 7 | Comma-separated built-in tools: read, bash, edit, write, grep, find, ls. `none` for no tools |
 | `extensions` | `true` | Inherit MCP/extension tools. `false` to disable |
-| `skills` | `true` | Inherit skills from parent. Can be a comma-separated list of skill names to preload from `.pi/skills/` |
+| `skills` | `true` | Inherit skills from parent. Can be a comma-separated list of skill names to preload (see [Skill Preloading](#skill-preloading) for discovery locations) |
 | `memory` | — | Persistent agent memory scope: `project`, `local`, or `user`. Auto-detects read-only agents |
 | `disallowed_tools` | — | Comma-separated tools to deny even if extensions provide them |
 | `isolation` | — | Set to `worktree` to run in an isolated git worktree |
@@ -457,7 +457,7 @@ If the worktree cannot be created (not a git repo, no commits, or `git worktree 
 
 ## Skill Preloading
 
-Skills can be preloaded as named files from `.pi/skills/` or `~/.pi/skills/`:
+Skills can be preloaded by name and injected into the agent's system prompt:
 
 ```yaml
 ---
@@ -465,7 +465,25 @@ skills: api-conventions, error-handling
 ---
 ```
 
-Skill files (`.md`, `.txt`, or extensionless) are read and injected into the agent's system prompt. Project-level skills take priority over global ones. Symlinked skill files are rejected for security.
+**Discovery roots** (checked in this order, first match wins):
+
+| Scope | Path | Source |
+|---|---|---|
+| Project | `<cwd>/.pi/skills/` | Pi-standard |
+| Project | `<cwd>/.agents/skills/` | [Agent Skills spec](https://agentskills.io/integrate-skills) |
+| User | `$PI_CODING_AGENT_DIR/skills/` (default `~/.pi/agent/skills/`) | Pi-standard |
+| User | `~/.agents/skills/` | [Agent Skills spec](https://agentskills.io/integrate-skills) |
+| User | `~/.pi/skills/` | Legacy (pre-Pi) |
+
+**Per root, a skill named `foo` resolves to the first of:**
+
+- `<root>/foo.md` — flat file at the top level
+- `<root>/foo/SKILL.md` — directory skill (top-level)
+- `<root>/*/.../foo/SKILL.md` — directory skill, found by recursive descent
+
+Recursion skips dotfile directories and `node_modules`. A directory that itself contains a `SKILL.md` is treated as a single skill — we don't descend into it. Traversal is byte-order sorted for deterministic resolution across filesystems.
+
+**Security:** symlinks are rejected at every layer (root, flat file, skill directory, `SKILL.md` inside a skill directory) — intentional deviation from Pi, which follows symlinks. Skill names with path-traversal characters (`..`, `/`, `\`, spaces, leading dot, >128 chars) are rejected.
 
 ## Tool Denylist
 
@@ -494,7 +512,7 @@ src/
   group-join.ts       # Group join manager: batched completion notifications with timeout
   custom-agents.ts    # Load user-defined agents from .pi/agents/*.md
   memory.ts           # Persistent agent memory (resolve, read, build prompt blocks)
-  skill-loader.ts     # Preload skill files from .pi/skills/
+  skill-loader.ts     # Preload skills (Pi-standard + Agent Skills spec layouts)
   output-file.ts      # Streaming output file transcripts for agent sessions
   worktree.ts         # Git worktree isolation (create, cleanup, prune)
   prompts.ts          # Config-driven system prompt builder

--- a/src/skill-loader.ts
+++ b/src/skill-loader.ts
@@ -1,79 +1,102 @@
 /**
- * skill-loader.ts — Preload specific skill files and inject their content into the system prompt.
+ * skill-loader.ts — Preload named skills.
  *
- * When skills is a string[], reads each named skill from .pi/skills/ or ~/.pi/skills/
- * and returns their content for injection into the agent's system prompt.
+ * Roots, in precedence order:
+ *   - <cwd>/.pi/skills           (project, Pi's standard)
+ *   - <cwd>/.agents/skills       (project, cross-tool Agent Skills spec — https://agentskills.io)
+ *   - getAgentDir()/skills       (user, default ~/.pi/agent/skills — Pi's standard)
+ *   - ~/.agents/skills           (user, cross-tool Agent Skills spec)
+ *   - ~/.pi/skills               (legacy global, pre-Pi)
+ *
+ * Layout per root:
+ *   - <root>/<name>.md            (flat file at the top level)
+ *   - <root>/.../<name>/SKILL.md  (directory skill, may be nested — Pi's standard)
+ *
+ * Recursion skips dotfile entries and node_modules. A directory that itself contains
+ * SKILL.md is a skill — we don't descend into it (Pi: skills don't nest).
+ *
+ * Symlinks are rejected for security (deviation from Pi, which follows them).
  */
 
+import type { Dirent } from "node:fs";
+import { existsSync, readdirSync } from "node:fs";
 import { homedir } from "node:os";
 import { join } from "node:path";
-import { isUnsafeName, safeReadFile } from "./memory.js";
+import { getAgentDir } from "@mariozechner/pi-coding-agent";
+import { isSymlink, isUnsafeName, safeReadFile } from "./memory.js";
 
 export interface PreloadedSkill {
   name: string;
   content: string;
 }
 
-/**
- * Attempt to load named skills from project and global skill directories.
- * Looks for: <dir>/<name>.md, <dir>/<name>.txt, <dir>/<name>
- *
- * @param skillNames  List of skill names to preload.
- * @param cwd         Working directory for project-level skills.
- * @returns Array of loaded skills (missing skills are skipped with a warning comment).
- */
 export function preloadSkills(skillNames: string[], cwd: string): PreloadedSkill[] {
-  const results: PreloadedSkill[] = [];
-
-  for (const name of skillNames) {
-    // Unlike memory (which throws on unsafe names because it's part of agent setup),
-    // skills are optional — skip gracefully to avoid blocking agent startup.
-    if (isUnsafeName(name)) {
-      results.push({ name, content: `(Skill "${name}" skipped: name contains path traversal characters)` });
-      continue;
-    }
-    const content = findAndReadSkill(name, cwd);
-    if (content !== undefined) {
-      results.push({ name, content });
-    } else {
-      // Include a note about missing skills so the agent knows it was requested but not found
-      results.push({ name, content: `(Skill "${name}" not found in .pi/skills/ or ~/.pi/skills/)` });
-    }
-  }
-
-  return results;
+  return skillNames.map((name) => ({ name, content: loadSkillContent(name, cwd) }));
 }
 
-/**
- * Search for a skill file in project and global directories.
- * Project-level takes priority over global.
- */
-function findAndReadSkill(name: string, cwd: string): string | undefined {
-  const projectDir = join(cwd, ".pi", "skills");
-  const globalDir = join(homedir(), ".pi", "skills");
-
-  // Try project first, then global
-  for (const dir of [projectDir, globalDir]) {
-    const content = tryReadSkillFile(dir, name);
+function loadSkillContent(name: string, cwd: string): string {
+  if (isUnsafeName(name)) {
+    return `(Skill "${name}" skipped: name contains path traversal characters)`;
+  }
+  const roots = [
+    join(cwd, ".pi", "skills"), // project — Pi standard
+    join(cwd, ".agents", "skills"), // project — Agent Skills spec
+    join(getAgentDir(), "skills"), // user — Pi standard
+    join(homedir(), ".agents", "skills"), // user — Agent Skills spec
+    join(homedir(), ".pi", "skills"), // legacy global, pre-Pi
+  ];
+  for (const root of roots) {
+    const content = findInRoot(root, name);
     if (content !== undefined) return content;
   }
-
-  return undefined;
+  return `(Skill "${name}" not found in .pi/skills/, .agents/skills/, or global skill locations)`;
 }
 
-/**
- * Try to read a skill file from a directory.
- * Tries extensions in order: .md, .txt, (no extension)
- */
-function tryReadSkillFile(dir: string, name: string): string | undefined {
-  const extensions = [".md", ".txt", ""];
+function findInRoot(root: string, name: string): string | undefined {
+  if (isSymlink(root)) return undefined; // reject symlinked roots entirely
+  const flat = safeReadFile(join(root, `${name}.md`))?.trim();
+  if (flat !== undefined) return flat;
+  return findSkillDirectory(root, name);
+}
 
-  for (const ext of extensions) {
-    const path = join(dir, name + ext);
-    // safeReadFile rejects symlinks to prevent reading arbitrary files
-    const content = safeReadFile(path);
-    if (content !== undefined) return content.trim();
+/** BFS under `root` for a directory named `name` containing `SKILL.md`. Pi-conforming filters. */
+function findSkillDirectory(root: string, name: string): string | undefined {
+  if (!existsSync(root)) return undefined;
+  const queue: string[] = [root];
+
+  while (queue.length > 0) {
+    const current = queue.shift();
+    if (current === undefined) continue;
+
+    let entries: Dirent<string>[];
+    try {
+      entries = readdirSync(current, { withFileTypes: true });
+    } catch {
+      continue;
+    }
+
+    // Deterministic byte-order traversal — locale-independent.
+    entries.sort((a, b) => (a.name < b.name ? -1 : a.name > b.name ? 1 : 0));
+
+    for (const entry of entries) {
+      if (!entry.isDirectory()) continue;
+      if (entry.name.startsWith(".") || entry.name === "node_modules") continue;
+
+      // Symlinked dirs already filtered by entry.isDirectory() — Dirent uses lstat semantics.
+      const path = join(current, entry.name);
+      const skillMd = join(path, "SKILL.md");
+      const isSkillDir = existsSync(skillMd);
+
+      if (isSkillDir) {
+        if (entry.name === name) {
+          const content = safeReadFile(skillMd)?.trim();
+          if (content !== undefined) return content;
+        }
+        continue; // Pi rule: skills don't nest — don't descend into a skill dir
+      }
+
+      queue.push(path);
+    }
   }
-
   return undefined;
 }

--- a/test/skill-loader.test.ts
+++ b/test/skill-loader.test.ts
@@ -6,117 +6,232 @@ import { preloadSkills } from "../src/skill-loader.js";
 
 describe("preloadSkills", () => {
   let tmpDir: string;
+  let originalAgentDir: string | undefined;
 
   beforeEach(() => {
     tmpDir = mkdtempSync(join(tmpdir(), "pi-skill-test-"));
+    originalAgentDir = process.env.PI_CODING_AGENT_DIR;
+    process.env.PI_CODING_AGENT_DIR = join(tmpDir, "user-agent-dir");
   });
 
   afterEach(() => {
+    if (originalAgentDir === undefined) {
+      delete process.env.PI_CODING_AGENT_DIR;
+    } else {
+      process.env.PI_CODING_AGENT_DIR = originalAgentDir;
+    }
     rmSync(tmpDir, { recursive: true, force: true });
   });
 
-  function writeSkill(name: string, content: string, ext = ".md") {
-    const dir = join(tmpDir, ".pi", "skills");
+  const projectRoot = () => join(tmpDir, ".pi", "skills");
+  const globalRoot = () => join(process.env.PI_CODING_AGENT_DIR!, "skills");
+
+  function writeFlat(root: string, name: string, content: string, ext = ".md") {
+    mkdirSync(root, { recursive: true });
+    writeFileSync(join(root, name + ext), content);
+  }
+
+  function writeSkillDir(root: string, name: string, content: string) {
+    const dir = join(root, name);
     mkdirSync(dir, { recursive: true });
-    writeFileSync(join(dir, name + ext), content);
+    writeFileSync(join(dir, "SKILL.md"), content);
   }
 
   it("returns empty array for empty skill list", () => {
-    const result = preloadSkills([], tmpDir);
-    expect(result).toEqual([]);
+    expect(preloadSkills([], tmpDir)).toEqual([]);
   });
 
-  it("loads a .md skill file", () => {
-    writeSkill("api-conventions", "# API Conventions\nUse REST.");
+  it("loads a top-level flat .md skill from project", () => {
+    writeFlat(projectRoot(), "api-conventions", "# API Conventions");
     const result = preloadSkills(["api-conventions"], tmpDir);
-    expect(result).toHaveLength(1);
-    expect(result[0].name).toBe("api-conventions");
     expect(result[0].content).toContain("API Conventions");
   });
 
-  it("loads a .txt skill file", () => {
-    writeSkill("error-handling", "Handle errors gracefully.", ".txt");
-    const result = preloadSkills(["error-handling"], tmpDir);
-    expect(result).toHaveLength(1);
-    expect(result[0].content).toContain("Handle errors gracefully");
+  it("ignores .txt files (only .md is supported)", () => {
+    writeFlat(projectRoot(), "error-handling", "should not load", ".txt");
+    expect(preloadSkills(["error-handling"], tmpDir)[0].content).toContain("not found");
   });
 
-  it("prefers .md over .txt", () => {
-    writeSkill("dual", "MD content", ".md");
-    writeSkill("dual", "TXT content", ".txt");
-    const result = preloadSkills(["dual"], tmpDir);
-    expect(result[0].content).toBe("MD content");
+  it("ignores extensionless files (only .md is supported)", () => {
+    writeFlat(projectRoot(), "bare-skill", "should not load", "");
+    expect(preloadSkills(["bare-skill"], tmpDir)[0].content).toContain("not found");
   });
 
-  it("returns fallback message for missing skills", () => {
+  it("loads a top-level <name>/SKILL.md from project", () => {
+    writeSkillDir(projectRoot(), "writing-go", "# Writing Go");
+    expect(preloadSkills(["writing-go"], tmpDir)[0].content).toContain("Writing Go");
+  });
+
+  it("loads a top-level <name>/SKILL.md from getAgentDir()/skills", () => {
+    writeSkillDir(globalRoot(), "writing-python", "# Writing Python");
+    expect(preloadSkills(["writing-python"], tmpDir)[0].content).toContain("Writing Python");
+  });
+
+  it("loads a flat .md from getAgentDir()/skills", () => {
+    writeFlat(globalRoot(), "shell-tips", "use rg");
+    expect(preloadSkills(["shell-tips"], tmpDir)[0].content).toBe("use rg");
+  });
+
+  it("finds nested <subdir>/<name>/SKILL.md in getAgentDir()/skills", () => {
+    writeSkillDir(join(globalRoot(), "dev-tools"), "using-modern-cli", "# Modern CLI");
+    expect(preloadSkills(["using-modern-cli"], tmpDir)[0].content).toContain("Modern CLI");
+  });
+
+  it("loads <name>/SKILL.md from project .agents/skills (Agent Skills spec)", () => {
+    writeSkillDir(join(tmpDir, ".agents", "skills"), "writing-rust", "# Writing Rust");
+    expect(preloadSkills(["writing-rust"], tmpDir)[0].content).toContain("Writing Rust");
+  });
+
+  it("prefers .pi/skills over .agents/skills in the same project", () => {
+    writeSkillDir(projectRoot(), "shared", "from-pi");
+    writeSkillDir(join(tmpDir, ".agents", "skills"), "shared", "from-agents");
+    expect(preloadSkills(["shared"], tmpDir)[0].content).toBe("from-pi");
+  });
+
+  it("finds nested <subdir>/<name>/SKILL.md", () => {
+    writeSkillDir(join(projectRoot(), "dev-tools"), "using-modern-cli", "# Modern CLI");
+    expect(preloadSkills(["using-modern-cli"], tmpDir)[0].content).toContain("Modern CLI");
+  });
+
+  it("prefers project over global", () => {
+    writeSkillDir(projectRoot(), "shared", "from-project");
+    writeSkillDir(globalRoot(), "shared", "from-global");
+    expect(preloadSkills(["shared"], tmpDir)[0].content).toBe("from-project");
+  });
+
+  it("prefers shallower match (lex tie-break)", () => {
+    // Different depths — shallower wins.
+    writeSkillDir(join(projectRoot(), "z-deep", "nested"), "collide", "deep");
+    writeSkillDir(join(projectRoot(), "a-shallow"), "collide", "shallow");
+    expect(preloadSkills(["collide"], tmpDir)[0].content).toBe("shallow");
+
+    // Same depth — alphabetical wins.
+    writeSkillDir(join(projectRoot(), "b-sibling"), "tie", "b");
+    writeSkillDir(join(projectRoot(), "a-sibling"), "tie", "a");
+    expect(preloadSkills(["tie"], tmpDir)[0].content).toBe("a");
+  });
+
+  it("descends past a same-named dir that lacks SKILL.md to find a deeper match", () => {
+    // .pi/skills/foo exists empty; .pi/skills/foo/inner/foo/SKILL.md is the real skill.
+    mkdirSync(join(projectRoot(), "foo"), { recursive: true });
+    writeSkillDir(join(projectRoot(), "foo", "inner"), "foo", "deeper");
+    expect(preloadSkills(["foo"], tmpDir)[0].content).toBe("deeper");
+  });
+
+  it("does not descend into a sibling skill directory (skills don't nest)", () => {
+    // .pi/skills/outer is itself a skill; .pi/skills/outer/target/SKILL.md must NOT be found.
+    writeSkillDir(projectRoot(), "outer", "outer-skill");
+    writeSkillDir(join(projectRoot(), "outer"), "target", "hidden");
+    expect(preloadSkills(["target"], tmpDir)[0].content).toContain("not found");
+  });
+
+  it("skips node_modules during recursion", () => {
+    writeSkillDir(join(projectRoot(), "node_modules", "some-pkg"), "leaked", "should not load");
+    expect(preloadSkills(["leaked"], tmpDir)[0].content).toContain("not found");
+  });
+
+  it("skips dotfile directories during recursion", () => {
+    writeSkillDir(join(projectRoot(), ".hidden-tree"), "buried", "should not load");
+    expect(preloadSkills(["buried"], tmpDir)[0].content).toContain("not found");
+  });
+
+  it("returns fallback for missing skills", () => {
     const result = preloadSkills(["nonexistent"], tmpDir);
-    expect(result).toHaveLength(1);
     expect(result[0].name).toBe("nonexistent");
     expect(result[0].content).toContain("not found");
   });
 
   it("loads multiple skills", () => {
-    writeSkill("skill-a", "Content A");
-    writeSkill("skill-b", "Content B");
-    const result = preloadSkills(["skill-a", "skill-b"], tmpDir);
-    expect(result).toHaveLength(2);
-    expect(result[0].content).toContain("Content A");
-    expect(result[1].content).toContain("Content B");
-  });
-
-  it("loads skills without extension", () => {
-    writeSkill("bare-skill", "Bare content", "");
-    const result = preloadSkills(["bare-skill"], tmpDir);
-    expect(result[0].content).toBe("Bare content");
+    writeFlat(projectRoot(), "a", "Content A");
+    writeSkillDir(projectRoot(), "b", "Content B");
+    const result = preloadSkills(["a", "b"], tmpDir);
+    expect(result.map((r) => r.content)).toEqual(["Content A", expect.stringContaining("Content B")]);
   });
 
   it("skips skill names with path traversal (..)", () => {
-    const result = preloadSkills(["../../etc/passwd"], tmpDir);
-    expect(result).toHaveLength(1);
-    expect(result[0].content).toContain("path traversal");
+    expect(preloadSkills(["../../etc/passwd"], tmpDir)[0].content).toContain("path traversal");
   });
 
   it("skips skill names with forward slash", () => {
-    const result = preloadSkills(["sub/dir"], tmpDir);
-    expect(result).toHaveLength(1);
-    expect(result[0].content).toContain("path traversal");
+    expect(preloadSkills(["sub/dir"], tmpDir)[0].content).toContain("path traversal");
   });
 
   it("skips skill names with backslash", () => {
-    const result = preloadSkills(["sub\\dir"], tmpDir);
-    expect(result).toHaveLength(1);
-    expect(result[0].content).toContain("path traversal");
+    expect(preloadSkills(["sub\\dir"], tmpDir)[0].content).toContain("path traversal");
+  });
+
+  it("skips skill names with spaces", () => {
+    expect(preloadSkills(["my skill"], tmpDir)[0].content).toContain("path traversal");
+  });
+
+  it("skips skill names starting with a dot", () => {
+    expect(preloadSkills([".hidden"], tmpDir)[0].content).toContain("path traversal");
+  });
+
+  it("skips empty skill names", () => {
+    expect(preloadSkills([""], tmpDir)[0].content).toContain("path traversal");
+  });
+
+  it("skips skill names exceeding 128 characters", () => {
+    const longName = "a".repeat(129);
+    expect(preloadSkills([longName], tmpDir)[0].content).toContain("path traversal");
   });
 
   it("loads valid skills alongside skipped unsafe ones", () => {
-    writeSkill("legit", "Good content");
+    writeFlat(projectRoot(), "legit", "Good content");
     const result = preloadSkills(["../evil", "legit"], tmpDir);
-    expect(result).toHaveLength(2);
     expect(result[0].content).toContain("path traversal");
-    expect(result[1].content).toContain("Good content");
+    expect(result[1].content).toBe("Good content");
   });
 
-  it("rejects symlinked skill files", () => {
-    const dir = join(tmpDir, ".pi", "skills");
-    mkdirSync(dir, { recursive: true });
-    const secretFile = join(tmpDir, "secret.md");
-    writeFileSync(secretFile, "TOP SECRET CONTENT");
-    symlinkSync(secretFile, join(dir, "evil-skill.md"));
-    const result = preloadSkills(["evil-skill"], tmpDir);
-    expect(result).toHaveLength(1);
+  it("rejects symlinked flat .md files", () => {
+    mkdirSync(projectRoot(), { recursive: true });
+    const secret = join(tmpDir, "secret.md");
+    writeFileSync(secret, "TOP SECRET");
+    symlinkSync(secret, join(projectRoot(), "evil.md"));
+    const result = preloadSkills(["evil"], tmpDir);
     expect(result[0].content).toContain("not found");
     expect(result[0].content).not.toContain("TOP SECRET");
   });
 
-  it("skips names with spaces (whitelist validation)", () => {
-    const result = preloadSkills(["my skill"], tmpDir);
-    expect(result).toHaveLength(1);
-    expect(result[0].content).toContain("path traversal");
+  it("rejects symlinked skill directories", () => {
+    mkdirSync(projectRoot(), { recursive: true });
+    const realDir = join(tmpDir, "real-skill");
+    mkdirSync(realDir, { recursive: true });
+    writeFileSync(join(realDir, "SKILL.md"), "TOP SECRET");
+    symlinkSync(realDir, join(projectRoot(), "evil-dir"));
+    const result = preloadSkills(["evil-dir"], tmpDir);
+    expect(result[0].content).toContain("not found");
+    expect(result[0].content).not.toContain("TOP SECRET");
   });
 
-  it("skips names starting with dot", () => {
-    const result = preloadSkills([".hidden"], tmpDir);
-    expect(result).toHaveLength(1);
-    expect(result[0].content).toContain("path traversal");
+  it("rejects symlinked skill root", () => {
+    // <cwd>/.pi/skills → symlink to a directory that holds real-looking skills.
+    const realRoot = join(tmpDir, "elsewhere");
+    mkdirSync(realRoot, { recursive: true });
+    writeFileSync(join(realRoot, "leaked-flat.md"), "TOP SECRET FLAT");
+    mkdirSync(join(realRoot, "leaked-dir"), { recursive: true });
+    writeFileSync(join(realRoot, "leaked-dir", "SKILL.md"), "TOP SECRET DIR");
+    mkdirSync(join(tmpDir, ".pi"), { recursive: true });
+    symlinkSync(realRoot, projectRoot());
+
+    const flatResult = preloadSkills(["leaked-flat"], tmpDir)[0].content;
+    expect(flatResult).toContain("not found");
+    expect(flatResult).not.toContain("TOP SECRET");
+
+    const dirResult = preloadSkills(["leaked-dir"], tmpDir)[0].content;
+    expect(dirResult).toContain("not found");
+    expect(dirResult).not.toContain("TOP SECRET");
+  });
+
+  it("rejects symlinked SKILL.md inside a real skill directory", () => {
+    const skillDir = join(projectRoot(), "evil-inner");
+    mkdirSync(skillDir, { recursive: true });
+    const secret = join(tmpDir, "secret.md");
+    writeFileSync(secret, "TOP SECRET");
+    symlinkSync(secret, join(skillDir, "SKILL.md"));
+    const result = preloadSkills(["evil-inner"], tmpDir);
+    expect(result[0].content).toContain("not found");
+    expect(result[0].content).not.toContain("TOP SECRET");
   });
 });


### PR DESCRIPTION
  Adds discovery for Pi's <name>/SKILL.md directory layout (top-level and
  nested) and Pi's user-global root at getAgentDir()/skills (defaults to
  ~/.pi/agent/skills, honors $PI_CODING_AGENT_DIR). Subagents previously
  only found flat <name>.md / .txt / extensionless files in <cwd>/.pi/skills
  and ~/.pi/skills, missing the layout Pi itself uses.

  Recursion follows Pi's filters: skips dotfile directories and node_modules,
  and treats any directory containing SKILL.md as a single skill — no
  descent into it (skills don't nest). Traversal sorted byte-order for
  deterministic ordering across filesystems.

  Strictly additive — every pre-existing root and file layout still
  resolves. Search order: project → getAgentDir()/skills → legacy
  ~/.pi/skills.

  Symlinks are rejected at every layer (root, flat file, skill directory,
  SKILL.md inside a real directory) — deliberate deviation from Pi, which
  follows symlinks.

  supersedes #50.


```
  ┌──────────────────────────────────────────┬──────────────┬──────────────┬────────────────────────────┐
  │                 Behavior                 │      Pi      │     #50      │            Ours            │
  ├──────────────────────────────────────────┼──────────────┼──────────────┼────────────────────────────┤
  │ <cwd>/.pi/skills                         │ ✅           │ ✅           │ ✅                         │
  ├──────────────────────────────────────────┼──────────────┼──────────────┼────────────────────────────┤
  │ <cwd>/.agents/skills (Agent Skills spec) │ ❌           │ ✅           │ ✅                         │
  ├──────────────────────────────────────────┼──────────────┼──────────────┼────────────────────────────┤
  │ getAgentDir()/skills (Pi user-global)    │ ✅           │ ✅           │ ✅                         │
  ├──────────────────────────────────────────┼──────────────┼──────────────┼────────────────────────────┤
  │ ~/.agents/skills (Agent Skills spec)     │ ❌           │ ✅           │ ✅                         │
  ├──────────────────────────────────────────┼──────────────┼──────────────┼────────────────────────────┤
  │ Legacy ~/.pi/skills global               │ ❌           │ ✅           │ ✅                         │
  ├──────────────────────────────────────────┼──────────────┼──────────────┼────────────────────────────┤
  │ Ancestor walk up to /                    │ ❌           │ ✅           │ ❌                         │
  ├──────────────────────────────────────────┼──────────────┼──────────────┼────────────────────────────┤
  │ Flat <name>.md                           │ ✅           │ ✅           │ ✅                         │
  ├──────────────────────────────────────────┼──────────────┼──────────────┼────────────────────────────┤
  │ Flat .txt                                │ ❌           │ ❌           │ ❌   breaking                      │
  ├──────────────────────────────────────────┼──────────────┼──────────────┼────────────────────────────┤
  │ Flat extensionless                       │ ❌           │ ❌           │ ❌   breaking                      │
  ├──────────────────────────────────────────┼──────────────┼──────────────┼────────────────────────────┤
  │ <name>/SKILL.md top-level                │ ✅           │ ✅           │ ✅                         │
  ├──────────────────────────────────────────┼──────────────┼──────────────┼────────────────────────────┤
  │ Nested */<name>/SKILL.md                 │ ✅           │ ✅           │ ✅                         │
  ├──────────────────────────────────────────┼──────────────┼──────────────┼────────────────────────────┤
  │ Skip node_modules                        │ ✅           │ ❌           │ ✅                         │
  ├──────────────────────────────────────────┼──────────────┼──────────────┼────────────────────────────┤
  │ Skip dotfile dirs                        │ ✅           │ ❌           │ ✅                         │
  ├──────────────────────────────────────────┼──────────────┼──────────────┼────────────────────────────┤
  │ Skills-don't-nest rule                   │ ✅           │ ❌           │ ✅                         │
  ├──────────────────────────────────────────┼──────────────┼──────────────┼────────────────────────────┤
  │ .gitignore respect                       │ ✅           │ ❌           │ ❌                         │
  ├──────────────────────────────────────────┼──────────────┼──────────────┼────────────────────────────┤
  │ Symlinks                                 │ follow       │ reject       │ reject                     │
  ├──────────────────────────────────────────┼──────────────┼──────────────┼────────────────────────────┤
  │ Traversal order                          │ FS-dependent │ FS-dependent │ byte-order (deterministic) │
  └──────────────────────────────────────────┴──────────────┴──────────────┴────────────────────────────┘

  Summary: Ours = Pi's discovery model + Agent Skills spec's .agents/skills interop roots − symlink-following + determinism. No .txt/extensionless
  back-compat anymore. #50 has .agents/skills and ancestor walking; we kept .agents/skills (it's in the spec) but dropped the ancestor walking (not in
  spec, not in Pi). All five of our roots are spec-aligned per https://agentskills.io/integrate-skills.
```