### PR TITLE
fix(widget): wire uiCtx for RPC-spawned agents

### DIFF
--- a/src/index.ts
+++ b/src/index.ts
@@ -567,6 +567,15 @@ export default function (pi: ExtensionAPI) {
     widget.onTurnStart();
   });
 
+  // Wire UI context for agents spawned via cross-extension RPC (no main-session tool call)
+  pi.events.on("subagents:started", () => {
+    if (currentCtx) {
+      widget.setUICtx(currentCtx.ui as UICtx);
+      widget.ensureTimer();
+      widget.update();
+    }
+  });
+
   /** Build the full type list text dynamically from the unified registry. */
   const buildTypeListText = () => {
     const defaultNames = getDefaultAgentNames();


### PR DESCRIPTION
`AgentWidget` bootstraps its UI context from `tool_execution_start`, which never fires for agents spawned via cross-extension RPC (no main-session tool call). The widget stays invisible for the entire agent lifetime.

Wire `uiCtx` from the cached `currentCtx` on `subagents:started` so the widget renders regardless of how the agent was spawned.