### PR TITLE
feat: complete foreground agent lifecycle and add conversation logging

### DIFF
--- a/src/agent-manager.ts
+++ b/src/agent-manager.ts
@@ -311,7 +311,12 @@ export class AgentManager {
           }
         }
 
-        if (options.isBackground) {
+        // Fire onComplete for foreground agents too — lifecycle symmetry.
+        // Mark resultConsumed so the callback skips notifications (result returned inline).
+        if (!options.isBackground) {
+          record.resultConsumed = true;
+          try { this.onComplete?.(record); } catch { /* ignore completion side-effect errors */ }
+        } else {
           this.runningBackground--;
           try { this.onComplete?.(record); } catch { /* ignore completion side-effect errors */ }
           this.drainQueue();
@@ -342,7 +347,12 @@ export class AgentManager {
           } catch { /* ignore cleanup errors */ }
         }
 
-        if (options.isBackground) {
+        // Fire onComplete for foreground agents too — lifecycle symmetry.
+        // Mark resultConsumed so the callback skips notifications (result returned inline).
+        if (!options.isBackground) {
+          record.resultConsumed = true;
+          this.onComplete?.(record);
+        } else {
           this.runningBackground--;
           this.onComplete?.(record);
           this.drainQueue();
@@ -351,6 +361,11 @@ export class AgentManager {
       });
 
     record.promise = promise;
+
+    // Notify caller that spawn is complete (record is in the map, promise is set).
+    // Called synchronously — onSessionCreated fires asynchronously inside runAgent.
+    // Used by spawnAndWait to let the caller set up output files before streaming starts.
+    this.onSpawned?.(id);
   }
 
   /** Start queued agents up to the concurrency limit. */
@@ -373,8 +388,19 @@ export class AgentManager {
   }
 
   /**
+   * Called synchronously right after spawn, before onSessionCreated fires.
+   * Lets the caller set up the output file path on the record.
+   * The record is guaranteed to be in this.agents at this point.
+   */
+  private onSpawned?: (id: string) => void;
+
+  /**
    * Spawn an agent and wait for completion (foreground use).
    * Foreground agents bypass the concurrency queue.
+   * Returns { id, record } so callers can access the agent ID.
+   *
+   * @param onSpawned - Called synchronously after spawn(), before onSessionCreated fires.
+   *   Use this to set record.outputFile so streamToOutputFile can pick it up.
    */
   async spawnAndWait(
     pi: ExtensionAPI,
@@ -382,11 +408,19 @@ export class AgentManager {
     type: SubagentType,
     prompt: string,
     options: Omit<SpawnOptions, "isBackground">,
-  ): Promise<AgentRecord> {
-    const id = this.spawn(pi, ctx, type, prompt, { ...options, isBackground: false });
-    const record = this.agents.get(id)!;
-    await record.promise;
-    return record;
+    onSpawned?: (id: string) => void,
+  ): Promise<{ id: string; record: AgentRecord }> {
+    // Temporarily register the onSpawned hook so startAgent can call it.
+    const prevOnSpawned = this.onSpawned;
+    this.onSpawned = onSpawned;
+    try {
+      const id = this.spawn(pi, ctx, type, prompt, { ...options, isBackground: false });
+      const record = this.agents.get(id)!;
+      await record.promise;
+      return { id, record };
+    } finally {
+      this.onSpawned = prevOnSpawned;
+    }
   }
 
   /**

--- a/src/index.ts
+++ b/src/index.ts
@@ -1200,7 +1200,9 @@ Terse command-style prompts produce shallow, generic work.
 
       const { state: fgState, callbacks: fgCallbacks } = createActivityTracker(effectiveMaxTurns, streamUpdate);
 
-      // Wire session creation to register in widget
+      // Wire session creation: register in widget + stream to output file.
+      // The output file path is set synchronously after spawn (below),
+      // before onSessionCreated fires — same pattern as background agents.
       const origOnSession = fgCallbacks.onSessionCreated;
       fgCallbacks.onSessionCreated = (session: any) => {
         origOnSession(session);
@@ -1210,6 +1212,13 @@ Terse command-style prompts produce shallow, generic work.
             agentActivity.set(a.id, fgState);
             widget.ensureTimer();
             break;
+          }
+        }
+        // Stream conversation to output file (foreground agent logging)
+        if (fgId) {
+          const rec = manager.getRecord(fgId);
+          if (rec?.outputFile) {
+            rec.outputCleanup = streamToOutputFile(session, rec.outputFile, fgId, ctx.cwd);
           }
         }
       };
@@ -1224,7 +1233,7 @@ Terse command-style prompts produce shallow, generic work.
 
       let record: AgentRecord;
       try {
-        record = await manager.spawnAndWait(pi, ctx, subagentType, params.prompt, {
+        const fgResult = await manager.spawnAndWait(pi, ctx, subagentType, params.prompt, {
           description: params.description,
           model,
           maxTurns: effectiveMaxTurns,
@@ -1235,7 +1244,16 @@ Terse command-style prompts produce shallow, generic work.
           invocation: agentInvocation,
           signal,
           ...fgCallbacks,
+        }, (fgAgentId) => {
+          // onSpawned: called synchronously after spawn, before onSessionCreated fires.
+          // Set up the output file so streamToOutputFile can pick it up.
+          const fgRec = manager.getRecord(fgAgentId);
+          if (fgRec) {
+            fgRec.outputFile = createOutputFilePath(ctx.cwd, fgAgentId, ctx.sessionManager.getSessionId());
+            writeInitialEntry(fgRec.outputFile, fgAgentId, params.prompt, ctx.cwd);
+          }
         });
+        record = fgResult.record;
       } catch (err) {
         clearInterval(spinnerInterval);
         return textResult(err instanceof Error ? err.message : String(err));
@@ -1838,7 +1856,7 @@ Guidelines for choosing settings:
 
 Write the file using the write tool. Only write the file, nothing else.`;
 
-    const record = await manager.spawnAndWait(pi, ctx, "general-purpose", generatePrompt, {
+    const { record } = await manager.spawnAndWait(pi, ctx, "general-purpose", generatePrompt, {
       description: `Generate ${name} agent`,
       maxTurns: 5,
     });

--- a/test/agent-manager.test.ts
+++ b/test/agent-manager.test.ts
@@ -94,18 +94,22 @@ describe("AgentManager — Bug 1 race condition (resultConsumed vs onComplete)",
     expect(completedRecord!.resultConsumed).toBeFalsy();
   });
 
-  it("onComplete is not called for foreground agents", async () => {
-    let onCompleteCalled = false;
-    manager = new AgentManager(() => {
-      onCompleteCalled = true;
+  it("onComplete IS called for foreground agents (lifecycle symmetry)", async () => {
+    let completedRecord: AgentRecord | undefined;
+    manager = new AgentManager((r) => {
+      completedRecord = r;
     });
     resolvedRun();
 
-    await manager.spawnAndWait(mockPi, mockCtx, "general-purpose", "test", {
+    const { record } = await manager.spawnAndWait(mockPi, mockCtx, "general-purpose", "test", {
       description: "test",
     });
 
-    expect(onCompleteCalled).toBe(false);
+    expect(completedRecord).toBeDefined();
+    expect(completedRecord!.status).toBe("completed");
+    // resultConsumed is set by spawnAndWait so onComplete skips notifications
+    expect(completedRecord!.resultConsumed).toBe(true);
+    expect(record).toBe(completedRecord);
   });
 });
 


### PR DESCRIPTION
## Problem

Foreground agents (the default — `run_in_background` unset or `false`) produce **zero persistent logs**:
- No `.output` file with the conversation
- No `subagents:record` entry in the parent JSONL  
- No `subagents:completed`/`subagents:failed` lifecycle events
- The full subagent conversation is discarded after `spawnAndWait` returns

Background agents (`run_in_background: true`) get all of the above. This asymmetry means foreground subagent conversations are permanently lost, and cross-extension observers (OpenTelemetry, session auditors) see an orphaned lifecycle (`started` but never `completed`).

## Solution

Two independent fixes in one PR:

### 1. Fire `onComplete` for foreground agents (lifecycle symmetry)

In `agent-manager.ts`, both `.then()` and `.catch()` blocks now call `onComplete` for foreground agents with `resultConsumed = true`. This:
- Emits `subagents:completed`/`subagents:failed` events
- Writes `subagents:record` metadata entry to parent JSONL
- Skips all notification/batch/group-join logic (via the `resultConsumed` early return)

### 2. Stream foreground conversations to `.output` files

In `index.ts`, the foreground `onSessionCreated` callback now wires `streamToOutputFile` (same as background agents). The output file path is set via a new `onSpawned` hook in `spawnAndWait`, called synchronously after `spawn()` but before `onSessionCreated` fires.

### API change

`spawnAndWait` now returns `{ id, record }` instead of just `record`, so callers can access the agent ID for output file setup.

## Safety

- `resultConsumed = true` makes `onComplete` hit its early return — only lifecycle event + JSONL entry are emitted, no notifications
- Multiple sequential foreground agents: framework dispatches one-at-a-time, zero overlap
- All shared-state mutations are idempotent (`agentActivity.delete`, `widget.markFinished`)
- Foreground agents never touch `currentBatchAgents`, `groupJoin`, or `runningBackground`
- Test suite: 605 tests pass (1 test updated to expect new behavior)

## Files changed

- `src/agent-manager.ts` — onComplete for foreground, onSpawned hook, spawnAndWait return type
- `src/index.ts` — streamToOutputFile for foreground, output file setup via onSpawned
- `test/agent-manager.test.ts` — update foreground onComplete test