### PR TITLE
fix: conversation viewer honors user tui.select.* keybindings

### DIFF
--- a/src/index.ts
+++ b/src/index.ts
@@ -1494,12 +1494,12 @@ Terse command-style prompts produce shallow, generic work.
     const activity = agentActivity.get(record.id);
 
     await ctx.ui.custom<undefined>(
-      (tui, theme, _keybindings, done) => {
+      (tui, theme, keybindings, done) => {
         return new ConversationViewer(tui, session, record, activity, theme, done, () => {
           if (manager.abort(record.id)) {
             ctx.ui.notify(`Stopped "${record.description}".`, "info");
           }
-        });
+        }, keybindings);
       },
       {
         overlay: true,

--- a/src/ui/conversation-viewer.ts
+++ b/src/ui/conversation-viewer.ts
@@ -12,6 +12,7 @@ import type { AgentRecord } from "../types.js";
 import { getLifetimeTotal, getSessionContextPercent } from "../usage.js";
 import type { Theme } from "./agent-widget.js";
 import { type AgentActivity, buildInvocationTags, describeActivity, formatDuration, formatSessionTokens, getDisplayName, getPromptModeLabel } from "./agent-widget.js";
+import { createViewerKeys, type ViewerKeybindings, type ViewerKeys } from "./viewer-keys.js";
 
 /** Base lines consumed by chrome: top border + header + header sep + footer sep + footer + bottom border. */
 const CHROME_LINES_BASE = 6;
@@ -27,6 +28,7 @@ export class ConversationViewer implements Component {
   private closed = false;
   /** Two-press confirm guard for the stop key, so a stray key can't kill the agent. */
   private stopArmed = false;
+  private keys: ViewerKeys;
 
   constructor(
     private tui: TUI,
@@ -37,7 +39,10 @@ export class ConversationViewer implements Component {
     private done: (result: undefined) => void,
     /** Abort the agent shown here. Omitted → no stop affordance (e.g. read-only history). */
     private onStop?: () => void,
+    /** User keybindings from `ctx.ui.custom()`. Omitted → hardcoded defaults. */
+    keybindings?: ViewerKeybindings,
   ) {
+    this.keys = createViewerKeys(keybindings);
     this.unsubscribe = session.subscribe(() => {
       if (this.closed) return;
       this.tui.requestRender();
@@ -71,16 +76,16 @@ export class ConversationViewer implements Component {
     const viewportHeight = this.viewportHeight();
     const maxScroll = Math.max(0, totalLines - viewportHeight);
 
-    if (matchesKey(data, "up") || matchesKey(data, "k")) {
+    if (this.keys.scrollUp(data)) {
       this.scrollOffset = Math.max(0, this.scrollOffset - 1);
       this.autoScroll = this.scrollOffset >= maxScroll;
-    } else if (matchesKey(data, "down") || matchesKey(data, "j")) {
+    } else if (this.keys.scrollDown(data)) {
       this.scrollOffset = Math.min(maxScroll, this.scrollOffset + 1);
       this.autoScroll = this.scrollOffset >= maxScroll;
-    } else if (matchesKey(data, "pageUp") || matchesKey(data, "shift+up")) {
+    } else if (this.keys.pageUp(data)) {
       this.scrollOffset = Math.max(0, this.scrollOffset - viewportHeight);
       this.autoScroll = false;
-    } else if (matchesKey(data, "pageDown") || matchesKey(data, "shift+down")) {
+    } else if (this.keys.pageDown(data)) {
       this.scrollOffset = Math.min(maxScroll, this.scrollOffset + viewportHeight);
       this.autoScroll = this.scrollOffset >= maxScroll;
     } else if (matchesKey(data, "home")) {

--- a/src/ui/viewer-keys.ts
+++ b/src/ui/viewer-keys.ts
@@ -1,0 +1,39 @@
+/**
+ * viewer-keys.ts — Scroll key matchers for the conversation viewer.
+ *
+ * Resolves `tui.select.*` through the user's keybindings when pi provides a
+ * manager, falling back to the previous hardcoded keys otherwise. The viewer's
+ * k/j and shift+arrow aliases always work alongside whatever is bound.
+ */
+
+import { type KeyId, matchesKey } from "@earendil-works/pi-tui";
+
+/** The `tui.select.*` keybinding ids the viewer resolves. */
+export type ViewerScrollKeybinding =
+  | "tui.select.up"
+  | "tui.select.down"
+  | "tui.select.pageUp"
+  | "tui.select.pageDown";
+
+/** Structural subset of pi-tui's `KeybindingsManager` (which satisfies it). */
+export interface ViewerKeybindings {
+  matches(data: string, keybinding: ViewerScrollKeybinding): boolean;
+}
+
+export interface ViewerKeys {
+  scrollUp(data: string): boolean;
+  scrollDown(data: string): boolean;
+  pageUp(data: string): boolean;
+  pageDown(data: string): boolean;
+}
+
+export function createViewerKeys(keybindings?: ViewerKeybindings): ViewerKeys {
+  const matches = (data: string, id: ViewerScrollKeybinding, fallback: KeyId): boolean =>
+    keybindings ? keybindings.matches(data, id) : matchesKey(data, fallback);
+  return {
+    scrollUp: (data) => matches(data, "tui.select.up", "up") || matchesKey(data, "k"),
+    scrollDown: (data) => matches(data, "tui.select.down", "down") || matchesKey(data, "j"),
+    pageUp: (data) => matches(data, "tui.select.pageUp", "pageUp") || matchesKey(data, "shift+up"),
+    pageDown: (data) => matches(data, "tui.select.pageDown", "pageDown") || matchesKey(data, "shift+down"),
+  };
+}

--- a/test/conversation-viewer-keybindings.test.ts
+++ b/test/conversation-viewer-keybindings.test.ts
@@ -1,0 +1,130 @@
+import { KeybindingsManager, TUI_KEYBINDINGS } from "@earendil-works/pi-tui";
+import { describe, expect, it, vi } from "vitest";
+import type { AgentRecord } from "../src/types.js";
+import { ConversationViewer } from "../src/ui/conversation-viewer.js";
+import type { ViewerKeybindings } from "../src/ui/viewer-keys.js";
+import { createViewerKeys } from "../src/ui/viewer-keys.js";
+
+const CTRL_P = "\x10";
+const CTRL_N = "\x0e";
+const UP = "\x1b[A";
+const DOWN = "\x1b[B";
+const SHIFT_UP = "\x1b[1;2A";
+const SHIFT_DOWN = "\x1b[1;2B";
+const PAGE_UP = "\x1b[5~";
+const PAGE_DOWN = "\x1b[6~";
+
+function createEmacsKeybindings(): KeybindingsManager {
+  return new KeybindingsManager(TUI_KEYBINDINGS, {
+    "tui.select.up": ["up", "ctrl+p"],
+    "tui.select.down": ["down", "ctrl+n"],
+  });
+}
+
+function createViewer(keybindings?: ViewerKeybindings) {
+  const tui = {
+    terminal: { rows: 20, columns: 80 },
+    requestRender: vi.fn(),
+  } as any;
+  const messages = Array.from({ length: 60 }, (_, i) => ({
+    role: "user",
+    content: `message ${i}`,
+  }));
+  const session = {
+    messages,
+    subscribe: vi.fn(() => vi.fn()),
+  } as any;
+  const record = {
+    id: "test-1",
+    type: "general-purpose",
+    description: "test agent",
+    status: "completed",
+    toolUses: 0,
+    startedAt: Date.now(),
+  } as AgentRecord;
+  const theme = {
+    fg: (_color: string, text: string) => text,
+    bold: (text: string) => text,
+  } as any;
+  const viewer = new ConversationViewer(tui, session, record, undefined, theme, vi.fn(), undefined, keybindings);
+  viewer.render(80); // sets lastInnerW and scrolls to bottom (autoScroll)
+  return viewer;
+}
+
+function scrollOffset(viewer: ConversationViewer): number {
+  return (viewer as any).scrollOffset;
+}
+
+describe("viewer-keys", () => {
+  it("honors user keybindings when a manager is provided", () => {
+    const keys = createViewerKeys(createEmacsKeybindings());
+    expect(keys.scrollUp(CTRL_P)).toBe(true);
+    expect(keys.scrollUp(UP)).toBe(true);
+    expect(keys.scrollDown(CTRL_N)).toBe(true);
+    expect(keys.scrollDown(DOWN)).toBe(true);
+  });
+
+  it("falls back to hardcoded defaults without a manager", () => {
+    const keys = createViewerKeys();
+    expect(keys.scrollUp(UP)).toBe(true);
+    expect(keys.scrollUp(CTRL_P)).toBe(false);
+    expect(keys.scrollDown(DOWN)).toBe(true);
+    expect(keys.scrollDown(CTRL_N)).toBe(false);
+    expect(keys.pageUp(PAGE_UP)).toBe(true);
+    expect(keys.pageDown(PAGE_DOWN)).toBe(true);
+  });
+
+  it("keeps the k/j and shift+arrow aliases with and without a manager", () => {
+    for (const keys of [createViewerKeys(), createViewerKeys(createEmacsKeybindings())]) {
+      expect(keys.scrollUp("k")).toBe(true);
+      expect(keys.scrollDown("j")).toBe(true);
+      expect(keys.pageUp(SHIFT_UP)).toBe(true);
+      expect(keys.pageDown(SHIFT_DOWN)).toBe(true);
+    }
+  });
+
+  it("respects rebinding that removes a default key", () => {
+    const manager = new KeybindingsManager(TUI_KEYBINDINGS, {
+      "tui.select.up": "ctrl+p",
+    });
+    const keys = createViewerKeys(manager);
+    expect(keys.scrollUp(CTRL_P)).toBe(true);
+    expect(keys.scrollUp(UP)).toBe(false);
+  });
+});
+
+describe("ConversationViewer custom keybindings", () => {
+  it("scrolls with ctrl+p/ctrl+n when bound to tui.select.up/down", () => {
+    const viewer = createViewer(createEmacsKeybindings());
+    const bottom = scrollOffset(viewer);
+    expect(bottom).toBeGreaterThan(0);
+
+    viewer.handleInput(CTRL_P);
+    expect(scrollOffset(viewer)).toBe(bottom - 1);
+    viewer.handleInput(CTRL_N);
+    expect(scrollOffset(viewer)).toBe(bottom);
+  });
+
+  it("keeps arrows and k/j working alongside custom bindings", () => {
+    const viewer = createViewer(createEmacsKeybindings());
+    const bottom = scrollOffset(viewer);
+
+    viewer.handleInput(UP);
+    viewer.handleInput("k");
+    expect(scrollOffset(viewer)).toBe(bottom - 2);
+    viewer.handleInput(DOWN);
+    viewer.handleInput("j");
+    expect(scrollOffset(viewer)).toBe(bottom);
+  });
+
+  it("treats ctrl+p/ctrl+n as unbound without a keybindings manager", () => {
+    const viewer = createViewer();
+    const bottom = scrollOffset(viewer);
+
+    viewer.handleInput(CTRL_P);
+    viewer.handleInput(CTRL_N);
+    expect(scrollOffset(viewer)).toBe(bottom);
+    viewer.handleInput(UP);
+    expect(scrollOffset(viewer)).toBe(bottom - 1);
+  });
+});


### PR DESCRIPTION
Fixes #99.

The conversation viewer hardcoded its scroll keys (`matchesKey(data, "up"/"down"/"pageUp"/"pageDown")`) and discarded the `KeybindingsManager` that pi injects into `ctx.ui.custom()` factories, so custom `tui.select.*` bindings (e.g. emacs-style ctrl+p/ctrl+n) worked in pi core selectors but not here.

- `src/ui/viewer-keys.ts`: `createViewerKeys(keybindings?)` resolves scrolling through the user's `tui.select.up/down/pageUp/pageDown` bindings, falling back to the previous hardcoded keys when no manager is supplied (the viewer stays constructible standalone, as existing tests do). The manager is typed as a minimal structural interface rather than the concrete class.
- The viewer's k/j and shift+arrow aliases are kept unconditionally, alongside whatever the user binds — default behavior is unchanged since `tui.select.*` defaults match the previous hardcoded keys.
- `escape`/`q` (close), `x` (stop), and `home`/`end` stay hardcoded; they have viewer-specific semantics with no `tui.select.*` counterpart.
- Footer hint text is unchanged.

Testing: `npm run typecheck` and `npm run lint` clean; new `test/conversation-viewer-keybindings.test.ts` (7 tests, real `KeybindingsManager`) covers custom bindings, defaults, alias preservation, rebinding that removes a default, and the no-manager fallback. Full suite: 579 passed, 4 skipped. Same approach as nicobailon/pi-mcp-adapter#138.
