### PR TITLE
Fix worktree when agent already committed

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -55,6 +55,11 @@ and this project adheres to [Semantic Versioning](https://semver.org/spec/v2.0.0
 - **`/agents → Settings` UI rewritten to inline-editable `SettingsList`.** Replaces the previous modal `ctx.ui.select` chain. All settings visible at once; `↑`/`↓` to navigate, `Space` to cycle preset values on numerics (`Max concurrency`, `Default max turns`, `Grace turns`), `Enter` to type a custom value, `Esc` to exit. Functionally equivalent — same fields, same valid ranges, same persistence behavior — but the interaction model is different. Users scripting against the old screen flow may notice.
 - **`.gitignore` additions.** Added `.pi/subagents.json` (project-local subagents settings — written by `/agents → Settings`, shouldn't be committed) plus pi-runtime working files (`progress.md`, `AGENTS.md`, `CLAUDE.md`). **Migration:** if you previously committed `.pi/subagents.json` to your repo, run `git rm --cached .pi/subagents.json` to untrack — gitignore only blocks new additions.
 
+### Fixed
+- **Automatic commits in isolated worktrees skip local Git hooks.** When an
+  `isolation: "worktree"` subagent makes its automatic commit, use
+  `--no-verify` so local hooks cannot block preserving the agent's work.
+
 ## [0.8.0] - 2026-05-26
 
 > **⚠️ Breaking: peer dependencies moved from `@mariozechner/pi-*` to `@earendil-works/pi-*`.** The upstream Pi runtime relocated npm scopes on 2026-05-07; the `@mariozechner/pi-*` packages are deprecated. This release pins `@earendil-works/pi-{ai,coding-agent,tui}` at `>=0.74.0`. Hosts on the old scope must update their pi installation first (`pi update --self` handles the rename automatically) before installing this version.

--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -59,6 +59,12 @@ and this project adheres to [Semantic Versioning](https://semver.org/spec/v2.0.0
 - **Automatic commits in isolated worktrees skip local Git hooks.** When an
   `isolation: "worktree"` subagent makes its automatic commit, use
   `--no-verify` so local hooks cannot block preserving the agent's work.
+- **Committed work from `isolation: "worktree"` subagents is now preserved.**
+  If an isolated subagent creates its own commit, cleanup now detects that the
+  clean worktree's HEAD moved and creates the expected `pi-agent-*` branch
+  before removing the detached worktree. Previously, cleanup treated the clean
+  status as no changes and removed the detached worktree without returning a
+  branch.
 
 ## [0.8.0] - 2026-05-26
 

--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -13,6 +13,8 @@ and this project adheres to [Semantic Versioning](https://semver.org/spec/v2.0.0
 ### Fixed
 - **Agents with `enabled: false` are no longer advertised in the Agent tool description** ([#92](https://github.com/tintinweb/pi-subagents/issues/92)). `buildTypeListText` listed every registered agent, including disabled ones that `isValidType` then refused to spawn — the LLM was offered types it could never use. The type list now filters through `getAvailableTypes()`, matching the `subagent_type` parameter description.
 - **Agent tool type list no longer built from pre-settings state.** The description text was captured into a variable before persisted settings were applied; it's now built at tool-registration time, after `subagents:settings_loaded`.
+- **Committed work from `isolation: "worktree"` subagents is now preserved** ([#68](https://github.com/tintinweb/pi-subagents/pull/68) — thanks [@rylwin](https://github.com/rylwin)). If an isolated subagent creates its own commit, cleanup previously saw a clean `git status`, treated it as "no changes", and removed the detached worktree — silently discarding the commits. The worktree now records its base SHA at creation, and cleanup creates the expected `pi-agent-*` branch whenever HEAD moved past it, even with a clean tree.
+- **Automatic commits in isolated worktrees skip local Git hooks** ([#68](https://github.com/tintinweb/pi-subagents/pull/68)). The preservation commit at worktree cleanup now uses `--no-verify`, so a failing local pre-commit hook can't abort it (which previously surfaced as `hasChanges: false` — the agent's work lost).
 
 ## [0.10.0] - 2026-06-01
 
@@ -61,17 +63,6 @@ and this project adheres to [Semantic Versioning](https://semver.org/spec/v2.0.0
 - **`/agents → Eject` now emits YAML-safe `description:` frontmatter.** The new Explore description contains a `: ` colon-space pattern (the search-breadth hint) and embedded quote characters — emitting it raw would have produced malformed frontmatter that the `yaml` parser would mis-parse. `ejectAgent` now wraps the description with `JSON.stringify` (a valid YAML 1.2 double-quoted scalar), so any description string round-trips cleanly through eject → re-load. Latent bug: previously unreachable because old descriptions were YAML-plain-safe.
 - **`/agents → Settings` UI rewritten to inline-editable `SettingsList`.** Replaces the previous modal `ctx.ui.select` chain. All settings visible at once; `↑`/`↓` to navigate, `Space` to cycle preset values on numerics (`Max concurrency`, `Default max turns`, `Grace turns`), `Enter` to type a custom value, `Esc` to exit. Functionally equivalent — same fields, same valid ranges, same persistence behavior — but the interaction model is different. Users scripting against the old screen flow may notice.
 - **`.gitignore` additions.** Added `.pi/subagents.json` (project-local subagents settings — written by `/agents → Settings`, shouldn't be committed) plus pi-runtime working files (`progress.md`, `AGENTS.md`, `CLAUDE.md`). **Migration:** if you previously committed `.pi/subagents.json` to your repo, run `git rm --cached .pi/subagents.json` to untrack — gitignore only blocks new additions.
-
-### Fixed
-- **Automatic commits in isolated worktrees skip local Git hooks.** When an
-  `isolation: "worktree"` subagent makes its automatic commit, use
-  `--no-verify` so local hooks cannot block preserving the agent's work.
-- **Committed work from `isolation: "worktree"` subagents is now preserved.**
-  If an isolated subagent creates its own commit, cleanup now detects that the
-  clean worktree's HEAD moved and creates the expected `pi-agent-*` branch
-  before removing the detached worktree. Previously, cleanup treated the clean
-  status as no changes and removed the detached worktree without returning a
-  branch.
 
 ## [0.8.0] - 2026-05-26
 

--- a/src/types.ts
+++ b/src/types.ts
@@ -80,7 +80,7 @@ export interface AgentRecord {
   /** Steering messages queued before the session was ready. */
   pendingSteers?: string[];
   /** Worktree info if the agent is running in an isolated worktree. */
-  worktree?: { path: string; branch: string };
+  worktree?: { path: string; branch: string; baseSha: string };
   /** Worktree cleanup result after agent completion. */
   worktreeResult?: { hasChanges: boolean; branch?: string };
   /** The tool_use_id from the original Agent tool call. */

--- a/src/worktree.ts
+++ b/src/worktree.ts
@@ -17,6 +17,8 @@ export interface WorktreeInfo {
   path: string;
   /** Branch name created for this worktree (if changes exist). */
   branch: string;
+  /** Commit SHA that the worktree was created from. */
+  baseSha: string;
 }
 
 export interface WorktreeCleanupResult {
@@ -34,9 +36,12 @@ export interface WorktreeCleanupResult {
  */
 export function createWorktree(cwd: string, agentId: string): WorktreeInfo | undefined {
   // Verify we're in a git repo with at least one commit (HEAD must exist)
+  let baseSha: string;
   try {
     execFileSync("git", ["rev-parse", "--is-inside-work-tree"], { cwd, stdio: "pipe", timeout: 5000 });
-    execFileSync("git", ["rev-parse", "HEAD"], { cwd, stdio: "pipe", timeout: 5000 });
+    baseSha = execFileSync("git", ["rev-parse", "HEAD"], { cwd, stdio: "pipe", timeout: 5000 })
+      .toString()
+      .trim();
   } catch {
     return undefined;
   }
@@ -52,7 +57,7 @@ export function createWorktree(cwd: string, agentId: string): WorktreeInfo | und
       stdio: "pipe",
       timeout: 30000,
     });
-    return { path: worktreePath, branch };
+    return { path: worktreePath, branch, baseSha };
   } catch {
     // If worktree creation fails, return undefined (agent runs in normal cwd)
     return undefined;
@@ -81,22 +86,30 @@ export function cleanupWorktree(
       timeout: 10000,
     }).toString().trim();
 
-    if (!status) {
-      // No changes — remove worktree
-      removeWorktree(cwd, worktree.path);
-      return { hasChanges: false };
-    }
+    if (status) {
+      // Changes exist — stage, commit, and create a branch
+      execFileSync("git", ["add", "-A"], { cwd: worktree.path, stdio: "pipe", timeout: 10000 });
+      // Truncate description for commit message (no shell sanitization needed — execFileSync uses argv)
+      const safeDesc = agentDescription.slice(0, 200);
+      const commitMsg = `pi-agent: ${safeDesc}`;
+      execFileSync("git", ["commit", "--no-verify", "-m", commitMsg], {
+        cwd: worktree.path,
+        stdio: "pipe",
+        timeout: 10000,
+      });
+    } else {
+      const currentSha = execFileSync("git", ["rev-parse", "HEAD"], {
+        cwd: worktree.path,
+        stdio: "pipe",
+        timeout: 5000,
+      }).toString().trim();
 
-    // Changes exist — stage, commit, and create a branch
-    execFileSync("git", ["add", "-A"], { cwd: worktree.path, stdio: "pipe", timeout: 10000 });
-    // Truncate description for commit message (no shell sanitization needed — execFileSync uses argv)
-    const safeDesc = agentDescription.slice(0, 200);
-    const commitMsg = `pi-agent: ${safeDesc}`;
-    execFileSync("git", ["commit", "--no-verify", "-m", commitMsg], {
-      cwd: worktree.path,
-      stdio: "pipe",
-      timeout: 10000,
-    });
+      if (currentSha === worktree.baseSha) {
+        // No changes — remove worktree
+        removeWorktree(cwd, worktree.path);
+        return { hasChanges: false };
+      }
+    }
 
     // Create a branch pointing to the worktree's HEAD.
     // If the branch already exists, append a suffix to avoid overwriting previous work.

--- a/src/worktree.ts
+++ b/src/worktree.ts
@@ -92,7 +92,7 @@ export function cleanupWorktree(
     // Truncate description for commit message (no shell sanitization needed — execFileSync uses argv)
     const safeDesc = agentDescription.slice(0, 200);
     const commitMsg = `pi-agent: ${safeDesc}`;
-    execFileSync("git", ["commit", "-m", commitMsg], {
+    execFileSync("git", ["commit", "--no-verify", "-m", commitMsg], {
       cwd: worktree.path,
       stdio: "pipe",
       timeout: 10000,

--- a/test/worktree.test.ts
+++ b/test/worktree.test.ts
@@ -121,6 +121,24 @@ describe("worktree", () => {
       try { execFileSync("git", ["branch", "-D", result.branch!], { cwd: repoDir, stdio: "pipe" }); } catch { /* ignore */ }
     });
 
+    it("commits changes even when a pre-commit hook rejects (--no-verify)", () => {
+      // A failing pre-commit hook in the main repo also applies to its
+      // worktrees — without --no-verify it would abort the preservation commit.
+      const hookPath = join(repoDir, ".git", "hooks", "pre-commit");
+      writeFileSync(hookPath, "#!/bin/sh\nexit 1\n", { mode: 0o755 });
+
+      const wt = createWorktree(repoDir, "hooked-1")!;
+      expect(wt).toBeDefined();
+      writeFileSync(join(wt.path, "hooked-file.txt"), "agent wrote this");
+
+      const result = cleanupWorktree(repoDir, wt, "hook should not block");
+      expect(result.hasChanges).toBe(true);
+      expect(result.branch).toBe("pi-agent-hooked-1");
+
+      // Cleanup branch
+      try { execFileSync("git", ["branch", "-D", result.branch!], { cwd: repoDir, stdio: "pipe" }); } catch { /* ignore */ }
+    });
+
     it("creates branch when worktree is clean but HEAD moved", () => {
       const wt = createWorktree(repoDir, "committed-1")!;
       expect(wt).toBeDefined();

--- a/test/worktree.test.ts
+++ b/test/worktree.test.ts
@@ -38,6 +38,9 @@ describe("worktree", () => {
       expect(wt).toBeDefined();
       expect(existsSync(wt!.path)).toBe(true);
       expect(wt!.branch).toBe("pi-agent-test-id-1");
+      expect(wt!.baseSha).toBe(execFileSync("git", ["rev-parse", "HEAD"], {
+        cwd: repoDir, stdio: "pipe",
+      }).toString().trim());
 
       // Verify it's a valid worktree with the repo's files
       expect(existsSync(join(wt!.path, "README.md"))).toBe(true);
@@ -113,6 +116,32 @@ describe("worktree", () => {
         cwd: repoDir, stdio: "pipe",
       }).toString().trim();
       expect(log).toContain("pi-agent: added new file");
+
+      // Cleanup branch
+      try { execFileSync("git", ["branch", "-D", result.branch!], { cwd: repoDir, stdio: "pipe" }); } catch { /* ignore */ }
+    });
+
+    it("creates branch when worktree is clean but HEAD moved", () => {
+      const wt = createWorktree(repoDir, "committed-1")!;
+      expect(wt).toBeDefined();
+
+      writeFileSync(join(wt.path, "committed-file.txt"), "agent committed this");
+      execFileSync("git", ["add", "committed-file.txt"], { cwd: wt.path, stdio: "pipe" });
+      execFileSync("git", ["commit", "-m", "agent commit"], { cwd: wt.path, stdio: "pipe" });
+      const agentCommit = execFileSync("git", ["rev-parse", "HEAD"], {
+        cwd: wt.path, stdio: "pipe",
+      }).toString().trim();
+
+      const result = cleanupWorktree(repoDir, wt, "already committed");
+      expect(result.hasChanges).toBe(true);
+      expect(result.branch).toBeDefined();
+      expect(result.branch).toBe("pi-agent-committed-1");
+
+      const branchCommit = execFileSync("git", ["rev-parse", result.branch!], {
+        cwd: repoDir, stdio: "pipe",
+      }).toString().trim();
+      expect(branchCommit).toBe(agentCommit);
+      expect(existsSync(wt.path)).toBe(false);
 
       // Cleanup branch
       try { execFileSync("git", ["branch", "-D", result.branch!], { cwd: repoDir, stdio: "pipe" }); } catch { /* ignore */ }


### PR DESCRIPTION
Fix two worktree isolation cleanup issues that can prevent subagent work from
being preserved.

I found that if an `isolation: "worktree"` subagent creates its own commit,
cleanup sees a clean `git status --porcelain`, removes the detached worktree,
and returns no branch. This PR records the worktree base SHA and creates the
expected `pi-agent-*` branch when the clean worktree's HEAD has advanced.

It also makes the automatic dirty-worktree commit use `--no-verify`, so local
Git hooks cannot block preserving the agent's work.

The commit messages include reproduction/QA details that can be used to show
the issue on master and verify that it is resolved on this branch.

Happy to make any adjustments to the PR if helpful.

---

P.S. Thanks again for maintaining this project, and for the quick turnaround on
my last PR. I really appreciate it.