### PR TITLE
feat(tools): add promptSnippet and promptGuidelines to registered tools

### DIFF
--- a/src/index.ts
+++ b/src/index.ts
@@ -695,6 +695,13 @@ Provide clear, detailed prompts so the agent can work autonomously. Brief it lik
 Terse command-style prompts produce shallow, generic work.
 
 **Never delegate understanding.** Don't write "based on your findings, fix the bug" or "based on the research, implement it." Those phrases push synthesis onto the agent instead of doing it yourself. Write prompts that prove you understood: include file paths, line numbers, what specifically to change.`,
+    promptSnippet: "Launch autonomous sub-agents for complex multi-step tasks",
+    promptGuidelines: [
+      "Use Agent with specialized agents when the task matches an agent type's description. Subagents are valuable for parallelizing independent queries or for protecting the main context window from excessive results, but should not be used excessively when not needed. Importantly, avoid duplicating work that subagents are already doing — if you delegate research to a subagent, do not also perform the same searches yourself.",
+      "For broad codebase exploration or research, spawn Agent with an appropriate subagent_type (e.g. Explore). Otherwise use direct tools (read, grep, find) when the target is already known.",
+      "When an agent runs in the background, you will be notified on completion — do not poll or sleep waiting for it. Continue with other work instead.",
+      "Trust but verify: an agent's summary describes intent, not outcome. When an agent writes or edits code, check the actual changes before reporting work as done.",
+    ],
     parameters: Type.Object({
       prompt: Type.String({
         description: "The task for the agent to perform.",
@@ -1185,6 +1192,7 @@ Terse command-style prompts produce shallow, generic work.
     label: "Get Agent Result",
     description:
       "Check status and retrieve results from a background agent. Use the agent ID returned by Agent with run_in_background.",
+    promptSnippet: "Check status and retrieve results from a background agent",
     parameters: Type.Object({
       agent_id: Type.String({
         description: "The agent ID to check.",
@@ -1265,6 +1273,7 @@ Terse command-style prompts produce shallow, generic work.
     description:
       "Send a steering message to a running agent. The message will interrupt the agent after its current tool execution " +
       "and be injected into its conversation, allowing you to redirect its work mid-run. Only works on running agents.",
+    promptSnippet: "Send a steering message to redirect a running background agent",
     parameters: Type.Object({
       agent_id: Type.String({
         description: "The agent ID to steer (must be currently running).",


### PR DESCRIPTION
## Problem

The three tools registered by pi-subagents (`Agent`, `get_subagent_result`, `steer_subagent`) do not provide `promptSnippet` and `promptGuidelines` parameters when calling `defineTool` / `pi.registerTool`.

In pi-mono's system prompt assembly logic (`system-prompt.ts`), these two fields serve critical roles:
- **`promptSnippet`**: A one-line description that appears in the system prompt's "Available tools" section. Tools without this field are omitted from that section entirely.
- **`promptGuidelines`**: Guideline bullets appended to the system prompt's "Guidelines" section.

**Impact**: Without these fields, the three tools are completely absent from the default system prompt. For models that strongly follow system prompt instructions (e.g., Claude), this may cause them to overlook tool schema parameter descriptions, leading to suboptimal tool usage.

## Changes

Only one file modified: `src/index.ts`

### 1. Agent tool — added `promptSnippet` + `promptGuidelines`

```typescript
promptSnippet: "Launch autonomous sub-agents for complex multi-step tasks",
promptGuidelines: [
  "Use Agent with specialized agents when the task matches an agent type's description...",
  "For broad codebase exploration or research, spawn Agent with an appropriate subagent_type...",
  "When an agent runs in the background, you will be notified on completion — do not poll...",
  "Trust but verify: an agent's summary describes intent, not outcome...",
],
```

The guidelines are aligned with Claude Code's system prompt conventions (specifically the "Session-specific guidance" section), ensuring compatibility with models like Claude while remaining generic enough for any LLM.

### 2. get_subagent_result — added `promptSnippet` only

Simple utility tool — the schema description is sufficient; a snippet ensures it appears in "Available tools".

### 3. steer_subagent — added `promptSnippet` only

Same rationale as above.

## Verification

- ✅ TypeScript compilation: `npm run typecheck` passes
- ✅ All 25 test files, 458 test cases pass: `npm test`
- ✅ Diff is minimal: 1 file, +9 lines

🤖 Generated with [Claude Code](https://claude.com/claude-code)
