### PR TITLE
feat(widget): optional trailing spacer below the Agents widget (opt-in widgetSpacer setting)

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -7,6 +7,9 @@ and this project adheres to [Semantic Versioning](https://semver.org/spec/v2.0.0
 
 ## [Unreleased]
 
+### Added
+- **Optional spacing below the agent widget (`widgetSpacer` setting).** The host inserts a leading spacer *above* the `aboveEditor` widget but none below it, so the last tree line (e.g. `└─ ✓ …`) renders directly on top of the input box. This is fine with the default editor but looks cramped with a **boxed/custom editor** whose top border touches that line. A new opt-in setting renders a trailing blank line below the widget for symmetric breathing room. **Defaults to `off`** — the compact look is unchanged for everyone unless they enable it via `/agents → Settings → Widget spacing` (persisted as `widgetSpacer` in `subagents.json`). Visual only — no behavior or stats-format changes.
+
 ## [0.10.0] - 2026-06-01
 
 > **⚠️ Breaking: `extensions:` and `tools:` in agent frontmatter semantics changed.** The `extensions: [...]` array now selects which extensions *load*, not which tool names surface. Agents that previously used the array form will behave differently — see migration below. The `tools:` field also grew new `ext:` and `*` selector forms; existing `tools:` values without these selectors are unchanged.

--- a/README.md
+++ b/README.md
@@ -365,12 +365,14 @@ When on, each subagent spawn's effective model is validated against pi's own `en
 
 ## Persistent Settings
 
-Runtime tuning values set via `/agents` → Settings (max concurrency, default max turns, grace turns, default join mode, scheduling on/off, scope models on/off) persist across pi restarts. Two files, merged on load:
+Runtime tuning values set via `/agents` → Settings (max concurrency, default max turns, grace turns, default join mode, scheduling on/off, scope models on/off, widget spacing on/off) persist across pi restarts. Two files, merged on load:
 
 - **Global:** `~/.pi/agent/subagents.json` — your machine-wide defaults. Edit by hand; the `/agents` menu never writes here.
 - **Project:** `<cwd>/.pi/subagents.json` — per-project overrides. Written by `/agents` → Settings.
 
-**Precedence:** project overrides global on any field present in both. Missing fields fall back to the hardcoded defaults (max concurrency `4`, default max turns unlimited, grace turns `5`, join mode `smart`).
+**Precedence:** project overrides global on any field present in both. Missing fields fall back to the hardcoded defaults (max concurrency `4`, default max turns unlimited, grace turns `5`, join mode `smart`, widget spacing `off`).
+
+**Widget spacing (`widgetSpacer`):** off by default. When on, the live agent widget renders a trailing blank line so it isn't flush against the editor — the host adds a leading spacer above the widget but none below, so the last tree line otherwise sits directly on top of the input box. Handy with a boxed/custom editor whose top border would touch that line. Toggle via `/agents → Settings → Widget spacing`.
 
 **Example — global defaults for a beefy machine:**
 

--- a/src/index.ts
+++ b/src/index.ts
@@ -521,6 +521,19 @@ export default function (pi: ExtensionAPI) {
   function isScopeModelsEnabled(): boolean { return scopeModelsEnabled; }
   function setScopeModelsEnabled(enabled: boolean): void { scopeModelsEnabled = enabled; }
 
+  // ---- Widget spacing configuration ----
+  // When enabled, the live agent widget renders a trailing blank line so it
+  // isn't flush against the editor (the host adds a leading spacer above but
+  // none below). Off by default to keep the compact look; opt-in via `/agents
+  // → Settings`. Persisted as `widgetSpacer`. The widget owns the live flag;
+  // this mirror exists only so snapshotSettings() can read it back.
+  let widgetSpacerEnabled = false;
+  function isWidgetSpacerEnabled(): boolean { return widgetSpacerEnabled; }
+  function setWidgetSpacerEnabled(enabled: boolean): void {
+    widgetSpacerEnabled = enabled;
+    widget.setTrailingSpacer(enabled);
+  }
+
   // ---- Batch tracking for smart join mode ----
   // Collects background agent IDs spawned in the current turn for smart grouping.
   // Uses a debounced timer: each new agent resets the 100ms window so that all
@@ -613,6 +626,7 @@ export default function (pi: ExtensionAPI) {
       setDefaultJoinMode,
       setSchedulingEnabled,
       setScopeModels: setScopeModelsEnabled,
+      setWidgetSpacer: setWidgetSpacerEnabled,
     },
     (event, payload) => pi.events.emit(event, payload),
   );
