### PR TITLE
fix: extension tools filtered out by allowedToolNames whitelist in subagents

### DIFF
--- a/src/agent-runner.ts
+++ b/src/agent-runner.ts
@@ -258,6 +258,32 @@ export async function runAgent(
   });
   await loader.reload();
 
+  // Collect extension tool names so they pass createAgentSession's allowlist.
+  // Passing `tools: toolNames` (built-in only) to createAgentSession sets
+  // allowedToolNames to a strict whitelist, which filters out all tools
+  // registered by extensions (e.g. globally installed tools).
+  // By merging extension tool names into the `tools` array before creating
+  // the session, we ensure extension tools are present in the tool registry
+  // and can be selectively enabled or disabled by the post-creation filter below.
+  const extensionsResult = loader.getExtensions();
+  let finalToolNames = toolNames;
+  if (extensions !== false) {
+    const extToolNames: string[] = [];
+    for (const ext of extensionsResult.extensions) {
+      for (const toolName of ext.tools.keys()) {
+        if (EXCLUDED_TOOL_NAMES.includes(toolName)) continue;
+        if (Array.isArray(extensions)) {
+          if (extensions.some(e => toolName.startsWith(e) || toolName.includes(e))) {
+            extToolNames.push(toolName);
+          }
+        } else {
+          extToolNames.push(toolName);
+        }
+      }
+    }
+    finalToolNames = [...new Set([...toolNames, ...extToolNames])];
+  }
+
   // Resolve model: explicit option > config.model > parent model
   const model = options.model ?? resolveDefaultModel(
     ctx.model, ctx.modelRegistry, agentConfig?.model,
@@ -273,7 +299,7 @@ export async function runAgent(
     settingsManager: SettingsManager.create(effectiveCwd, agentDir),
     modelRegistry: ctx.modelRegistry,
     model,
-    tools: toolNames,
+    tools: finalToolNames,
     resourceLoader: loader,
   };
   if (thinkingLevel) {


### PR DESCRIPTION
## Problem

Subagents created via the `Agent` tool cannot use tools registered by globally-installed extensions. Only the 7 built-in tools (read, bash, edit, write, grep, find, ls) are available — all extension-provided tools are missing.

### Root Cause

In `runAgent()`, `createAgentSession({ tools: toolNames })` is called with only built-in tool names. The `AgentSession` constructor treats the `tools` option as an allowlist (`allowedToolNames`), and `_refreshToolRegistry()` filters out any tool whose name is not in that set — including all extension tools — before they ever reach the tool registry.

The post-creation filter in `runAgent()` is designed to keep extension tools when `extensions === true`, but it operates on `session.getActiveToolNames()`, which never contained extension tools because they were already excluded during session construction.

### Fix

Collect extension tool names from the resource loader after `await loader.reload()` and merge them into `finalToolNames` before passing to `createAgentSession()`. This ensures extension tools are present in the tool registry. The existing post-creation filter continues to work correctly — it keeps or removes tools based on the `extensions` config, `EXCLUDED_TOOL_NAMES`, and `disallowedTools`.

The change handles all three `extensions` cases:
- `extensions === true`: all extension tools are included
- `extensions === string[]`: only tools matching the prefix allowlist are included
- `extensions === false`: no extension tools are loaded (unchanged behavior)

### Testing

Verified on a live pi instance with a globally-installed extension that registers a tool. Before this fix, subagents could only see the 7 built-in tools. After the fix, subagents can see and successfully invoke extension-registered tools.