### PR TITLE
fix(agent-runner): re-filter active tools after bindExtensions so extension tools land in child

### DIFF
--- a/src/agent-runner.ts
+++ b/src/agent-runner.ts
@@ -26,6 +26,42 @@ import type { SubagentType, ThinkingLevel } from "./types.js";
 /** Names of tools registered by this extension that subagents must NOT inherit. */
 const EXCLUDED_TOOL_NAMES = ["Agent", "get_subagent_result", "steer_subagent"];
 
+/**
+ * Filter the session's active tool names according to extension/denylist rules.
+ *
+ * Run twice — once before `bindExtensions` (filters built-in tools) and once after
+ * (filters extension-registered tools, which only join the active set during
+ * `bindExtensions`). Extracting this keeps the two callsites consistent and makes
+ * the post-bind re-filter trivial.
+ *
+ * @param activeTools  Names currently active on the session.
+ * @param toolNames    The built-in tool name allowlist for this agent type.
+ * @param extensions   Agent config `extensions` field: false | true | string[] (allowlist).
+ * @param disallowedSet  Optional denylist from agent config.
+ */
+function filterActiveTools(
+  activeTools: string[],
+  toolNames: string[],
+  extensions: boolean | string[],
+  disallowedSet: Set<string> | undefined,
+): string[] {
+  if (extensions === false) {
+    // Extensions disabled: only apply the denylist to built-in tools.
+    if (!disallowedSet) return activeTools;
+    return activeTools.filter((t) => !disallowedSet.has(t));
+  }
+  const builtinToolNameSet = new Set(toolNames);
+  return activeTools.filter((t) => {
+    if (EXCLUDED_TOOL_NAMES.includes(t)) return false;
+    if (disallowedSet?.has(t)) return false;
+    if (builtinToolNameSet.has(t)) return true;
+    if (Array.isArray(extensions)) {
+      return extensions.some(ext => t.startsWith(ext) || t.includes(ext));
+    }
+    return true;
+  });
+}
+
 /** Default max turns. undefined = unlimited (no turn limit). */
 let defaultMaxTurns: number | undefined;
 