@@ -1855,6 +1869,7 @@ ${systemPrompt}
       defaultJoinMode: getDefaultJoinMode(),
       schedulingEnabled: isSchedulingEnabled(),
       scopeModels: isScopeModelsEnabled(),
+      widgetSpacer: isWidgetSpacerEnabled(),
     };
   }
 
@@ -1909,6 +1924,13 @@ ${systemPrompt}
           currentValue: isScopeModelsEnabled() ? "on" : "off",
           values: ["on", "off"],
         },
+        {
+          id: "widgetSpacer",
+          label: "Widget spacing",
+          description: "Blank line below the Agents widget so it isn't flush against the editor (helps with boxed editors)",
+          currentValue: isWidgetSpacerEnabled() ? "on" : "off",
+          values: ["on", "off"],
+        },
       ];
     }
 
@@ -1953,6 +1975,11 @@ ${systemPrompt}
         const enabled = value === "on";
         setScopeModelsEnabled(enabled);
         notifyApplied(ctx, `Scope models ${enabled ? "enabled" : "disabled"}`);
+      } else if (id === "widgetSpacer") {
+        const enabled = value === "on";
+        setWidgetSpacerEnabled(enabled);
+        widget.update();  // re-render immediately so the spacing change is visible
+        notifyApplied(ctx, `Widget spacing ${enabled ? "enabled" : "disabled"}`);
       }
     }
 

--- a/src/settings.ts
+++ b/src/settings.ts
@@ -48,6 +48,14 @@ export interface SubagentsSettings {
    * against. Defaults to false: subagents may use any model.
    */
   scopeModels?: boolean;
+  /**
+   * Render a trailing blank line below the live agent widget so it isn't flush
+   * against the editor. The host adds a leading spacer above the widget but none
+   * below, so the last tree line would otherwise sit directly on top of the input
+   * box — noticeable with a boxed/custom editor whose top border touches it.
+   * Defaults to `false` (compact look preserved); opt-in via `/agents → Settings`.
+   */
+  widgetSpacer?: boolean;
 }
 
 /** Setter hooks used by applySettings to wire persisted values into in-memory state. */
@@ -58,6 +66,7 @@ export interface SettingsAppliers {
   setDefaultJoinMode: (mode: JoinMode) => void;
   setSchedulingEnabled: (b: boolean) => void;
   setScopeModels: (enabled: boolean) => void;
+  setWidgetSpacer: (enabled: boolean) => void;
 }
 
 /** Emit callback — a subset of `pi.events.emit` to keep helpers testable. */
@@ -106,6 +115,9 @@ function sanitize(raw: unknown): SubagentsSettings {
   }
   if (typeof r.scopeModels === "boolean") {
     out.scopeModels = r.scopeModels;
+  }
+  if (typeof r.widgetSpacer === "boolean") {
+    out.widgetSpacer = r.widgetSpacer;
   }
   return out;
 }
@@ -163,6 +175,7 @@ export function applySettings(s: SubagentsSettings, appliers: SettingsAppliers):
   if (s.defaultJoinMode) appliers.setDefaultJoinMode(s.defaultJoinMode);
   if (typeof s.schedulingEnabled === "boolean") appliers.setSchedulingEnabled(s.schedulingEnabled);
   if (typeof s.scopeModels === "boolean") appliers.setScopeModels(s.scopeModels);
+  if (typeof s.widgetSpacer === "boolean") appliers.setWidgetSpacer(s.widgetSpacer);
 }
 
 /**

--- a/src/ui/agent-widget.ts
+++ b/src/ui/agent-widget.ts
@@ -220,11 +220,23 @@ export class AgentWidget {
   private tui: any | undefined;
   /** Last status bar text, used to avoid redundant setStatus calls. */
   private lastStatusText: string | undefined;
