### PR TITLE
feat: persist_session + session_dir frontmatter for subagents

### DIFF
--- a/README.md
+++ b/README.md
@@ -204,6 +204,8 @@ All fields are optional — sensible defaults for everything.
 | `model` | inherit parent | Model — `provider/modelId` or fuzzy name (`"haiku"`, `"sonnet"`) |
 | `thinking` | inherit | off, minimal, low, medium, high, xhigh |
 | `max_turns` | unlimited | Max agentic turns before graceful shutdown. `0` or omit for unlimited |
+| `persist_session` | `false` | Persist this subagent as a normal pi session instead of keeping the session in memory only. The sidechain output transcript is still written either way |
+| `session_dir` | pi default | Optional session directory when `persist_session: true`; omitted uses pi's normal session location, and relative paths resolve from the agent cwd |
 | `prompt_mode` | `replace` | `replace`: body is the full system prompt (no AGENTS.md / CLAUDE.md inheritance). `append`: body appended to parent's prompt (agent acts as a "parent twin" — inherits parent's AGENTS.md / CLAUDE.md) |
 | `inherit_context` | `false` | Fork parent conversation into agent |
 | `run_in_background` | `false` | Run in background by default |

--- a/src/agent-runner.ts
+++ b/src/agent-runner.ts
@@ -288,6 +288,13 @@ function forwardAbortSignal(session: AgentSession, signal?: AbortSignal): () => 
   return () => signal.removeEventListener("abort", onAbort);
 }
 
+function resolveConfiguredSessionDir(sessionDir: string | undefined, cwd: string): string | undefined {
+  if (!sessionDir) return undefined;
+  if (sessionDir === "~" || sessionDir.startsWith("~/")) return resolve(homedir(), sessionDir.slice(2));
+  if (isAbsolute(sessionDir)) return sessionDir;
+  return resolve(cwd, sessionDir);
+}
+
 export async function runAgent(
   ctx: ExtensionContext,
   type: SubagentType,
@@ -555,11 +562,18 @@ export async function runAgent(
     return !noExtensions;
   });
 
