### PR TITLE
fix(agent): emit lifecycle events for foreground RPC agents

### DIFF
--- a/src/agent-manager.ts
+++ b/src/agent-manager.ts
@@ -125,8 +125,8 @@ export class AgentManager {
       startedAt: Date.now(),
       abortController,
       lifetimeUsage: { input: 0, output: 0, cacheWrite: 0 },
-      compactionCount: 0,
       invocation: options.invocation,
+      isBackground: options.isBackground ?? false,
     };
     this.agents.set(id, record);
 
@@ -247,9 +247,9 @@ export class AgentManager {
 
         if (options.isBackground) {
           this.runningBackground--;
-          try { this.onComplete?.(record); } catch { /* ignore completion side-effect errors */ }
-          this.drainQueue();
         }
+        try { this.onComplete?.(record); } catch { /* ignore completion side-effect errors */ }
+        this.drainQueue();
         return responseText;
       })
       .catch((err) => {
@@ -278,9 +278,9 @@ export class AgentManager {
 
         if (options.isBackground) {
           this.runningBackground--;
-          this.onComplete?.(record);
-          this.drainQueue();
         }
+        this.onComplete?.(record);
+        this.drainQueue();
         return "";
       });
 

--- a/src/index.ts
+++ b/src/index.ts
@@ -389,25 +389,33 @@ export default function (pi: ExtensionAPI) {
 
     // Skip notification if result was already consumed via get_subagent_result
     if (record.resultConsumed) {
+      // For foreground agents: just update widget (they stream inline)
       agentActivity.delete(record.id);
       widget.markFinished(record.id);
       widget.update();
       return;
     }
 
-    // If this agent is pending batch finalization (debounce window still open),
-    // don't send an individual nudge — finalizeBatch will pick it up retroactively.
-    if (currentBatchAgents.some(a => a.id === record.id)) {
-      widget.update();
-      return;
+    // Only background agents participate in batching and get notifications
+    if (record.isBackground) {
+      // If this agent is pending batch finalization (debounce window still open),
+      // don't send an individual nudge — finalizeBatch will pick it up retroactively.
+      if (currentBatchAgents.some(a => a.id === record.id)) {
+        widget.update();
+        return;
+      }
+
+      const result = groupJoin.onAgentComplete(record);
+      if (result === 'pass') {
+        sendIndividualNudge(record);
+      }
+      // 'held' → do nothing, group will fire later
+      // 'delivered' → group callback already fired
     }
 
-    const result = groupJoin.onAgentComplete(record);
-    if (result === 'pass') {
-      sendIndividualNudge(record);
-    }
-    // 'held' → do nothing, group will fire later
-    // 'delivered' → group callback already fired
+    // Always update widget for ALL agents (foreground and background)
+    agentActivity.delete(record.id);
+    widget.markFinished(record.id);
     widget.update();
   }, undefined, (record) => {
     // Emit started event when agent transitions to running (including from queue)

--- a/src/index.ts
+++ b/src/index.ts
@@ -567,6 +567,15 @@ export default function (pi: ExtensionAPI) {
     widget.onTurnStart();
   });
 
+  // Wire UI context for agents spawned via cross-extension RPC (no main-session tool call)
+  pi.events.on("subagents:started", () => {
+    if (currentCtx) {
+      widget.setUICtx(currentCtx.ui as UICtx);
+      widget.ensureTimer();
+      widget.update();
+    }
+  });
+
   /** Build the full type list text dynamically from the unified registry. */
   const buildTypeListText = () => {
     const defaultNames = getDefaultAgentNames();

--- a/src/types.ts
+++ b/src/types.ts
@@ -94,8 +94,9 @@ export interface AgentRecord {
   lifetimeUsage: LifetimeUsage;
   /** Number of times this agent's session has compacted. Initialized to 0 at spawn. */
   compactionCount: number;
-  /** Resolved spawn params, captured for UI display. Fixed at spawn time. */
   invocation?: AgentInvocation;
+  /** Whether the agent was spawned in background mode. */
+  isBackground?: boolean;
 }
 
 export interface AgentInvocation {


### PR DESCRIPTION
When a subagent is spawned via cross-extension RPC with `isBackground: false`, the `subagents:completed` event is never emitted.

`agent-manager.ts` only calls `onComplete` (which emits the event) for background agents. Foreground agents are expected to have their caller await the promise directly, but an RPC caller has no promise to await. Cross-extension consumers like `pi-dacmicu/evolve` rely on the event to detect completion.

Changes:
- Emit `onComplete` for ALL agents (background and foreground)
- Add `isBackground` field to `AgentRecord` to preserve the spawn flag
- Gate notification / batching on `isBackground` in `index.ts`; foreground agents still update the widget but do not receive follow-up nudges
- Keep `runningBackground--` guarded so the concurrency counter stays accurate.