+  /**
+   * When true, render a trailing blank line below the widget so it isn't flush
+   * against the editor. Off by default to preserve the compact look; opt-in via
+   * `/agents → Settings → Widget spacing` (setting `widgetSpacer`). Useful with
+   * a boxed/custom editor whose top border would otherwise touch the last line.
+   */
+  private trailingSpacer = false;
 
   constructor(
     private manager: AgentManager,
     private agentActivity: Map<string, AgentActivity>,
   ) {}
+
+  /** Toggle the trailing blank line below the widget (see `trailingSpacer`). */
+  setTrailingSpacer(enabled: boolean) {
+    this.trailingSpacer = enabled;
+  }
 
   /** Set the UI context (grabbed from first tool execution). */
   setUICtx(ctx: UICtx) {
@@ -441,6 +453,13 @@ export class AgentWidget {
       lines.push(truncate(theme.fg("dim", "└─") + ` ${theme.fg("dim", `+${hiddenRunning + hiddenFinished} more (${overflowText})`)}`)
       );
     }
+
+    // Optional trailing blank line so the widget isn't flush against the editor.
+    // The host inserts a leading spacer above the widget but none below, so the
+    // last tree line (e.g. `└─ ✓ …`) would otherwise sit directly on top of the
+    // input box — noticeable with a boxed/custom editor. Off by default (compact);
+    // opt-in via the `widgetSpacer` setting.
+    if (this.trailingSpacer) lines.push("");
 
     return lines;
   }

--- a/test/settings.test.ts
+++ b/test/settings.test.ts
@@ -215,6 +215,22 @@ describe("settings persistence", () => {
       expect(loadSettings(projectDir).scopeModels).toBeUndefined();
     });
 
