### PR TITLE
fix: inline provided 'model' param wins over the agent's frontmatter

### DIFF
--- a/src/invocation-config.ts
+++ b/src/invocation-config.ts
@@ -24,8 +24,11 @@ export function resolveAgentInvocationConfig(
   isolation?: IsolationMode;
 } {
   return {
-    modelInput: agentConfig?.model ?? params.model,
-    modelFromParams: agentConfig?.model == null && params.model != null,
+    // Caller-supplied `params.model` wins over the agent's frontmatter
+    // default. The param is documented as an "override ... omit to use the
+    // agent type's default" — frontmatter is the default, not authoritative.
+    modelInput: params.model ?? agentConfig?.model,
+    modelFromParams: params.model != null,
     thinking: (agentConfig?.thinking ?? params.thinking) as ThinkingLevel | undefined,
     maxTurns: agentConfig?.maxTurns ?? params.max_turns,
     inheritContext: agentConfig?.inheritContext ?? params.inherit_context ?? false,

--- a/test/invocation-config.test.ts
+++ b/test/invocation-config.test.ts
@@ -19,7 +19,11 @@ function makeConfig(overrides: Partial<AgentConfig> = {}): AgentConfig {
 }
 
 describe("resolveAgentInvocationConfig", () => {
-  it("prefers agent config over tool-call params for locked fields", () => {
+  it("lets tool-call params override agent config for model only; other fields stay config-authoritative", () => {
+    // The `model` param is documented as an override ("omit to use the agent
+    // type's default"), so the param wins. All other fields remain
+    // frontmatter-authoritative — only fill gaps when the config leaves them
+    // unspecified.
     const resolved = resolveAgentInvocationConfig(
       makeConfig({
         model: "provider/config-model",
@@ -41,8 +45,10 @@ describe("resolveAgentInvocationConfig", () => {
       },
     );
 
-    expect(resolved.modelInput).toBe("provider/config-model");
-    expect(resolved.modelFromParams).toBe(false);
+    // Model: param wins
+    expect(resolved.modelInput).toBe("provider/param-model");
+    expect(resolved.modelFromParams).toBe(true);
+    // Other fields: config wins
     expect(resolved.thinking).toBe("high");
     expect(resolved.maxTurns).toBe(42);
     expect(resolved.inheritContext).toBe(false);


### PR DESCRIPTION
Address issue #106.