### PR TITLE
fix(types): source ThinkingLevel from @mariozechner/pi-ai (not pi-agent-core)

### DIFF
--- a/src/types.ts
+++ b/src/types.ts
@@ -2,7 +2,7 @@
  * types.ts — Type definitions for the subagent system.
  */
 
-import type { ThinkingLevel } from "@mariozechner/pi-agent-core";
+import type { ThinkingLevel } from "@mariozechner/pi-ai";
 import type { AgentSession } from "@mariozechner/pi-coding-agent";
 import type { LifetimeUsage } from "./usage.js";
 


### PR DESCRIPTION
## Summary

`src/types.ts` imports `ThinkingLevel` from `@mariozechner/pi-agent-core`, which is not declared as a peer dependency — it works under npm's flat hoisting (transitive of `pi-coding-agent`) but fails under pnpm / `node-linker=isolated`.

`ThinkingLevel` is also exported by `@mariozechner/pi-ai` (a declared peer dependency), so re-sourcing it from there is a one-line, zero-behavior-change fix that makes the package consumable under any dependency-resolution strategy.

## Reproduction

```bash
git clone https://github.com/tintinweb/pi-subagents
cd pi-subagents
rm -rf node_modules package-lock.json
echo 'packageManager: pnpm@10.30.3' >> package.json   # or any pnpm version
pnpm install
pnpm run typecheck
# error TS2307: Cannot find module '@mariozechner/pi-agent-core'
```

## Fix

```diff
-import type { ThinkingLevel } from "@mariozechner/pi-agent-core";
+import type { ThinkingLevel } from "@mariozechner/pi-ai";
```

## Verification

`npm run typecheck && npm test` passes (379/379 tests).

## Related

Discovered while preparing a downstream fork ([`@gotgenes/pi-subagents`](https://github.com/gotgenes/pi-subagents)) for publication. See [Tiny-IG-Software/repone#445](https://github.com/Tiny-IG-Software/repone/issues/445) for context.