### PR TITLE
feat(prompts): inject <active_agent name="..."/> tag for permission resolution

### DIFF
--- a/src/prompts.ts
+++ b/src/prompts.ts
@@ -19,6 +19,10 @@ export interface PromptExtras {
  * - "append" mode: env header + parent system prompt + sub-agent context + config.systemPrompt
  * - "append" with empty systemPrompt: pure parent clone
  *
+ * Both modes prepend an `<active_agent name="${config.name}"/>` tag so downstream
+ * extensions (e.g. permission/policy systems) can resolve per-agent policy
+ * inside the child session by parsing the system prompt.
+ *
  * @param parentSystemPrompt  The parent agent's effective system prompt (for append mode).
  * @param extras  Optional extra sections to inject (memory, preloaded skills).
  */
@@ -29,6 +33,8 @@ export function buildAgentPrompt(
   parentSystemPrompt?: string,
   extras?: PromptExtras,
 ): string {
+  const activeAgentTag = `<active_agent name="${config.name}"/>\n\n`;
+
   const envBlock = `# Environment
 Working directory: ${cwd}
 ${env.isGitRepo ? `Git repository: yes\nBranch: ${env.branch}` : "Not a git repository"}
@@ -66,7 +72,7 @@ You are operating as a sub-agent invoked to handle a specific task.
       ? `\n\n<agent_instructions>\n${config.systemPrompt}\n</agent_instructions>`
       : "";
 
-    return envBlock + "\n\n<inherited_system_prompt>\n" + identity + "\n</inherited_system_prompt>\n\n" + bridge + customSection + extrasSuffix;
+    return activeAgentTag + envBlock + "\n\n<inherited_system_prompt>\n" + identity + "\n</inherited_system_prompt>\n\n" + bridge + customSection + extrasSuffix;
   }
 
   // "replace" mode — env header + the config's full system prompt
@@ -75,7 +81,7 @@ You have been invoked to handle a specific task autonomously.
 
 ${envBlock}`;
 
-  return replaceHeader + "\n\n" + config.systemPrompt + extrasSuffix;
+  return activeAgentTag + replaceHeader + "\n\n" + config.systemPrompt + extrasSuffix;
 }
 
 /** Fallback base prompt when parent system prompt is unavailable in append mode. */

--- a/test/prompts.test.ts
+++ b/test/prompts.test.ts
@@ -308,4 +308,78 @@ describe("buildAgentPrompt", () => {
     expect(prompt).not.toContain("Agent Memory");
     expect(prompt).not.toContain("Preloaded Skill");
   });
+
+  describe("active_agent tag", () => {
+    it("tag is present at start of prompt in replace mode", () => {
+      const config: AgentConfig = {
+        name: "my-agent",
+        description: "Test",
+        builtinToolNames: [],
+        extensions: true,
+        skills: true,
+        systemPrompt: "You are a test agent.",
+        promptMode: "replace",
+        inheritContext: false,
+        runInBackground: false,
+        isolated: false,
+      };
+      const prompt = buildAgentPrompt(config, "/workspace", env);
+      expect(prompt).toMatch(/^<active_agent name="my-agent"\/>/);
+    });
+
+    it("tag is present at start of prompt in append mode", () => {
+      const config: AgentConfig = {
+        name: "my-agent",
+        description: "Test",
+        builtinToolNames: [],
+        extensions: true,
+        skills: true,
+        systemPrompt: "Custom instructions.",
+        promptMode: "append",
+        inheritContext: false,
+        runInBackground: false,
+        isolated: false,
+      };
+      const prompt = buildAgentPrompt(config, "/workspace", env, "Parent prompt.");
+      expect(prompt).toMatch(/^<active_agent name="my-agent"\/>/);
+    });
+
+    it("tag uses agent name verbatim", () => {
+      const config: AgentConfig = {
+        name: "Some Agent With Spaces",
+        description: "Test",
+        builtinToolNames: [],
+        extensions: true,
+        skills: true,
+        systemPrompt: "Test.",
+        promptMode: "replace",
+        inheritContext: false,
+        runInBackground: false,
+        isolated: false,
+      };
+      const prompt = buildAgentPrompt(config, "/workspace", env);
+      expect(prompt).toContain('<active_agent name="Some Agent With Spaces"/>');
+    });
+
+    it("tag appears before the env block in both modes", () => {
+      for (const promptMode of ["replace", "append"] as const) {
+        const config: AgentConfig = {
+          name: "test-agent",
+          description: "Test",
+          builtinToolNames: [],
+          extensions: true,
+          skills: true,
+          systemPrompt: "Test.",
+          promptMode,
+          inheritContext: false,
+          runInBackground: false,
+          isolated: false,
+        };
+        const prompt = buildAgentPrompt(config, "/workspace", env, "Parent.");
+        const tagIndex = prompt.indexOf('<active_agent name="test-agent"/>');
+        const envIndex = prompt.indexOf("# Environment");
+        expect(tagIndex).toBeLessThan(envIndex);
+      }
+    });
+  });
 });


### PR DESCRIPTION
## Summary

Prepends `<active_agent name="${config.name}"/>` to every assembled child system prompt (both `replace` and `append` modes) so downstream extensions can resolve per-agent policy inside the child by parsing the system prompt.

## Motivation

Downstream permission/policy extensions need to know which agent is currently active inside a child session to apply per-agent policy (e.g. per-agent `permission:` frontmatter). The child session has no API surface exposing this directly — the only stable signal that survives session-creation is the system prompt itself.

This change provides a small, parseable marker (`<active_agent name="..."/>`) without coupling `pi-subagents` to any specific downstream extension. The tag is:
- **Short** — one line, prepended before the env block
- **Harmless if ignored** — models treat unknown XML-style tags as structural hints
- **Unambiguous to parse** — regex: `<active_agent\s+name=["\x27]([^"\x27]+)["\x27][^>]*>`

## Change

```diff
 export function buildAgentPrompt(...): string {
+  const activeAgentTag = `<active_agent name="${config.name}"/>\n\n`;
+
   const envBlock = ...;
   ...
   // append mode
-  return envBlock + "\n\n<inherited_system_prompt>\n" + ...;
+  return activeAgentTag + envBlock + "\n\n<inherited_system_prompt>\n" + ...;
   ...
   // replace mode
-  return replaceHeader + "\n\n" + config.systemPrompt + extrasSuffix;
+  return activeAgentTag + replaceHeader + "\n\n" + config.systemPrompt + extrasSuffix;
 }
```

## Tests

Adds 4 new tests in `test/prompts.test.ts`:

1. Tag is present at start of prompt in `replace` mode
2. Tag is present at start of prompt in `append` mode
3. Tag uses agent name verbatim (no escaping or normalization)
4. Tag appears before the env block in both modes

Negative-control validated: the new tests fail against the unpatched code.

## Verification

`npm run typecheck && npm test` passes (379 upstream + 4 new = 383 tests).

## Reference implementation

This change has been running in production via [`@gotgenes/pi-subagents@0.8.0`](https://github.com/gotgenes/pi-subagents) (a friendly fork). The patch is at https://github.com/gotgenes/pi-subagents/commit/83c225b. See [Tiny-IG-Software/repone#445](https://github.com/Tiny-IG-Software/repone/issues/445) for context.