+    it("accepts widgetSpacer boolean (true and false)", () => {
+      writeProject({ widgetSpacer: true });
+      expect(loadSettings(projectDir)).toEqual({ widgetSpacer: true });
+      writeProject({ widgetSpacer: false });
+      expect(loadSettings(projectDir)).toEqual({ widgetSpacer: false });
+    });
+
+    it("drops non-boolean widgetSpacer", () => {
+      writeProject({ widgetSpacer: "yes" });
+      expect(loadSettings(projectDir).widgetSpacer).toBeUndefined();
+      writeProject({ widgetSpacer: 1 });
+      expect(loadSettings(projectDir).widgetSpacer).toBeUndefined();
+      writeProject({ widgetSpacer: null });
+      expect(loadSettings(projectDir).widgetSpacer).toBeUndefined();
+    });
+
     it("returns {} when the JSON root is not an object (array, string, null)", () => {
       mkdirSync(join(projectDir, ".pi"), { recursive: true });
       writeFileSync(projectFile(), '["not", "an", "object"]');
@@ -312,6 +328,7 @@ describe("settings persistence", () => {
         setDefaultJoinMode: vi.fn(),
         setSchedulingEnabled: vi.fn(),
         setScopeModels: vi.fn(),
+        setWidgetSpacer: vi.fn(),
       };
     });
 
@@ -323,6 +340,7 @@ describe("settings persistence", () => {
       expect(appliers.setDefaultJoinMode).not.toHaveBeenCalled();
       expect(appliers.setSchedulingEnabled).not.toHaveBeenCalled();
       expect(appliers.setScopeModels).not.toHaveBeenCalled();
+      expect(appliers.setWidgetSpacer).not.toHaveBeenCalled();
     });
 
     it("applies only the fields that are present", () => {
@@ -344,6 +362,7 @@ describe("settings persistence", () => {
           defaultJoinMode: "group",
           schedulingEnabled: false,
           scopeModels: true,
+          widgetSpacer: true,
         },
         appliers,
       );
@@ -353,11 +372,22 @@ describe("settings persistence", () => {
       expect(appliers.setDefaultJoinMode).toHaveBeenCalledWith("group");
       expect(appliers.setSchedulingEnabled).toHaveBeenCalledWith(false);
       expect(appliers.setScopeModels).toHaveBeenCalledWith(true);
+      expect(appliers.setWidgetSpacer).toHaveBeenCalledWith(true);
     });
 
     it("applies scopeModels: false", () => {
       applySettings({ scopeModels: false }, appliers);
       expect(appliers.setScopeModels).toHaveBeenCalledWith(false);
+    });
+
+    it("applies widgetSpacer (true and false), and skips it when absent", () => {
+      applySettings({ widgetSpacer: true }, appliers);
+      expect(appliers.setWidgetSpacer).toHaveBeenCalledWith(true);
+      applySettings({ widgetSpacer: false }, appliers);
+      expect(appliers.setWidgetSpacer).toHaveBeenCalledWith(false);
+      vi.clearAllMocks();
+      applySettings({ maxConcurrent: 4 }, appliers);
+      expect(appliers.setWidgetSpacer).not.toHaveBeenCalled();
     });
 
     it("applies defaultMaxTurns: 0 as the explicit unlimited marker", () => {
@@ -414,6 +444,7 @@ describe("settings persistence", () => {
         setDefaultJoinMode: vi.fn(),
         setSchedulingEnabled: vi.fn(),
         setScopeModels: vi.fn(),
+        setWidgetSpacer: vi.fn(),
       };
     });
 


### PR DESCRIPTION
## Summary

The agent widget (the **Agents** panel rendered `aboveEditor`) sits **flush against the input box** — there's no spacing between its last line and the editor.

The host (`InteractiveMode.renderWidgetContainer`) inserts a **leading** spacer *above* the widget but **none below** it, so the last tree line — e.g. `└─ ✓ Explore  … · 8 tool uses · 43.2s` — renders directly on top of the editor's top border. With the default editor this is fine, but with a **boxed / custom editor** (e.g. a Rich Input box) whose top border touches that line it looks cramped.

## What changed

Rather than always adding spacing (which would change the compact look for everyone, including default-editor users who may prefer it), this adds an **opt-in setting**:

- **`widgetSpacer`** — when `on`, the widget renders a trailing blank line below itself for symmetric breathing room. **Defaults to `off`**, so nothing changes for anyone unless they enable it.
- Toggle at runtime via **`/agents → Settings → Widget spacing`**; persisted in `subagents.json` (global + project merge) like the other settings.

```
[blank]      ← host leading spacer (always)
○ Agents
└─ ✓ Explore  …
[blank]      ← only when widgetSpacer = on
┌──────────── editor box
```

`Container.render()` concatenates child lines verbatim (no trailing-empty trimming), so the blank line is reliably preserved between the widget and the editor.

## Before / After (with `widgetSpacer = on`)

**Default (`off`)** — unchanged, last line touches the input box:
```
○ Agents
└─ ✓ Explore  Explore VANDERLEIA directory · 8 tool uses · 43.2s
▌                                                                   ← editor (no gap)
```

**`on`** — one line of breathing room (nice with a boxed editor):
```
○ Agents
└─ ✓ Explore  Explore VANDERLEIA directory · 8 tool uses · 43.2s

▌                                                                   ← editor
```

## Implementation

- **`src/ui/agent-widget.ts`** — `trailingSpacer` flag + `setTrailingSpacer()`; the `lines.push("")` is gated on it (both normal and overflow render paths; the early `return []` "nothing to show" path is untouched, so the widget still fully clears).
- **`src/settings.ts`** — `widgetSpacer?: boolean` field, sanitizer entry (non-boolean dropped), and `setWidgetSpacer` applier hook.
- **`src/index.ts`** — wires the applier, `snapshotSettings()`, and the `/agents → Settings` menu item; calls `widget.update()` so the toggle re-renders immediately.

## Scope / risk

- **Default behavior is unchanged** (`widgetSpacer` defaults to `off`).
- **Visual only** — no API, behavior, or stats-format changes.

## Testing

- `npm run typecheck` ✅
- `npm run lint` (biome) ✅
- Unit suite (excluding e2e): **517 passed** ✅ — added sanitizer round-trip + `applySettings` wiring coverage in `test/settings.test.ts` for the new field.

CHANGELOG (`[Unreleased] → Added`) and README (Persistent Settings) updated.