@@ -285,30 +321,16 @@ export async function runAgent(
     ? new Set(agentConfig.disallowedTools)
     : undefined;
 
-  // Filter active tools: remove our own tools to prevent nesting,
-  // apply extension allowlist if specified, and apply disallowedTools denylist
-  if (extensions !== false) {
-    const builtinToolNameSet = new Set(toolNames);
-    const activeTools = session.getActiveToolNames().filter((t) => {
-      if (EXCLUDED_TOOL_NAMES.includes(t)) return false;
-      if (disallowedSet?.has(t)) return false;
-      if (builtinToolNameSet.has(t)) return true;
-      if (Array.isArray(extensions)) {
-        return extensions.some(ext => t.startsWith(ext) || t.includes(ext));
-      }
-      return true;
-    });
-    session.setActiveToolsByName(activeTools);
-  } else if (disallowedSet) {
-    // Even with extensions disabled, apply denylist to built-in tools
-    const activeTools = session.getActiveToolNames().filter(t => !disallowedSet.has(t));
-    session.setActiveToolsByName(activeTools);
+  // Pre-bind filter: remove our own tools, apply extension allowlist/denylist
+  // to built-in tools that are already active.
+  if (extensions !== false || disallowedSet) {
+    const preBind = filterActiveTools(session.getActiveToolNames(), toolNames, extensions, disallowedSet);
+    session.setActiveToolsByName(preBind);
   }
 
   // Bind extensions so that session_start fires and extensions can initialize
-  // (e.g. loading credentials, setting up state). Placed after tool filtering
-  // so extension-provided skills/prompts from extendResourcesFromExtensions()
-  // respect the active tool set. All ExtensionBindings fields are optional.
+  // (e.g. loading credentials, setting up state). Extension-registered tools
+  // join the active set during this call.
   await session.bindExtensions({
     onError: (err) => {
       options.onToolActivity?.({
@@ -317,6 +339,13 @@ export async function runAgent(
       });
     },
   });
+
+  // Post-bind re-filter: extension tools are now in the active set, so re-run
+  // the same rules to gate them by the extensions config and denylist.
+  if (extensions !== false || disallowedSet) {
+    const postBind = filterActiveTools(session.getActiveToolNames(), toolNames, extensions, disallowedSet);
+    session.setActiveToolsByName(postBind);
+  }
 
   options.onSessionCreated?.(session);
 

--- a/test/agent-runner-extension-tools.test.ts
+++ b/test/agent-runner-extension-tools.test.ts
@@ -1,0 +1,287 @@
+/**
+ * Tests for post-bind active-tool re-filter.
+ *
+ * Extension-registered tools (added during `session.bindExtensions(...)`) are
+ * not in the session's active tool set when the initial filter pass runs.
+ * Without a post-bind re-filter, the `extensions: string[]` allowlist branch
+ * never matches any extension tool, and `extensions: true` lets denylisted
+ * extension tools slip through.
+ *
+ * This file simulates that flow by having `getActiveToolNames` return a small
+ * built-in set before `bindExtensions` is called and a larger set including
+ * extension tools after, then asserts that the final `setActiveToolsByName`
+ * call (the post-bind re-filter) honors the agent's `extensions` and
+ * `disallowedTools` config against the post-bind world.
+ */
+
+import { beforeEach, describe, expect, it, vi } from "vitest";
+
+const {
+  createAgentSession,
+  defaultResourceLoaderCtor,
+  getAgentDir,
+  sessionManagerInMemory,
+  settingsManagerCreate,
+} = vi.hoisted(() => ({
+  createAgentSession: vi.fn(),
+  defaultResourceLoaderCtor: vi.fn(),
+  getAgentDir: vi.fn(() => "/mock/agent-dir"),
+  sessionManagerInMemory: vi.fn(() => ({ kind: "memory-session-manager" })),
+  settingsManagerCreate: vi.fn(() => ({ kind: "settings-manager" })),
+}));
+
+vi.mock("@mariozechner/pi-coding-agent", () => ({
+  createAgentSession,
+  DefaultResourceLoader: class {
+    constructor(options: any) {
+      defaultResourceLoaderCtor(options);
+    }
+
+    async reload() {}
+  },
+  getAgentDir,
+  SessionManager: { inMemory: sessionManagerInMemory },
+  SettingsManager: { create: settingsManagerCreate },
+}));
+
+const agentConfigMock = vi.hoisted(() => ({
+  current: {
+    name: "test-agent",
+    description: "Test agent",
+    builtinToolNames: ["read"],
+    extensions: true as boolean | string[],
+    skills: false,
+    systemPrompt: "You are a test agent.",
+    promptMode: "replace",
+    inheritContext: false,
+    runInBackground: false,
+    isolated: false,
+    disallowedTools: undefined as string[] | undefined,
+  },
+}));
+
+vi.mock("../src/agent-types.js", () => ({
+  getConfig: vi.fn(() => agentConfigMock.current),
+  getAgentConfig: vi.fn(() => agentConfigMock.current),
+  getMemoryToolNames: vi.fn(() => []),
+  getReadOnlyMemoryToolNames: vi.fn(() => []),
+  getToolNamesForType: vi.fn(() => ["read"]),
+}));
+
+vi.mock("../src/env.js", () => ({
+  detectEnv: vi.fn(async () => ({
+    isGitRepo: false,
+    branch: "",
+    platform: "linux",
+  })),
+}));
+
+vi.mock("../src/prompts.js", () => ({
+  buildAgentPrompt: vi.fn(() => "system prompt"),
+}));
+
+vi.mock("../src/memory.js", () => ({
+  buildMemoryBlock: vi.fn(() => ""),
+  buildReadOnlyMemoryBlock: vi.fn(() => ""),
+}));
+
+vi.mock("../src/skill-loader.js", () => ({
+  preloadSkills: vi.fn(() => []),
+}));
+
+import { runAgent } from "../src/agent-runner.js";
+
+/**
+ * Build a mock session where `getActiveToolNames` returns one set before
+ * `bindExtensions` is called and another set after.
+ *
+ * @param beforeBind  Tools active before bindExtensions (built-in only).
+ * @param afterBind   Tools active after bindExtensions (built-in + extension).
+ */
+function createSessionWithExtensionToolRegistration(
+  beforeBind: string[],
+  afterBind: string[],
+) {
+  let bound = false;
+  const session = {
+    messages: [] as any[],
+    subscribe: vi.fn(() => () => {}),
+    prompt: vi.fn(async () => {
+      session.messages.push({
+        role: "assistant",
+        content: [{ type: "text", text: "DONE" }],
+      });
+    }),
+    abort: vi.fn(),
+    steer: vi.fn(),
+    getActiveToolNames: vi.fn(() => (bound ? afterBind : beforeBind)),
+    setActiveToolsByName: vi.fn(),
+    bindExtensions: vi.fn(async () => {
+      bound = true;
+    }),
+  };
+  return session;
+}
+
+const ctx = {
+  cwd: "/tmp",
+  model: undefined,
+  modelRegistry: { find: vi.fn(), getAvailable: vi.fn(() => []) },
+  getSystemPrompt: vi.fn(() => "parent prompt"),
+  sessionManager: { getBranch: vi.fn(() => []) },
+} as any;
+
+const pi = {} as any;
+
+beforeEach(() => {
+  createAgentSession.mockReset();
+  defaultResourceLoaderCtor.mockClear();
+  getAgentDir.mockClear();
+  sessionManagerInMemory.mockClear();
+  settingsManagerCreate.mockClear();
+  // Reset agent config to defaults
+  agentConfigMock.current = {
+    name: "test-agent",
+    description: "Test agent",
+    builtinToolNames: ["read"],
+    extensions: true,
+    skills: false,
+    systemPrompt: "You are a test agent.",
+    promptMode: "replace",
+    inheritContext: false,
+    runInBackground: false,
+    isolated: false,
+    disallowedTools: undefined,
+  };
+});
+
+describe("post-bind active-tool re-filter", () => {
+  it("setActiveToolsByName is called both before and after bindExtensions", async () => {
+    const session = createSessionWithExtensionToolRegistration(
+      ["read"],
+      ["read", "extension_tool"],
+    );
+    createAgentSession.mockResolvedValue({ session });
+
+    await runAgent(ctx, "test-agent", "go", { pi });
+
+    // Should be called twice: once before bind, once after.
+    expect(session.setActiveToolsByName).toHaveBeenCalledTimes(2);
+
+    const bindOrder = session.bindExtensions.mock.invocationCallOrder[0];
+    const firstSetOrder =
+      session.setActiveToolsByName.mock.invocationCallOrder[0];
+    const secondSetOrder =
+      session.setActiveToolsByName.mock.invocationCallOrder[1];
+
+    // First set is before bind, second is after.
+    expect(firstSetOrder).toBeLessThan(bindOrder);
+    expect(secondSetOrder).toBeGreaterThan(bindOrder);
+  });
+
+  it("post-bind re-filter includes extension tool when extensions: true", async () => {
+    agentConfigMock.current.extensions = true;
+    const session = createSessionWithExtensionToolRegistration(
+      ["read"],
+      ["read", "extension_tool"],
+    );
+    createAgentSession.mockResolvedValue({ session });
+
+    await runAgent(ctx, "test-agent", "go", { pi });
+
+    // Second (post-bind) call is the re-filter; it should include the
+    // extension-registered tool since extensions: true allows everything.
+    const secondCallArgs = session.setActiveToolsByName.mock.calls[1][0];
+    expect(secondCallArgs).toContain("read");
+    expect(secondCallArgs).toContain("extension_tool");
+  });
+
+  it("post-bind re-filter respects extensions: string[] allowlist", async () => {
+    // Allowlist only "permission-system" prefix; "other_tool" must be excluded.
+    agentConfigMock.current.extensions = ["permission-system"];
+    const session = createSessionWithExtensionToolRegistration(
+      ["read"],
+      ["read", "permission-system_check", "other_tool"],
+    );
+    createAgentSession.mockResolvedValue({ session });
+
+    await runAgent(ctx, "test-agent", "go", { pi });
+
+    const postBindArgs = session.setActiveToolsByName.mock.calls[1][0];
+    // Built-in tools are always allowed.
+    expect(postBindArgs).toContain("read");
+    // Allowlisted extension tool included.
+    expect(postBindArgs).toContain("permission-system_check");
+    // Non-allowlisted extension tool excluded.
+    expect(postBindArgs).not.toContain("other_tool");
+  });
+
+  it("post-bind re-filter respects disallowedTools denylist for extension tools", async () => {
+    agentConfigMock.current.extensions = true;
+    agentConfigMock.current.disallowedTools = ["bad_extension_tool"];
+    const session = createSessionWithExtensionToolRegistration(
+      ["read"],
+      ["read", "good_extension_tool", "bad_extension_tool"],
+    );
+    createAgentSession.mockResolvedValue({ session });
+
+    await runAgent(ctx, "test-agent", "go", { pi });
+
+    const postBindArgs = session.setActiveToolsByName.mock.calls[1][0];
+    expect(postBindArgs).toContain("read");
+    expect(postBindArgs).toContain("good_extension_tool");
+    expect(postBindArgs).not.toContain("bad_extension_tool");
+  });
+
+  it("post-bind re-filter excludes our own tools (EXCLUDED_TOOL_NAMES) even when extensions: true", async () => {
+    agentConfigMock.current.extensions = true;
+    const session = createSessionWithExtensionToolRegistration(
+      ["read"],
+      ["read", "Agent", "get_subagent_result", "steer_subagent", "external"],
+    );
+    createAgentSession.mockResolvedValue({ session });
+
+    await runAgent(ctx, "test-agent", "go", { pi });
+
+    const postBindArgs = session.setActiveToolsByName.mock.calls[1][0];
+    expect(postBindArgs).toContain("read");
+    expect(postBindArgs).toContain("external");
+    // Our own subagent-dispatch tools must never reach children.
+    expect(postBindArgs).not.toContain("Agent");
+    expect(postBindArgs).not.toContain("get_subagent_result");
+    expect(postBindArgs).not.toContain("steer_subagent");
+  });
+
+  it("extensions: false still applies disallowedTools to built-in tools (post-bind re-filter)", async () => {
+    agentConfigMock.current.extensions = false;
+    agentConfigMock.current.disallowedTools = ["read"];
+    const session = createSessionWithExtensionToolRegistration(
+      ["read", "write"],
+      ["read", "write"],
+    );
+    createAgentSession.mockResolvedValue({ session });
+
+    await runAgent(ctx, "test-agent", "go", { pi });
+
+    expect(session.setActiveToolsByName).toHaveBeenCalledTimes(2);
+    const postBindArgs = session.setActiveToolsByName.mock.calls[1][0];
+    // Denylisted built-in is removed.
+    expect(postBindArgs).not.toContain("read");
+    // Non-denylisted built-in survives.
+    expect(postBindArgs).toContain("write");
+  });
+
+  it("extensions: false with no disallowedTools skips the filter (no setActiveToolsByName call)", async () => {
+    agentConfigMock.current.extensions = false;
+    agentConfigMock.current.disallowedTools = undefined;
+    const session = createSessionWithExtensionToolRegistration(
+      ["read"],
+      ["read"],
+    );
+    createAgentSession.mockResolvedValue({ session });
+
+    await runAgent(ctx, "test-agent", "go", { pi });
+
+    expect(session.setActiveToolsByName).not.toHaveBeenCalled();
+  });
+});


### PR DESCRIPTION
## Summary

`runAgent` filters the child session's active tool names **before** calling `session.bindExtensions(...)`. Extension-registered tools are added to the session during `bindExtensions`, so the filter pass never sees them — making the `extensions: string[]` allowlist branch functionally dead for extension tools and letting denylisted extension tools through under `extensions: true` + `disallowedTools`.

Related: #47

## Fix

Extract the filter into a `filterActiveTools` helper and call it both before `bindExtensions` (current behavior, filters built-in tools) and after (new, filters extension-registered tools). The post-bind pass uses identical rules against the post-bind active set.

## Tests

Adds 7 new tests in `test/agent-runner-extension-tools.test.ts` covering:

1. `setActiveToolsByName` is called both before and after `bindExtensions`
2. Post-bind re-filter includes extension tool when `extensions: true`
3. Post-bind re-filter respects `extensions: string[]` allowlist
4. Post-bind re-filter respects `disallowedTools` denylist for extension tools
5. Post-bind re-filter excludes our own tools (`EXCLUDED_TOOL_NAMES`) even when `extensions: true`
6. `extensions: false` still applies `disallowedTools` to built-in tools (post-bind re-filter)
7. `extensions: false` with no `disallowedTools` skips the filter (no `setActiveToolsByName` call)

Negative-control validated: the new tests fail against the unpatched code.

## Verification

`npm run typecheck && npm test` passes (379 upstream + 7 new = 386 tests).

## Relation to #64

PR #64 addresses the same root cause (#47) with a different approach: passing `tools: undefined` when extensions are enabled so all registered tools activate by default. This PR takes an alternative approach — keeping the existing `tools` allowlist but re-running the filter after `bindExtensions` so extension tools are gated by the same rules (allowlist, denylist, EXCLUDED_TOOL_NAMES) as built-in tools.

Either approach fixes the bug. This one preserves the invariant that the session's active set is always explicitly filtered rather than briefly containing everything.

## Reference implementation

This change has been running in production via [`@gotgenes/pi-subagents@0.8.0`](https://github.com/gotgenes/pi-subagents) (a friendly fork). See [Tiny-IG-Software/repone#445](https://github.com/Tiny-IG-Software/repone/issues/445) for context.