### PR TITLE
feat: exclude_extensions frontmatter — extension denylist for subagents.

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -7,6 +7,9 @@ and this project adheres to [Semantic Versioning](https://semver.org/spec/v2.0.0
 
 ## [Unreleased]
 
+### Added
+- **`exclude_extensions:` agent frontmatter — extension denylist for subagents** ([#94](https://github.com/tintinweb/pi-subagents/issues/94) — thanks [@ramhaidar](https://github.com/ramhaidar)). Applied after the `extensions:` include set; exclude wins, including over `tools: ext:` selectors (an excluded extension never loads, so its `ext:` reference becomes the usual orphan warning). The key use case: `extensions: true` + `exclude_extensions: pi-notify` — all extensions except a noisy one, without hand-maintaining an allowlist. Plain canonical names only (case-insensitive); paths, `*`, and unmatched names fire `extension-error:…` warnings (warn-not-abort, as with `extensions:` mismatches); `extensions: false` + an exclude warns that the exclude has no effect. **Not a sandbox:** excluded extensions' factory code still executes once during loading — exclusion suppresses handler binding and tool registration, not load-time side effects. The negation syntax `extensions: ["*", "!name"]` was deliberately rejected: an unquoted `!name` is a YAML tag and silently mis-parses.
+
 ## [0.10.1] - 2026-06-10
 
 ### Added

--- a/README.md
+++ b/README.md
@@ -196,6 +196,7 @@ All fields are optional — sensible defaults for everything.
 | `display_name` | — | Display name for UI (e.g. widget, agent list) |
 | `tools` | all 7 | Which tools the agent can call. Built-in names (`read, grep, …`), `*` / `all` (all built-ins), `none`, and `ext:<extension>` / `ext:<extension>/<tool>` selectors for extension tools. See [Tool & extension scoping](#tool--extension-scoping) below |
 | `extensions` | `true` | Which extensions to load for the agent. `true` (all defaults), `false` (none), or an explicit list: `[mcp, "/abs/path.ts", "*"]`. See [Tool & extension scoping](#tool--extension-scoping) below |
+| `exclude_extensions` | — | Extension denylist applied after `extensions:` — exclude wins. Plain names only (case-insensitive), no paths or `*`. Useful with `extensions: true` to drop one extension (e.g. `pi-notify`) |
 | `skills` | `true` | Inherit skills from parent. Can be a comma-separated list of skill names to preload (see [Skill Preloading](#skill-preloading) for discovery locations) |
 | `memory` | — | Persistent agent memory scope: `project`, `local`, or `user`. Auto-detects read-only agents |
 | `disallowed_tools` | — | Comma-separated tools to deny even if extensions provide them |
@@ -227,6 +228,8 @@ extensions: false                 # no extensions load
 extensions: [mcp]                 # only mcp loads
 extensions: ["*", "/abs/foo.ts"]  # all defaults plus one path-loaded extension
 
+exclude_extensions: pi-notify     # everything except pi-notify (with extensions: true)
+
 # Specialist: load one extension, expose only one of its tools, keep built-ins
 extensions: [mcp]
 tools: "*, ext:mcp/search"
@@ -240,6 +243,8 @@ A few rules the examples don't make obvious:
 - Any `ext:` entry flips extension tools to an explicit allowlist — unnamed extensions still load (handlers fire) but expose no tools. So `tools: "*, ext:mcp/search"` exposes only `search` from `mcp`, nothing from any other extension.
 - Extension names match case-insensitively (`[Mcp]` = `[mcp]`); tool names in `ext:foo/bar` stay case-sensitive.
 - Plain `tools:` typos fail loudly: `tools: reed, grep` fires `tools-error:…` instead of silently producing an under-tooled agent.
+- `exclude_extensions:` wins over `extensions:` and over `ext:` selectors — an excluded extension never loads and a `tools: ext:` entry can't pull it back. Plain names only (no paths, no `*`); a name matching nothing fires an `extension-error:…` warning.
+- `exclude_extensions:` is **not a sandbox**: excluded extensions' factory code still executes once during loading — exclusion suppresses their handlers and tools, not their load-time side effects. Don't rely on it to contain an untrusted extension.
 - Array and string forms are equivalent: `[a, b]` == `"a, b"`.
 
 ## Tools

--- a/src/agent-runner.ts
+++ b/src/agent-runner.ts
@@ -296,6 +296,9 @@ export async function runAgent(
 
   // Resolve extensions/skills: isolated overrides to false
   const extensions = options.isolated ? false : config.extensions;
+  // Nulling excludes under isolated also suppresses the orphaned-exclude warning —
+  // isolation is an intentional override, not a misconfiguration.
+  const excludeExtensions = options.isolated ? undefined : config.excludeExtensions;
   const skills = options.isolated ? false : config.skills;
 
   // Skill preloading: when skills is string[], preload their content into prompt
@@ -373,18 +376,35 @@ export async function runAgent(
     ? parseExtensionsSpec(extensions, effectiveCwd)
     : undefined;
   const keepNames = extensionsSpec?.names ?? new Set<string>();
-  // The override filters loaded extensions down to `keepNames`. It's only needed
-  // when we're neither loading everything (`extensions: true` or a `"*"` wildcard)
-  // nor nothing (`noExtensions`).
+  // `exclude_extensions:` is a denylist applied AFTER the include set — exclude wins.
+  // Plain canonical names only (case-insensitive). Note: excluded extensions'
+  // factories still run once during reload() (see comment above) — exclusion
+  // suppresses handler binding and tool registration; it is not a sandbox.
+  const excludeNames = new Set((excludeExtensions ?? []).map((n) => n.toLowerCase()));
+  const hasExcludes = excludeNames.size > 0;
+  // The override filters loaded extensions down to `keepNames` minus `excludeNames`.
+  // It's only needed when we're neither loading everything without excludes
+  // (`extensions: true` or a `"*"` wildcard) nor nothing (`noExtensions`).
   const loadAll = extensions === true || extensionsSpec?.wildcard === true;
   const additionalExtensionPaths = extensionsSpec?.paths.length ? extensionsSpec.paths : undefined;
+  // Pre-filter discovered set, captured by the override — the exclude-typo warning
+  // must compare against this, not the surviving set (absence from survivors is
+  // an exclude *succeeding*).
+  let discoveredNames: Set<string> | undefined;
   const extensionsOverride: ((base: LoadExtensionsResult) => LoadExtensionsResult) | undefined =
-    loadAll || noExtensions
+    noExtensions || (loadAll && !hasExcludes)
       ? undefined
-      : (base) => ({
-          ...base,
-          extensions: base.extensions.filter((e) => keepNames.has(extensionCanonicalName(e.path))),
-        });
+      : (base) => {
+          discoveredNames = new Set(base.extensions.map((e) => extensionCanonicalName(e.path)));
+          return {
+            ...base,
+            extensions: base.extensions.filter((e) => {
+              const name = extensionCanonicalName(e.path);
+              if (excludeNames.has(name)) return false; // exclude wins
+              return loadAll || keepNames.has(name);
+            }),
+          };
+        };
 
   const loader = new DefaultResourceLoader({
     cwd: effectiveCwd,
@@ -425,6 +445,27 @@ export async function runAgent(
   //   - `tools: ext:foo` but foo isn't in the loaded set (because `extensions:`
   //     didn't include it). Since v0.9, `ext:` no longer pulls extensions in;
   //     loading is `extensions:`-authoritative.
+  // An exclude_extensions: alongside extensions: false is contradictory — nothing
+  // loads, so there is nothing to exclude.
+  if (hasExcludes && noExtensions) {
+    options.onToolActivity?.({
+      type: "end",
+      toolName: `extension-error:exclude_extensions has no effect for agent "${type}" — extensions: false loads nothing`,
+    });
+  }
+  // Exclude typo check: compares against the PRE-filter discovered set (an excluded
+  // name absent from the surviving set is the exclude working as intended). Also
+  // flags path-like and "*" entries — excludes are plain names only.
+  if (hasExcludes && discoveredNames) {
+    for (const name of excludeNames) {
+      if (!discoveredNames.has(name)) {
+        options.onToolActivity?.({
+          type: "end",
+          toolName: `extension-error:exclude_extensions: "${name}" for agent "${type}" did not match any discovered extension`,
+        });
+      }
+    }
+  }
   if (keepNames.size > 0 || extNames.size > 0) {
     const survivingNames = new Set(
       loader.getExtensions().extensions.map((e) => extensionCanonicalName(e.path)),
@@ -433,7 +474,9 @@ export async function runAgent(
       if (!survivingNames.has(name)) {
         options.onToolActivity?.({
           type: "end",
-          toolName: `extension-error:extension "${name}" requested by agent "${type}" was not loaded`,
+          toolName: excludeNames.has(name)
+            ? `extension-error:extension "${name}" is in both extensions: and exclude_extensions: for agent "${type}" — exclude wins`
+            : `extension-error:extension "${name}" requested by agent "${type}" was not loaded`,
         });
       }
     }
@@ -441,7 +484,7 @@ export async function runAgent(
       if (!survivingNames.has(name)) {
         options.onToolActivity?.({
           type: "end",
-          toolName: `extension-error:ext:${name} referenced by agent "${type}" but extension "${name}" is not loaded (add it to extensions:)`,
+          toolName: `extension-error:ext:${name} referenced by agent "${type}" but extension "${name}" is not loaded (check extensions:/exclude_extensions:)`,
         });
       }
     }

--- a/src/agent-types.ts
+++ b/src/agent-types.ts
@@ -144,6 +144,7 @@ export function getConfig(type: string): {
   description: string;
   builtinToolNames: string[];
   extensions: true | string[] | false;
+  excludeExtensions?: string[];
   skills: true | string[] | false;
   promptMode: "replace" | "append";
 } {
@@ -155,6 +156,7 @@ export function getConfig(type: string): {
       description: config.description,
       builtinToolNames: config.builtinToolNames ?? BUILTIN_TOOL_NAMES,
       extensions: config.extensions,
+      excludeExtensions: config.excludeExtensions,
       skills: config.skills,
       promptMode: config.promptMode,
     };
@@ -168,6 +170,7 @@ export function getConfig(type: string): {
       description: gp.description,
       builtinToolNames: gp.builtinToolNames ?? BUILTIN_TOOL_NAMES,
       extensions: gp.extensions,
+      excludeExtensions: gp.excludeExtensions,
       skills: gp.skills,
       promptMode: gp.promptMode,
     };

--- a/src/custom-agents.ts
+++ b/src/custom-agents.ts
@@ -60,6 +60,7 @@ function loadFromDir(dir: string, agents: Map<string, AgentConfig>, source: "pro
       extSelectors,
       disallowedTools: csvListOptional(fm.disallowed_tools),
       extensions: inheritField(fm.extensions ?? fm.inherit_extensions),
+      excludeExtensions: csvListOptional(fm.exclude_extensions),
       skills: inheritField(fm.skills ?? fm.inherit_skills),
       model: str(fm.model),
       thinking: str(fm.thinking) as ThinkingLevel | undefined,

--- a/src/index.ts
+++ b/src/index.ts
@@ -1601,6 +1601,7 @@ Terse command-style prompts produce shallow, generic work.
     fmFields.push(`prompt_mode: ${cfg.promptMode}`);
     if (cfg.extensions === false) fmFields.push("extensions: false");
     else if (Array.isArray(cfg.extensions)) fmFields.push(`extensions: ${cfg.extensions.join(", ")}`);
+    if (cfg.excludeExtensions?.length) fmFields.push(`exclude_extensions: ${cfg.excludeExtensions.join(", ")}`);
     if (cfg.skills === false) fmFields.push("skills: false");
     else if (Array.isArray(cfg.skills)) fmFields.push(`skills: ${cfg.skills.join(", ")}`);
     if (cfg.disallowedTools?.length) fmFields.push(`disallowed_tools: ${cfg.disallowedTools.join(", ")}`);

--- a/src/types.ts
+++ b/src/types.ts
@@ -33,6 +33,9 @@ export interface AgentConfig {
   disallowedTools?: string[];
   /** true = inherit all, string[] = only listed, false = none */
   extensions: true | string[] | false;
+  /** Extension-name denylist applied after the `extensions:` include set. Exclude wins.
+   * Plain canonical names only (case-insensitive); no paths, no wildcard. */
+  excludeExtensions?: string[];
   /** true = inherit all, string[] = only listed, false = none */
   skills: true | string[] | false;
   model?: string;

--- a/test/agent-runner.test.ts
+++ b/test/agent-runner.test.ts
@@ -832,6 +832,153 @@ describe("agent-runner extension allowlist", () => {
   });
 });
 
+// ─── exclude_extensions: denylist (#94) ──────────────────────────────────
+describe("agent-runner exclude_extensions", () => {
+  function setupAgent(overrides: Record<string, unknown>) {
+    vi.mocked(getConfig).mockReturnValueOnce(makeConfig(overrides));
+    vi.mocked(getAgentConfig).mockReturnValueOnce(makeAgentConfig(overrides));
+    vi.mocked(getToolNamesForType).mockReturnValueOnce(BUILTINS_7);
+  }
+  function extensionErrors(onToolActivity: ReturnType<typeof vi.fn>): string[] {
+    return onToolActivity.mock.calls
+      .map((c) => c[0]?.toolName)
+      .filter((n): n is string => typeof n === "string" && n.startsWith("extension-error:"));
+  }
+
+  it("extensions: true + exclude — override installed, excluded tools dropped, others kept", async () => {
+    setupAgent({ extensions: true, excludeExtensions: ["notify"] });
+    withExtensions({
+      "/ext/notify.ts": ["notify_send"],
+      "/ext/mcp.ts": ["mcp_tool"],
+    });
+    const { session } = createSession("OK");
+    createAgentSession.mockResolvedValue({ session });
+    const onToolActivity = vi.fn();
+
+    await runAgent(ctx, "Explore", "go", { pi, onToolActivity });
+
+    expect(lastLoaderOpts().extensionsOverride).toBeDefined();
+    const tools = lastToolsPassed();
+    expect(tools).not.toContain("notify_send");
+    expect(tools).toContain("mcp_tool");
+    expect(extensionErrors(onToolActivity)).toEqual([]);
+  });
+
+  it("['*'] + exclude — wildcard no longer short-circuits, exclusion applies", async () => {
+    setupAgent({ extensions: ["*"], excludeExtensions: ["notify"] });
+    withExtensions({
+      "/ext/notify.ts": ["notify_send"],
+      "/ext/mcp.ts": ["mcp_tool"],
+    });
+    const { session } = createSession("OK");
+    createAgentSession.mockResolvedValue({ session });
+
+    await runAgent(ctx, "Explore", "go", { pi });
+
+    expect(lastLoaderOpts().extensionsOverride).toBeDefined();
+    const tools = lastToolsPassed();
+    expect(tools).not.toContain("notify_send");
+    expect(tools).toContain("mcp_tool");
+  });
+
+  it("allowlist + exclude of a listed name — subtracted, 'in both' warning fires", async () => {
+    setupAgent({ extensions: ["mcp", "other"], excludeExtensions: ["other"] });
+    withExtensions({
+      "/ext/mcp.ts": ["mcp_tool"],
+      "/ext/other.ts": ["other_tool"],
+    });
+    const { session } = createSession("OK");
+    createAgentSession.mockResolvedValue({ session });
+    const onToolActivity = vi.fn();
+
+    await runAgent(ctx, "Explore", "go", { pi, onToolActivity });
+
+    const tools = lastToolsPassed();
+    expect(tools).toContain("mcp_tool");
+    expect(tools).not.toContain("other_tool");
+    expect(extensionErrors(onToolActivity)).toEqual([
+      expect.stringContaining('in both extensions: and exclude_extensions:'),
+    ]);
+  });
+
+  it("exclude typo — warning fires, all extensions still load", async () => {
+    setupAgent({ extensions: true, excludeExtensions: ["nope"] });
+    withExtensions({ "/ext/mcp.ts": ["mcp_tool"] });
+    const { session } = createSession("OK");
+    createAgentSession.mockResolvedValue({ session });
+    const onToolActivity = vi.fn();
+
+    await runAgent(ctx, "Explore", "go", { pi, onToolActivity });
+
+    expect(lastToolsPassed()).toContain("mcp_tool");
+    expect(extensionErrors(onToolActivity)).toEqual([
+      expect.stringContaining('exclude_extensions: "nope"'),
+    ]);
+  });
+
+  it("extensions: false + exclude — orphan warning, no override", async () => {
+    setupAgent({ extensions: false, excludeExtensions: ["notify"] });
+    const { session } = createSession("OK");
+    createAgentSession.mockResolvedValue({ session });
+    const onToolActivity = vi.fn();
+
+    await runAgent(ctx, "Explore", "go", { pi, onToolActivity });
+
+    expect(lastLoaderOpts().extensionsOverride).toBeUndefined();
+    expect(extensionErrors(onToolActivity)).toEqual([
+      expect.stringContaining("exclude_extensions has no effect"),
+    ]);
+  });
+
+  it("isolated: true + exclude — excludes nulled, no warnings", async () => {
+    setupAgent({ extensions: true, excludeExtensions: ["notify"] });
+    withExtensions({ "/ext/notify.ts": ["notify_send"] });
+    const { session } = createSession("OK");
+    createAgentSession.mockResolvedValue({ session });
+    const onToolActivity = vi.fn();
+
+    await runAgent(ctx, "Explore", "go", { pi, onToolActivity, isolated: true });
+
+    expect(lastToolsPassed()).not.toContain("notify_send");
+    expect(extensionErrors(onToolActivity)).toEqual([]);
+  });
+
+  it("tools: ext:foo referencing an excluded extension — existing orphan warning fires", async () => {
+    setupAgent({
+      extensions: true,
+      excludeExtensions: ["beta"],
+      extSelectors: ["ext:beta"],
+    });
+    withExtensions({
+      "/ext/beta.ts": ["beta_tool"],
+      "/ext/mcp.ts": ["mcp_tool"],
+    });
+    const { session } = createSession("OK");
+    createAgentSession.mockResolvedValue({ session });
+    const onToolActivity = vi.fn();
+
+    await runAgent(ctx, "Explore", "go", { pi, onToolActivity });
+
+    expect(lastToolsPassed()).not.toContain("beta_tool");
+    expect(extensionErrors(onToolActivity)).toEqual([
+      expect.stringContaining("extension-error:ext:beta"),
+    ]);
+  });
+
+  it("exclude matches case-insensitively", async () => {
+    setupAgent({ extensions: true, excludeExtensions: ["MCP"] });
+    withExtensions({ "/ext/mcp.ts": ["mcp_tool"] });
+    const { session } = createSession("OK");
+    createAgentSession.mockResolvedValue({ session });
+    const onToolActivity = vi.fn();
+
+    await runAgent(ctx, "Explore", "go", { pi, onToolActivity });
+
+    expect(lastToolsPassed()).not.toContain("mcp_tool");
+    expect(extensionErrors(onToolActivity)).toEqual([]);
+  });
+});
+
 // ─── unknown built-in tool names in `tools:` (#75) ──────────────────────
 describe("agent-runner unknown built-in tools", () => {
   it("emits a tools-error warning for each plain entry not in BUILTIN_TOOL_NAMES", async () => {

--- a/test/custom-agents.test.ts
+++ b/test/custom-agents.test.ts
@@ -139,6 +139,49 @@ Partial access.`);
     expect(agent.skills).toEqual(["planning", "review"]);
   });
 
+  it("parses exclude_extensions CSV", () => {
+    writeAgent("no-notify", `---
+extensions: true
+exclude_extensions: pi-notify, telemetry
+---
+
+No notifications.`);
+
+    const result = loadCustomAgents(tmpDir);
+    const agent = result.get("no-notify")!;
+    expect(agent.extensions).toBe(true);
+    expect(agent.excludeExtensions).toEqual(["pi-notify", "telemetry"]);
+  });
+
+  it("parses exclude_extensions YAML list", () => {
+    writeAgent("no-notify-yaml", `---
+exclude_extensions:
+  - pi-notify
+---
+
+No notifications.`);
+
+    const result = loadCustomAgents(tmpDir);
+    expect(result.get("no-notify-yaml")!.excludeExtensions).toEqual(["pi-notify"]);
+  });
+
+  it("exclude_extensions omitted or none → undefined", () => {
+    writeAgent("plain", `---
+description: plain
+---
+
+Plain.`);
+    writeAgent("explicit-none", `---
+exclude_extensions: none
+---
+
+None.`);
+
+    const result = loadCustomAgents(tmpDir);
+    expect(result.get("plain")!.excludeExtensions).toBeUndefined();
+    expect(result.get("explicit-none")!.excludeExtensions).toBeUndefined();
+  });
+
   it("passes through unknown tool names (not filtered)", () => {
     writeAgent("custom-tools", `---
 tools: read, my_custom_tool, grep

--- a/test/fixtures/.pi/agents/exclude-beats-ext-selector.md
+++ b/test/fixtures/.pi/agents/exclude-beats-ext-selector.md
@@ -1,0 +1,12 @@
+---
+description: "An ext: selector cannot resurrect an excluded extension."
+extensions: "./ext-alpha.mjs, ./ext-beta.mjs"
+exclude_extensions: ext-beta.mjs
+tools: "*, ext:ext-beta.mjs"
+expect_tools_present: "read"
+expect_tools_absent: "beta_tool, alpha_read, alpha_write"
+---
+e2e template: exclude_extensions beats a tools: ext: selector — beta never
+loads, so ext:ext-beta.mjs is an orphan (warns, does not pull beta back in).
+Alpha tools are also absent because any ext: entry flips extension tools to an
+explicit allowlist and alpha is not selected.

--- a/test/fixtures/.pi/agents/exclude-beta.md
+++ b/test/fixtures/.pi/agents/exclude-beta.md
@@ -1,0 +1,12 @@
+---
+description: "Loads alpha+beta, excludes beta via exclude_extensions."
+extensions: "./ext-alpha.mjs, ./ext-beta.mjs"
+exclude_extensions: ext-beta.mjs
+tools: "*"
+expect_tools_present: "read, alpha_read, alpha_write"
+expect_tools_absent: "beta_tool"
+---
+e2e template: exclude_extensions removes an extension after the include set is
+computed — alpha surfaces normally, beta's tools never register. (Excluding a
+name that the extensions: list also loads warns "in both — exclude wins"; the
+exclusion still applies.)


### PR DESCRIPTION


## Summary

  Adds an `exclude_extensions:` agent-frontmatter field — an extension **denylist** applied after the `extensions:`
  include set. Closes #94 (thanks @ramhaidar for the report).

  The key use case: run subagents with all extensions *except* a noisy one, without hand-maintaining an allowlist:

  ```yaml
  ---
  description: Research agent
  extensions: true
  exclude_extensions: pi-notify
  ---
  ```

  ## Design

  - **Exclude wins** — over `extensions: true`, `"*"`, allowlists, and `tools: ext:` selectors (an excluded extension
  never loads, so an `ext:` reference becomes the existing orphan warning).
  - **Plain canonical names only** (case-insensitive). No paths, no `*`, and deliberately **no `["*", "!name"]` negation
  syntax** — an unquoted `!name` is a YAML tag and silently mis-parses.
  - **Warn-not-abort**, consistent with existing `extensions:` mismatch handling (`extension-error:…` via
  `onToolActivity`):
    - exclude matching no discovered extension → typo warning (checked against the *pre-filter* discovered set)
    - `extensions: false` + exclude → "has no effect" warning
    - name in both `extensions:` and `exclude_extensions:` → accurate "exclude wins" message (previously this shape
  would have warned misleadingly "was not loaded")
  - **Not a sandbox** (documented): excluded extensions' factory code still executes once during `loader.reload()` —
  exclusion suppresses handler binding and tool registration, not load-time side effects.
  - `isolated: true` nulls excludes along with everything else (intentional override, no warnings).

  ## Implementation

  - `src/types.ts`, `src/agent-types.ts`, `src/custom-agents.ts` — optional `excludeExtensions` threaded frontmatter →
  `AgentConfig` → `getConfig()`; parsed with the existing `csvListOptional` (CSV or YAML list; `none`/omitted → unset)
  - `src/agent-runner.ts` — the core: `extensionsOverride` is now also installed when load-all + excludes exist; single
  filter predicate (exclude first, then include set); the override callback captures the pre-filter discovered set for
  the typo warning
  - `src/index.ts` — `/agents → Eject` serializes the field back to frontmatter
  - README field table + scoping rules (incl. the not-a-sandbox caveat), CHANGELOG

  ## Purely additive — verified

  The no-exclude path is provably identical to before (the new condition and filter reduce to the old ones when no
  excludes exist). Confirmed by running the **unmodified pre-change test suite against the new source: 561 passed, 0
  failures**. Only user-visible change without the feature: one warning hint string, `(add it to extensions:)` → `(check
  extensions:/exclude_extensions:)`.

  ## Tests (14 new)

  - 3 frontmatter-parse tests (CSV, YAML list, `none`/omitted)
  - 8 runner tests: `extensions: true` + exclude, wildcard no longer short-circuits, allowlist subtract + "in both"
  warning, typo warning, orphan warning, `isolated:` suppression, `ext:` selector can't resurrect an excluded extension,
  case-insensitivity
  - 2 auto-discovered e2e templates through real pi-mono: `exclude-beta`, `exclude-beats-ext-selector`

  Full suite: 572 passed / 4 skipped. Lint, typecheck, e2e (37 passed) all clean.