+  const settingsManager = SettingsManager.create(configCwd, agentDir);
+  const configuredSessionDir = resolveConfiguredSessionDir(agentConfig?.sessionDir, effectiveCwd);
+  const defaultSessionDir = process.env.PI_CODING_AGENT_SESSION_DIR ?? settingsManager.getSessionDir?.();
+  const sessionManager = agentConfig?.persistSession
+    ? SessionManager.create(effectiveCwd, configuredSessionDir ?? defaultSessionDir)
+    : SessionManager.inMemory(effectiveCwd);
+
   const sessionOpts: Parameters<typeof createAgentSession>[0] = {
     cwd: effectiveCwd,
     agentDir,
-    sessionManager: SessionManager.inMemory(effectiveCwd),
-    settingsManager: SettingsManager.create(configCwd, agentDir),
+    sessionManager,
+    settingsManager,
     modelRegistry: ctx.modelRegistry,
     model,
     tools: allowedTools,

--- a/src/custom-agents.ts
+++ b/src/custom-agents.ts
@@ -65,6 +65,8 @@ function loadFromDir(dir: string, agents: Map<string, AgentConfig>, source: "pro
       model: str(fm.model),
       thinking: str(fm.thinking) as ThinkingLevel | undefined,
       maxTurns: nonNegativeInt(fm.max_turns),
+      persistSession: fm.persist_session != null ? fm.persist_session === true : undefined,
+      sessionDir: str(fm.session_dir),
       systemPrompt: body.trim(),
       promptMode: fm.prompt_mode === "append" ? "append" : "replace",
       inheritContext: fm.inherit_context != null ? fm.inherit_context === true : undefined,

--- a/src/types.ts
+++ b/src/types.ts
@@ -41,6 +41,10 @@ export interface AgentConfig {
   model?: string;
   thinking?: ThinkingLevel;
   maxTurns?: number;
+  /** Persist this subagent as a normal pi session instead of keeping it in memory only. */
+  persistSession?: boolean;
+  /** Optional session directory used when persistSession is true. Omitted = pi's normal session location. */
+  sessionDir?: string;
   systemPrompt: string;
   promptMode: "replace" | "append";
   /** Default for spawn: fork parent conversation. undefined = caller decides. */

--- a/test/agent-runner.test.ts
+++ b/test/agent-runner.test.ts
@@ -7,7 +7,9 @@ const {
   loaderExtensionsRef,
   getAgentDir,
   sessionManagerInMemory,
+  sessionManagerCreate,
   settingsManagerCreate,
+  settingsManagerGetSessionDir,
 } = vi.hoisted(() => ({
   createAgentSession: vi.fn(),
   defaultResourceLoaderCtor: vi.fn(),
@@ -20,7 +22,9 @@ const {
   },
   getAgentDir: vi.fn(() => "/mock/agent-dir"),
   sessionManagerInMemory: vi.fn(() => ({ kind: "memory-session-manager" })),
-  settingsManagerCreate: vi.fn(() => ({ kind: "settings-manager" })),
+  sessionManagerCreate: vi.fn(() => ({ kind: "persistent-session-manager" })),
+  settingsManagerGetSessionDir: vi.fn(() => undefined as string | undefined),
+  settingsManagerCreate: vi.fn(() => ({ kind: "settings-manager", getSessionDir: settingsManagerGetSessionDir })),
 }));
 
 vi.mock("@earendil-works/pi-coding-agent", () => ({
@@ -53,7 +57,7 @@ vi.mock("@earendil-works/pi-coding-agent", () => ({
     }
   },
   getAgentDir,
-  SessionManager: { inMemory: sessionManagerInMemory },
+  SessionManager: { inMemory: sessionManagerInMemory, create: sessionManagerCreate },
   SettingsManager: { create: settingsManagerCreate },
 }));
 
@@ -149,6 +153,9 @@ beforeEach(() => {
   defaultResourceLoaderCtor.mockClear();
   getAgentDir.mockClear();
   sessionManagerInMemory.mockClear();
+  sessionManagerCreate.mockClear();
+  settingsManagerGetSessionDir.mockReset();
+  settingsManagerGetSessionDir.mockReturnValue(undefined);
   settingsManagerCreate.mockClear();
   loaderExtensionsRef.current = { extensions: [], errors: [], runtime: {} };
 });
@@ -499,6 +506,53 @@ function lastToolsPassed(): string[] {
 function lastLoaderOpts(): Record<string, unknown> {
   return defaultResourceLoaderCtor.mock.calls[0][0];
 }
+
+describe("agent-runner session persistence", () => {
+  it("uses an in-memory session by default", async () => {
+    vi.mocked(getAgentConfig).mockReturnValueOnce(makeAgentConfig());
+    const { session } = createSession("OK");
+    createAgentSession.mockResolvedValue({ session });
+
+    await runAgent(ctx, "Explore", "go", { pi });
+
+    expect(sessionManagerInMemory).toHaveBeenCalledWith("/tmp");
+    expect(sessionManagerCreate).not.toHaveBeenCalled();
+    expect(createAgentSession).toHaveBeenCalledWith(expect.objectContaining({
+      sessionManager: { kind: "memory-session-manager" },
+    }));
+  });
+
+  it("uses pi's normal persistent session location when persistSession is true", async () => {
+    vi.mocked(getAgentConfig).mockReturnValueOnce(makeAgentConfig({ persistSession: true }));
+    settingsManagerGetSessionDir.mockReturnValue("/normal/pi/sessions");
+    const { session } = createSession("OK");
+    createAgentSession.mockResolvedValue({ session });
+
+    await runAgent(ctx, "Explore", "go", { pi });
+
+    expect(sessionManagerInMemory).not.toHaveBeenCalled();
+    expect(sessionManagerCreate).toHaveBeenCalledWith("/tmp", "/normal/pi/sessions");
+    expect(createAgentSession).toHaveBeenCalledWith(expect.objectContaining({
+      sessionManager: { kind: "persistent-session-manager" },
+    }));
+  });
+
+  it("uses a frontmatter sessionDir when persistSession is true and sessionDir is configured", async () => {
+    vi.mocked(getAgentConfig).mockReturnValueOnce(
+      makeAgentConfig({ persistSession: true, sessionDir: ".seams/pi-sessions/seam-plan-reviewer" }),
+    );
+    settingsManagerGetSessionDir.mockReturnValue("/normal/pi/sessions");
+    const { session } = createSession("OK");
+    createAgentSession.mockResolvedValue({ session });
+
+    await runAgent(ctx, "Explore", "go", { pi, cwd: "/repo" });
+
+    expect(sessionManagerCreate).toHaveBeenCalledWith(
+      "/repo",
+      "/repo/.seams/pi-sessions/seam-plan-reviewer",
+    );
+  });
+});
 
 describe("agent-runner master tool allowlist", () => {
   it("extensions: true with extension tools — all 7 built-ins plus extension tools land in the allowlist", async () => {

--- a/test/custom-agents.test.ts
+++ b/test/custom-agents.test.ts
@@ -39,6 +39,8 @@ tools: read, grep, find
 model: anthropic/claude-opus-4-6
 thinking: high
 max_turns: 30
+persist_session: true
+session_dir: .seams/pi-sessions/seam-plan-reviewer
 prompt_mode: replace
 inherit_context: true
 run_in_background: true
@@ -57,6 +59,8 @@ You are a security auditor.`);
     expect(agent.model).toBe("anthropic/claude-opus-4-6");
     expect(agent.thinking).toBe("high");
     expect(agent.maxTurns).toBe(30);
+    expect(agent.persistSession).toBe(true);
+    expect(agent.sessionDir).toBe(".seams/pi-sessions/seam-plan-reviewer");
     expect(agent.promptMode).toBe("replace");
     expect(agent.inheritContext).toBe(true);
     expect(agent.runInBackground).toBe(true);
@@ -81,6 +85,8 @@ Just a prompt.`);
     expect(agent.model).toBeUndefined();
     expect(agent.thinking).toBeUndefined();
     expect(agent.maxTurns).toBeUndefined();
+    expect(agent.persistSession).toBeUndefined();
+    expect(agent.sessionDir).toBeUndefined();
     expect(agent.promptMode).toBe("replace");
     expect(agent.inheritContext).toBeUndefined();
     expect(agent.runInBackground).toBeUndefined();


### PR DESCRIPTION
## Summary

Adds two optional frontmatter fields to custom agents so a subagent can run as a **real, persisted pi session** instead of an in-memory-only one:

- **`persist_session`** (default `false`) — when `true`, the subagent runs through `SessionManager.create(...)` so its transcript is written to pi's normal session location, exactly like a top-level session. When `false` (the default), behaviour is unchanged (`SessionManager.inMemory(...)`).
- **`session_dir`** (optional) — overrides where the persisted session is written when `persist_session: true`. Supports absolute paths, `~`, and cwd-relative paths. Omitted ⇒ pi's normal session location (via `PI_CODING_AGENT_SESSION_DIR` or the settings manager's `getSessionDir()`).

## Motivation

When orchestrating long-running, multi-round workflows (plan → review → implement → verify), it's valuable to have each subagent's full conversation persisted as a normal pi session — so it shows up in `~/.pi/agent/sessions`, can be inspected after the fact, and can be resumed. Today subagents are in-memory only. This makes persistence opt-in per agent via frontmatter, with zero change to the default.

## Changes

- `src/types.ts` — add `persistSession?: boolean` and `sessionDir?: string` to `AgentConfig`.
- `src/custom-agents.ts` — parse `persist_session` / `session_dir` from frontmatter.
- `src/agent-runner.ts` — resolve the configured session dir (absolute / `~` / cwd-relative) and select `SessionManager.create(...)` vs `SessionManager.inMemory(...)` based on `persistSession`; default session dir falls back to `PI_CODING_AGENT_SESSION_DIR` then `settingsManager.getSessionDir?.()`.
- `README.md` — document both fields in the frontmatter table.
- Tests — `test/agent-runner.test.ts` (in-memory default, persisted to pi's normal location, frontmatter `session_dir` override) and `test/custom-agents.test.ts` (frontmatter parsing for both fields).

## Compatibility

Fully backward compatible — defaults preserve the existing in-memory behaviour. The sidechain output transcript is still written either way.

## Verification

- `npm run typecheck` — clean
- `npm run lint` — clean (exit 0)
- `npm run test` — added unit tests pass; full unit suite green
