### PR TITLE
feat: FleetView — Claude Code-style subagent navigator below the editor

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -7,6 +7,9 @@ and this project adheres to [Semantic Versioning](https://semver.org/spec/v2.0.0
 
 ## [Unreleased]
 
+### Added
+- **FleetView — a Claude Code-style subagent navigator below the editor.** A persistent, navigable list of `main` + every active subagent renders beneath the editor whenever agents are running — **auto-shown, no keypress needed** — mirroring Claude Code's bottom fleet bar: `⏺`/`◯` selection markers, agent type + description, right-aligned `elapsed · ↓ tokens`, and a `↓ N more` overflow once past five rows. Press `↓` (or `←`) at an **empty prompt** to move focus into the list, `↑`/`↓` to select, `Enter` to open the selected agent's live, auto-updating conversation overlay, and `Esc` (or `↑` above `main`) to return to the prompt. Implemented as a `belowEditor` widget with all key handling routed through `onTerminalInput` (which fires before the editor); it only captures arrow keys at an empty prompt — and acts on key-**press** only (kitty-protocol release events are ignored, otherwise each tap moved twice) — so typing, history, and cursor movement are untouched. Rows are ordered **earliest-launched first**; only openable agents (those with a session) are shown, so pending/queued agents appear once they start and `Enter` never dead-ends; **finished agents linger ~4s** before dropping out (their elapsed freezes at completion); and a viewer **stays open through its agent's completion** so the final output remains readable. Selection follows the viewed agent by id, so closing a viewer returns you to the same agent even if the list reordered while it was open. Every rendered line is width-clamped — the narrow-terminal crash/flicker class previously fixed in v0.2.7 and [#7](https://github.com/tintinweb/pi-subagents/issues/7). Toggle via `/agents → Settings → Fleet view` (default on; pure-UI, so no LLM-context cost).
+
 ## [0.11.0] - 2026-06-23
 
 ### Added

--- a/README.md
+++ b/README.md
@@ -13,6 +13,7 @@ https://github.com/user-attachments/assets/8685261b-9338-4fea-8dfe-1c590d5df543
 - **Claude Code look & feel** — same tool names, calling conventions, and UI patterns (`Agent`, `get_subagent_result`, `steer_subagent`) — feels native
 - **Parallel background agents** — spawn multiple agents that run concurrently with automatic queuing (configurable concurrency limit, default 4) and smart group join (consolidated notifications)
 - **Live widget UI** — persistent above-editor widget with animated spinners, live tool activity, token counts, and colored status icons
+- **FleetView** — Claude Code-style navigable list of `main` + every running subagent rendered below the editor (earliest-launched first). Press `↓` (or `←`) at an empty prompt to jump in, `↑`/`↓` to move the selection, `Enter` to open the selected agent's live, auto-updating conversation, `Esc` to return. Finished agents linger briefly before dropping out, and a viewer stays open through completion so you can read the final output. Toggle via `/agents → Settings → Fleet view`
 - **Conversation viewer** — select any agent in `/agents` to open a live-scrolling overlay of its full conversation (auto-follows new content, scroll up to pause). Stop a still-running agent from here by pressing `x` (then `x` again to confirm) — works for background agents too
 - **Custom agent types** — define agents in `.pi/agents/<name>.md` with YAML frontmatter: custom system prompts, model selection, thinking levels, tool restrictions
 - **Mid-run steering** — inject messages into running agents to redirect their work without restarting
@@ -108,6 +109,21 @@ The extension renders a persistent widget above the editor showing all active ag
 The token field is annotated with two optional signals inside parens:
 - **`NN%`** — context-window utilization (color-coded: <70% dim, 70–85% warning, ≥85% error). Omitted when the model has no declared `contextWindow`, or briefly right after compaction.
 - **`⇊N`** — number of times the session has compacted, when > 0. Stays dim; the percent's color carries urgency.
+
+### FleetView
+
+While subagents are running, a Claude Code-style navigable list renders **below** the editor:
+
+```
+  esc to interrupt · ← for agents · ↓ to manage
+
+  ⏺ main
+  ◯ general-purpose  Sleep then report 1                                11s · ↓ 13.1k tokens
+  ◯ general-purpose  Sleep then report 2                                11s · ↓ 13.1k tokens
+                                                                                   ↓ 3 more
+```
+
+The list is ordered earliest-launched first, and only shows agents you can actually open (pending/queued agents with no session yet appear once they start). At an **empty prompt**, press `↓` (or `←`) to move focus from the prompt into the list — the selected row is marked `⏺`, the rest `◯`. `↑`/`↓` move the selection, `Enter` opens the selected agent's live conversation overlay (it auto-updates as the agent works), and `Esc` (or `↑` above `main`) returns to the prompt. Selecting `main` returns to the normal view. A viewer stays open when its agent finishes so you can read the final output, and finished agents linger in the list for a few seconds before dropping out. Typing anything at a non-empty prompt behaves normally — the list only captures arrow keys when the prompt is empty. Disable it entirely via `/agents → Settings → Fleet view`.
 
 Individual agent results render Claude Code-style in the conversation:
 

--- a/src/index.ts
+++ b/src/index.ts
@@ -45,6 +45,7 @@ import {
   SPINNER,
   type UICtx,
 } from "./ui/agent-widget.js";
+import { FleetList, type FleetUICtx } from "./ui/fleet-list.js";
 import { showSchedulesMenu } from "./ui/schedule-menu.js";
 import { addUsage, getLifetimeTotal, getSessionContextPercent, type LifetimeUsage } from "./usage.js";
 
@@ -298,6 +299,7 @@ export default function (pi: ExtensionAPI) {
   function sendIndividualNudge(record: AgentRecord) {
     agentActivity.delete(record.id);
     widget.markFinished(record.id);
+    fleet.onAgentFinished(record.id);
     scheduleNudge(record.id, () => emitIndividualNudge(record));
     widget.update();
   }
@@ -305,7 +307,7 @@ export default function (pi: ExtensionAPI) {
   // ---- Group join manager ----
   const groupJoin = new GroupJoinManager(
     (records, partial) => {
-      for (const r of records) { agentActivity.delete(r.id); widget.markFinished(r.id); }
+      for (const r of records) { agentActivity.delete(r.id); widget.markFinished(r.id); fleet.onAgentFinished(r.id); }
 
       const groupKey = `group:${records.map(r => r.id).join(",")}`;
       scheduleNudge(groupKey, () => {
@@ -383,6 +385,7 @@ export default function (pi: ExtensionAPI) {
     if (record.resultConsumed) {
       agentActivity.delete(record.id);
       widget.markFinished(record.id);
+      fleet.onAgentFinished(record.id);
       widget.update();
       return;
     }
@@ -489,11 +492,18 @@ export default function (pi: ExtensionAPI) {
     manager.abortAll();
     for (const timer of pendingNudges.values()) clearTimeout(timer);
     pendingNudges.clear();
+    fleet.dispose();
     manager.dispose();
   });
 
   // Live widget: show running agents above editor
   const widget = new AgentWidget(manager, agentActivity);
+
+  // Claude Code-style FleetView: navigable list of main + subagents below the editor.
+  const fleet = new FleetList(manager, agentActivity);
+  let fleetViewEnabled = true;
+  function isFleetViewEnabled(): boolean { return fleetViewEnabled; }
+  function setFleetViewEnabled(b: boolean): void { fleetViewEnabled = b; fleet.setEnabled(b); }
 
   // ---- Join mode configuration ----
   let defaultJoinMode: JoinMode = 'smart';
@@ -587,6 +597,7 @@ export default function (pi: ExtensionAPI) {
   // Grab UI context from first tool execution + clear lingering widget on new turn
   pi.on("tool_execution_start", async (_event, ctx) => {
     widget.setUICtx(ctx.ui as UICtx);
+    fleet.setUICtx(ctx.ui as unknown as FleetUICtx);
     widget.onTurnStart();
   });
 
@@ -646,6 +657,7 @@ export default function (pi: ExtensionAPI) {
       setScopeModels: setScopeModelsEnabled,
       setDisableDefaultAgents: setDisableDefaultAgents,
       setToolDescriptionMode: setToolDescriptionMode,
+      setFleetView: setFleetViewEnabled,
     },
     (event, payload) => pi.events.emit(event, payload),
   );
@@ -1151,6 +1163,8 @@ Terse command-style prompts produce shallow, generic work.
         agentActivity.set(id, bgState);
         widget.ensureTimer();
         widget.update();
+        fleet.ensureTimer();
+        fleet.update();
 
         // Emit created event
         pi.events.emit("subagents:created", {
@@ -1211,6 +1225,8 @@ Terse command-style prompts produce shallow, generic work.
             fgId = a.id;
             agentActivity.set(a.id, fgState);
             widget.ensureTimer();
+            fleet.ensureTimer();
+            fleet.update();
             break;
           }
         }
@@ -1265,6 +1281,7 @@ Terse command-style prompts produce shallow, generic work.
       if (fgId) {
         agentActivity.delete(fgId);
         widget.markFinished(fgId);
+        fleet.onAgentFinished(fgId);
       }
 
       // Get final token count
@@ -1975,6 +1992,7 @@ ${systemPrompt}
       scopeModels: isScopeModelsEnabled(),
       disableDefaultAgents: isDefaultsDisabled(),
       toolDescriptionMode: getToolDescriptionMode(),
+      fleetView: isFleetViewEnabled(),
     };
   }
 
@@ -2037,6 +2055,13 @@ ${systemPrompt}
           values: ["on", "off"],
         },
         {
+          id: "fleetView",
+          label: "Fleet view",
+          description: "Claude Code-style main+subagents list below the editor (↓/← to navigate, Enter to view)",
+          currentValue: isFleetViewEnabled() ? "on" : "off",
+          values: ["on", "off"],
+        },
+        {
           id: "toolDescriptionMode",
           label: "Tool description",
           description: "Agent tool description sent to the LLM: full (rich, default), compact (~75% fewer tokens, for small/local models), or custom (.pi/agent-tool-description.md with {{placeholders}})",
@@ -2094,6 +2119,10 @@ ${systemPrompt}
       } else if (id === "toolDescriptionMode") {
         setToolDescriptionMode(value as ToolDescriptionMode);
         notifyApplied(ctx, `Tool description set to ${value}. Takes effect on next pi session.`);
+      } else if (id === "fleetView") {
+        const enabled = value === "on";
+        setFleetViewEnabled(enabled);
+        notifyApplied(ctx, `Fleet view ${enabled ? "enabled" : "disabled"}`);
       }
     }
 

--- a/src/settings.ts
+++ b/src/settings.ts
@@ -66,6 +66,12 @@ export interface SubagentsSettings {
    * next pi session.
    */
   toolDescriptionMode?: ToolDescriptionMode;
+  /**
+   * Whether the Claude Code-style FleetView (the navigable main+subagents list
+   * rendered below the editor) is shown. Defaults to `true`. Pure-UI: when off,
+   * the list never registers and the global key handler never captures input.
+   */
+  fleetView?: boolean;
 }
 
 export type ToolDescriptionMode = "full" | "compact" | "custom";
@@ -80,6 +86,7 @@ export interface SettingsAppliers {
   setScopeModels: (enabled: boolean) => void;
   setDisableDefaultAgents: (b: boolean) => void;
   setToolDescriptionMode: (mode: ToolDescriptionMode) => void;
+  setFleetView: (b: boolean) => void;
 }
 
 /** Emit callback — a subset of `pi.events.emit` to keep helpers testable. */
@@ -135,6 +142,9 @@ function sanitize(raw: unknown): SubagentsSettings {
   }
   if (typeof r.toolDescriptionMode === "string" && VALID_TOOL_DESCRIPTION_MODES.has(r.toolDescriptionMode)) {
     out.toolDescriptionMode = r.toolDescriptionMode as ToolDescriptionMode;
+  }
+  if (typeof r.fleetView === "boolean") {
+    out.fleetView = r.fleetView;
   }
   return out;
 }
@@ -194,6 +204,7 @@ export function applySettings(s: SubagentsSettings, appliers: SettingsAppliers):
   if (typeof s.scopeModels === "boolean") appliers.setScopeModels(s.scopeModels);
   if (typeof s.disableDefaultAgents === "boolean") appliers.setDisableDefaultAgents(s.disableDefaultAgents);
   if (s.toolDescriptionMode) appliers.setToolDescriptionMode(s.toolDescriptionMode);
+  if (typeof s.fleetView === "boolean") appliers.setFleetView(s.fleetView);
 }
 
 /**

--- a/src/ui/fleet-list.ts
+++ b/src/ui/fleet-list.ts
@@ -1,0 +1,357 @@
+/**
+ * fleet-list.ts — Claude Code-style "FleetView" list rendered below the editor.
+ *
+ * Shows `main` + each running/queued subagent as a navigable list. Pressing ↓ (or
+ * ←) at an empty prompt activates the list; ↑/↓ move the selection (filled ⏺ marker),
+ * Enter opens the selected agent's live conversation overlay, Esc returns to the prompt.
+ * If the viewed agent finishes, the overlay auto-closes back to the list.
+ *
+ * Mechanics (see plan): the list is a `belowEditor` widget (render-only), and ALL key
+ * handling goes through `onTerminalInput` — which fires before the focused editor and
+ * can `consume` keys — gated on `getEditorText() === ""` so normal typing is untouched.
+ */
+
+import { isKeyRelease, Key, matchesKey, truncateToWidth, visibleWidth } from "@earendil-works/pi-tui";
+import type { AgentManager } from "../agent-manager.js";
+import type { AgentRecord } from "../types.js";
+import { getLifetimeTotal } from "../usage.js";
+import { type AgentActivity, getDisplayName, type Theme } from "./agent-widget.js";
+import { ConversationViewer, VIEWPORT_HEIGHT_PCT } from "./conversation-viewer.js";
+
+/** Widget key for the below-editor fleet list. */
+const FLEET_KEY = "fleet";
+/** Max agent rows shown at once; extras collapse into a "↓ N more" indicator. */
+const MAX_AGENT_ROWS = 5;
+/** Re-render cadence so elapsed/token stats tick while agents run. */
+const TICK_MS = 200;
+/** How long a finished agent lingers in the list before it drops out. */
+const FINISHED_LINGER_MS = 4000;
+
+/** Minimal UI surface the FleetView needs from `ctx.ui` (structural subset). */
+export type FleetUICtx = {
+  setWidget(
+    key: string,
+    content: undefined | ((tui: any, theme: Theme) => { render(width: number): string[]; invalidate(): void; dispose?(): void }),
+    options?: { placement?: "aboveEditor" | "belowEditor" },
+  ): void;
+  onTerminalInput(handler: (data: string) => { consume?: boolean; data?: string } | undefined): () => void;
+  getEditorText(): string;
+  notify(message: string, type?: "info" | "warning" | "error"): void;
+  custom<T>(
+    factory: (tui: any, theme: Theme, keybindings: any, done: (result: T) => void) => { render(width: number): string[]; invalidate(): void; dispose?(): void },
+    options?: { overlay?: boolean; overlayOptions?: unknown; onHandle?: (handle: unknown) => void },
+  ): Promise<T>;
+};
+
+type MainEntry = { kind: "main" };
+type AgentEntry = { kind: "agent"; record: AgentRecord };
+type FleetEntry = MainEntry | AgentEntry;
+
+/** `11s` — integer seconds, no decimal/suffix (matches Claude Code, unlike formatMs). */
+export function formatFleetElapsed(ms: number): string {
+  return `${Math.max(0, Math.round(ms / 1000))}s`;
+}
+
+/** `↓ 13.1k tokens` — down-arrow prefix, compact magnitude, plural "tokens". */
+export function formatFleetTokens(count: number): string {
+  let compact: string;
+  if (count >= 1_000_000) compact = `${(count / 1_000_000).toFixed(1)}M`;
+  else if (count >= 1_000) compact = `${(count / 1_000).toFixed(1)}k`;
+  else compact = `${count}`;
+  return `↓ ${compact} tokens`;
+}
+
+/**
+ * Place `right` flush to `width`, truncating `left` first so the stats survive.
+ * The final clamp guarantees the line never exceeds `width` (which would wrap and
+ * desync pi's line-diff → flicker) even on a terminal too narrow for the stats.
+ */
+function rightAlign(left: string, right: string, width: number): string {
+  const rightW = visibleWidth(right);
+  const maxLeft = Math.max(0, width - rightW - 1);
+  const leftClamped = truncateToWidth(left, maxLeft);
+  const gap = Math.max(1, width - visibleWidth(leftClamped) - rightW);
+  return truncateToWidth(leftClamped + " ".repeat(gap) + right, width);
+}
+
+export class FleetList {
+  private ui: FleetUICtx | undefined;
+  private tui: any | undefined;
+  private inputUnsub: (() => void) | undefined;
+  private widgetRegistered = false;
+  private timer: ReturnType<typeof setInterval> | undefined;
+
+  private enabled = true;
+  /** Whether arrow keys currently navigate the list (vs. flow to the editor). */
+  private active = false;
+  /** 0 = `main`, 1..N = subagents. */
+  private selectedIndex = 0;
+  /** Set while a conversation overlay is open; calling it closes the overlay. */
+  private viewerClose: (() => void) | undefined;
+  private viewingAgentId: string | undefined;
+
+  constructor(
+    private manager: AgentManager,
+    private agentActivity: Map<string, AgentActivity>,
+  ) {}
+
+  // ---- Lifecycle ----
+
+  setEnabled(enabled: boolean): void {
+    if (enabled === this.enabled) return;
+    this.enabled = enabled;
+    if (!enabled) this.active = false;
+    this.update();
+  }
+
+  /** Capture the UI context and (re)register the global input handler. */
+  setUICtx(ui: FleetUICtx): void {
+    if (ui === this.ui) return;
+    this.inputUnsub?.();
+    this.ui = ui;
+    this.widgetRegistered = false;
+    this.tui = undefined;
+    this.inputUnsub = ui.onTerminalInput(data => this.handleKey(data));
+  }
+
+  /** Ensure the re-render timer is running (called when an agent spawns). */
+  ensureTimer(): void {
+    if (!this.timer) this.timer = setInterval(() => this.update(), TICK_MS);
+  }
+
+  /**
+   * Called when an agent finishes. The viewer (if open on it) stays open so the
+   * final output remains readable, and the row lingers in the list — just refresh.
+   */
+  onAgentFinished(_id: string): void {
+    this.update();
+  }
+
+  dispose(): void {
+    if (this.timer) { clearInterval(this.timer); this.timer = undefined; }
+    this.inputUnsub?.();
+    this.inputUnsub = undefined;
+    if (this.viewerClose) { this.viewerClose(); this.viewerClose = undefined; }
+    this.viewingAgentId = undefined;
+    if (this.ui && this.widgetRegistered) this.ui.setWidget(FLEET_KEY, undefined);
+    this.widgetRegistered = false;
+    this.tui = undefined;
+    this.active = false;
+    // Null last so a `viewerClose()` microtask above can't re-register the widget.
+    this.ui = undefined;
+  }
+
+  /** Re-register/refresh the below-editor widget; clears it when no agents remain. */
+  update(): void {
+    if (!this.ui) return;
+    const hasAgents = this.enabled && this.agentRecords().length > 0;
+
+    if (!hasAgents) {
+      if (this.widgetRegistered) {
+        this.ui.setWidget(FLEET_KEY, undefined);
+        this.widgetRegistered = false;
+        this.tui = undefined;
+      }
+      if (this.timer) { clearInterval(this.timer); this.timer = undefined; }
+      this.active = false;
+      this.selectedIndex = 0;
+      return;
+    }
+
+    this.clampSelection();
+
+    if (!this.widgetRegistered) {
+      this.ui.setWidget(FLEET_KEY, (tui, theme) => {
+        this.tui = tui;
+        return {
+          render: (w: number) => this.renderBar(w, theme),
+          invalidate: () => { this.widgetRegistered = false; this.tui = undefined; },
+        };
+      }, { placement: "belowEditor" });
+      this.widgetRegistered = true;
+    } else {
+      this.tui?.requestRender();
+    }
+  }
+
+  // ---- Roster ----
+
+  /**
+   * Agents shown in the list, ordered earliest-launched first so the ones you
+   * started sooner sit at the top. Every row is openable (has a session), so Enter
+   * never dead-ends. Included: running/queued, plus the agent currently being
+   * viewed, plus recently-finished ones (they linger briefly before dropping out).
+   * Pending agents with no session yet are hidden until they start.
+   * (`listAgents()` is newest-first, so we re-sort.)
+   */
+  private agentRecords(): AgentRecord[] {
+    const now = Date.now();
+    return this.manager.listAgents()
+      .filter(a => a.session && (
+        a.status === "running" || a.status === "queued"
+        || a.id === this.viewingAgentId
+        || (a.completedAt != null && now - a.completedAt < FINISHED_LINGER_MS)
+      ))
+      .sort((a, b) => a.startedAt - b.startedAt);
+  }
+
+  private roster(): FleetEntry[] {
+    return [{ kind: "main" }, ...this.agentRecords().map(record => ({ kind: "agent" as const, record }))];
+  }
+
+  private clampSelection(): void {
+    const max = this.roster().length - 1;
+    if (this.selectedIndex > max) this.selectedIndex = Math.max(0, max);
+    if (this.selectedIndex < 0) this.selectedIndex = 0;
+  }
+
+  // ---- Key handling ----
+
+  /** Returns `{consume:true}` to swallow a key, or undefined to let it through. */
+  handleKey(data: string): { consume?: boolean; data?: string } | undefined {
+    if (!this.enabled || !this.ui) return undefined;
+    // Input listeners receive BOTH key-press and key-release (the kitty protocol
+    // emits both, and matchesKey matches either) — act on press only, or every
+    // tap would move/fire twice. Repeats still pass through for held-key nav.
+    if (isKeyRelease(data)) return undefined;
+    // While an overlay is open, let it own all input.
+    if (this.viewerClose) return undefined;
+
+    if (!this.active) {
+      // Activate: ↓ or ← at an empty prompt moves focus into the list.
+      const isActivator = matchesKey(data, "down") || matchesKey(data, "left");
+      if (isActivator && this.agentRecords().length > 0 && this.ui.getEditorText() === "") {
+        this.active = true;
+        this.selectedIndex = 0;
+        this.update();
+        return { consume: true };
+      }
+      return undefined;
+    }
+
+    // Active — arrows navigate, Enter opens, Esc / Up-past-top exits.
+    if (matchesKey(data, "down")) {
+      const max = this.roster().length - 1;
+      this.selectedIndex = Math.min(max, this.selectedIndex + 1);
+      this.update();
+      return { consume: true };
+    }
+    if (matchesKey(data, "up")) {
+      if (this.selectedIndex === 0) { this.deactivate(); return { consume: true }; }
+      this.selectedIndex -= 1;
+      this.update();
+      return { consume: true };
+    }
+    if (matchesKey(data, "escape")) { this.deactivate(); return { consume: true }; }
+    if (matchesKey(data, Key.enter)) { this.openSelected(); return { consume: true }; }
+
+    // Any other key cancels navigation and flows to the editor.
+    this.deactivate();
+    return undefined;
+  }
+
+  private deactivate(): void {
+    this.active = false;
+    this.selectedIndex = 0;
+    this.update();
+  }
+
+  private openSelected(): void {
+    const entry = this.roster()[this.selectedIndex];
+    if (!entry || entry.kind === "main") {
+      // `main` = return to the prompt; the native transcript is already shown.
+      this.deactivate();
+      return;
+    }
+    const record = entry.record;
+    if (!this.ui) return;
+    if (!record.session) {
+      this.ui.notify(`Agent is ${record.status} — no session available.`, "info");
+      return;
+    }
+    const session = record.session;
+    const activity = this.agentActivity.get(record.id);
+    this.viewingAgentId = record.id;
+
+    void this.ui.custom<undefined>(
+      (tui, theme, keybindings, done) => {
+        this.viewerClose = () => done(undefined);
+        return new ConversationViewer(
+          tui,
+          session,
+          record,
+          activity,
+          theme,
+          done,
+          () => {
+            if (this.manager.abort(record.id)) this.ui?.notify(`Stopped "${record.description}".`, "info");
+          },
+          keybindings,
+        );
+      },
+      {
+        overlay: true,
+        overlayOptions: { anchor: "center", width: "90%", maxHeight: `${VIEWPORT_HEIGHT_PCT}%` },
+      },
+    ).then(() => this.clearViewer(), () => this.clearViewer());
+  }
+
+  /** Reset overlay state and return to the list (on close, auto-close, or error). */
+  private clearViewer(): void {
+    // Keep the cursor on the agent we were viewing — re-resolve by id so it
+    // still feels natural if the list reordered (an earlier agent finished)
+    // while the overlay was open. If that agent is gone, leave the index for
+    // update()'s clamp to settle.
+    if (this.viewingAgentId) {
+      const idx = this.roster().findIndex(e => e.kind === "agent" && e.record.id === this.viewingAgentId);
+      if (idx >= 0) this.selectedIndex = idx;
+    }
+    this.viewerClose = undefined;
+    this.viewingAgentId = undefined;
+    this.update();
+  }
+
+  // ---- Rendering ----
+
+  private renderBar(width: number, theme: Theme): string[] {
+    const agents = this.roster().slice(1) as AgentEntry[];
+    if (agents.length === 0) return [];
+    // Clamp locally so a render between a roster shrink and the next update()
+    // (e.g. on terminal resize) never loses the selection marker.
+    const sel = Math.min(this.selectedIndex, agents.length);
+
+    const hint = this.active
+      ? "↑↓ select · enter view · esc back"
+      : "esc to interrupt · ← for agents · ↓ to manage";
+    const lines: string[] = [];
+    lines.push(truncateToWidth("  " + theme.fg("dim", hint), width));
+    lines.push("");
+    lines.push(truncateToWidth(`  ${this.bullet(0, sel, theme)} main`, width));
+
+    // Window the agent rows so the selected one stays visible.
+    const visible = Math.min(MAX_AGENT_ROWS, agents.length);
+    const selAgent = Math.max(0, sel - 1);
+    const start = selAgent < visible ? 0 : selAgent - visible + 1;
+    const hiddenBelow = agents.length - (start + visible);
+
+    if (start > 0) lines.push(rightAlign("", theme.fg("dim", `↑ ${start} more`), width));
+    for (let a = start; a < start + visible; a++) {
+      lines.push(this.renderAgentRow(a + 1, sel, agents[a].record, width, theme));
+    }
+    if (hiddenBelow > 0) lines.push(rightAlign("", theme.fg("dim", `↓ ${hiddenBelow} more`), width));
+
+    return lines;
+  }
+
+  private bullet(rosterIndex: number, sel: number, theme: Theme): string {
+    return rosterIndex === sel ? theme.fg("accent", "⏺") : theme.fg("dim", "◯");
+  }
+
+  private renderAgentRow(rosterIndex: number, sel: number, record: AgentRecord, width: number, theme: Theme): string {
+    const left = `  ${this.bullet(rosterIndex, sel, theme)} ${theme.fg("muted", getDisplayName(record.type))}  ${record.description}`;
+    const tokens = getLifetimeTotal(this.agentActivity.get(record.id)?.lifetimeUsage ?? record.lifetimeUsage);
+    const elapsedMs = (record.completedAt ?? Date.now()) - record.startedAt; // freezes once finished
+    const right = theme.fg("dim", `${formatFleetElapsed(elapsedMs)} · ${formatFleetTokens(tokens)}`);
+    return rightAlign(left, right, width);
+  }
+}

--- a/src/ui/fleet-list.ts
+++ b/src/ui/fleet-list.ts
@@ -4,7 +4,7 @@
  * Shows `main` + each running/queued subagent as a navigable list. Pressing ↓ (or
  * ←) at an empty prompt activates the list; ↑/↓ move the selection (filled ⏺ marker),
  * Enter opens the selected agent's live conversation overlay, Esc returns to the prompt.
- * If the viewed agent finishes, the overlay auto-closes back to the list.
+ * A viewer stays open when its agent finishes; finished agents linger briefly in the list.
  *
  * Mechanics (see plan): the list is a `belowEditor` widget (render-only), and ALL key
  * handling goes through `onTerminalInput` — which fires before the focused editor and
@@ -159,6 +159,7 @@ export class FleetList {
     }
 
     this.clampSelection();
+    this.ensureTimer(); // keep stats ticking whenever the list is shown (e.g. after a re-enable)
 
     if (!this.widgetRegistered) {
       this.ui.setWidget(FLEET_KEY, (tui, theme) => {

--- a/test/fleet-list.test.ts
+++ b/test/fleet-list.test.ts
@@ -1,5 +1,5 @@
 import { visibleWidth } from "@earendil-works/pi-tui";
-import { describe, expect, it } from "vitest";
+import { describe, expect, it, vi } from "vitest";
 import type { AgentManager } from "../src/agent-manager.js";
 import type { AgentRecord } from "../src/types.js";
 import { getDisplayName } from "../src/ui/agent-widget.js";
@@ -201,6 +201,29 @@ describe("FleetList navigation", () => {
     h.fleet.setEnabled(false);
     expect(h.press(DOWN)).toBeUndefined();
     expect(h.render()).toEqual([]);
+  });
+
+  it("re-arms the refresh timer when the list is re-shown (toggle off→on)", () => {
+    vi.useFakeTimers();
+    try {
+      const agents = [makeRecord({ id: "a1" })];
+      const listAgents = vi.fn(() => agents);
+      const manager = { listAgents, abort: () => true } as unknown as AgentManager;
+      const fleet = new FleetList(manager, new Map());
+      fleet.setUICtx({
+        setWidget: () => {}, onTerminalInput: () => () => {}, getEditorText: () => "",
+        notify: () => {}, custom: (() => new Promise<undefined>(() => {})) as FleetUICtx["custom"],
+      });
+      fleet.update();          // shows list, arms the timer
+      fleet.setEnabled(false); // hides, clears the timer
+      fleet.setEnabled(true);  // re-shows — must re-arm the timer
+      const before = listAgents.mock.calls.length;
+      vi.advanceTimersByTime(250); // a tick should fire and re-read the roster
+      expect(listAgents.mock.calls.length).toBeGreaterThan(before);
+      fleet.dispose();
+    } finally {
+      vi.useRealTimers();
+    }
   });
 });
 

--- a/test/fleet-list.test.ts
+++ b/test/fleet-list.test.ts
@@ -1,0 +1,325 @@
+import { visibleWidth } from "@earendil-works/pi-tui";
+import { describe, expect, it } from "vitest";
+import type { AgentManager } from "../src/agent-manager.js";
+import type { AgentRecord } from "../src/types.js";
+import { getDisplayName } from "../src/ui/agent-widget.js";
+import { FleetList, type FleetUICtx, formatFleetElapsed, formatFleetTokens } from "../src/ui/fleet-list.js";
+
+// ---- Key sequences (see node_modules/@earendil-works/pi-tui/dist/keys.js) ----
+const DOWN = "\x1b[B";
+const UP = "\x1b[A";
+const LEFT = "\x1b[D";
+const RIGHT = "\x1b[C";
+const ESC = "\x1b";
+const ENTER = "\r";
+// Kitty-protocol key-RELEASE for ↓ (event type 3) — listeners receive these too.
+const DOWN_RELEASE = "\x1b[1;1:3B";
+
+const theme = { fg: (c: string, s: string) => `<${c}>${s}</${c}>`, bold: (s: string) => `*${s}*` };
+
+/** A no-op session so a record is "openable" by default (the list hides session-less agents). */
+const FAKE_SESSION = { subscribe: () => () => {}, messages: [] };
+
+function makeRecord(over: Partial<AgentRecord> = {}): AgentRecord {
+  return {
+    id: "a1",
+    type: "general-purpose",
+    description: "Sleep then report 1",
+    status: "running",
+    toolUses: 0,
+    startedAt: Date.now(),
+    session: FAKE_SESSION as any,
+    lifetimeUsage: { input: 13100, output: 0, cacheWrite: 0 },
+    compactionCount: 0,
+    ...over,
+  } as AgentRecord;
+}
+
+/** Fake manager exposing only what FleetList touches. */
+function fakeManager(agents: AgentRecord[]): AgentManager {
+  return {
+    listAgents: () => agents,
+    abort: () => true,
+  } as unknown as AgentManager;
+}
+
+interface Harness {
+  fleet: FleetList;
+  ui: FleetUICtx;
+  /** Feed a key to the registered input handler; returns the consume result. */
+  press: (data: string) => { consume?: boolean } | undefined;
+  /** Render the currently-registered below-editor widget at the given width. */
+  render: (width?: number) => string[];
+  setEditorText: (t: string) => void;
+  /** Whether an overlay has been opened. */
+  overlayOpened: () => boolean;
+  /** Whether the most recently opened overlay's `done` was invoked (closed). */
+  overlayClosed: () => boolean;
+  /** Simulate the viewer closing itself (Esc → done); flushes the close microtask. */
+  closeOverlay: () => Promise<void>;
+}
+
+function harness(agents: AgentRecord[]): Harness {
+  let inputHandler: ((data: string) => { consume?: boolean } | undefined) | undefined;
+  let widgetFactory: ((tui: any, theme: any) => { render(w: number): string[] }) | undefined;
+  let editorText = "";
+  let opened = false;
+  let closed = false;
+  let overlayDone: ((r: undefined) => void) | undefined;
+  const fakeTui = { requestRender: () => {}, terminal: { columns: 120, rows: 40 } };
+
+  const ui: FleetUICtx = {
+    setWidget: (_key, content) => { widgetFactory = content as any; },
+    onTerminalInput: (h) => { inputHandler = h; return () => { inputHandler = undefined; }; },
+    getEditorText: () => editorText,
+    notify: () => {},
+    custom: ((factory: any) => {
+      opened = true;
+      return new Promise<undefined>((resolve) => {
+        const done = (r: undefined) => { closed = true; overlayDone = undefined; resolve(r); };
+        overlayDone = done;
+        // Construct the overlay component so the controller wires viewerClose.
+        factory(fakeTui, theme, undefined, done);
+      });
+    }) as FleetUICtx["custom"],
+  };
+
+  const fleet = new FleetList(fakeManager(agents), new Map());
+  fleet.setUICtx(ui);
+  fleet.update();
+
+  return {
+    fleet,
+    ui,
+    press: (data) => inputHandler?.(data),
+    render: (width = 120) => (widgetFactory ? widgetFactory(fakeTui, theme).render(width) : []),
+    setEditorText: (t) => { editorText = t; },
+    overlayOpened: () => opened,
+    overlayClosed: () => closed,
+    closeOverlay: async () => { overlayDone?.(undefined); await Promise.resolve(); },
+  };
+}
+
+describe("formatFleetElapsed", () => {
+  it("renders integer seconds (no decimal, no suffix)", () => {
+    expect(formatFleetElapsed(0)).toBe("0s");
+    expect(formatFleetElapsed(11_000)).toBe("11s");
+    expect(formatFleetElapsed(11_400)).toBe("11s");
+    expect(formatFleetElapsed(11_600)).toBe("12s");
+  });
+  it("floors negatives to 0s", () => {
+    expect(formatFleetElapsed(-500)).toBe("0s");
+  });
+});
+
+describe("formatFleetTokens", () => {
+  it("prefixes a down-arrow and uses plural 'tokens'", () => {
+    expect(formatFleetTokens(13_100)).toBe("↓ 13.1k tokens");
+    expect(formatFleetTokens(950)).toBe("↓ 950 tokens");
+    expect(formatFleetTokens(1_200_000)).toBe("↓ 1.2M tokens");
+  });
+});
+
+describe("FleetList navigation", () => {
+  it("does not register a widget when there are no agents", () => {
+    const h = harness([]);
+    expect(h.render()).toEqual([]);
+  });
+
+  it("activates on ↓ at an empty prompt, consuming the key", () => {
+    const h = harness([makeRecord()]);
+    const res = h.press(DOWN);
+    expect(res).toEqual({ consume: true });
+    // main selected, list active → nav hint shown
+    expect(h.render().some(l => l.includes("enter view"))).toBe(true);
+  });
+
+  it("also activates on ← (matches the '← for agents' hint)", () => {
+    const h = harness([makeRecord()]);
+    expect(h.press(LEFT)).toEqual({ consume: true });
+  });
+
+  it("does NOT activate when the prompt is non-empty (typing is preserved)", () => {
+    const h = harness([makeRecord()]);
+    h.setEditorText("hello");
+    expect(h.press(DOWN)).toBeUndefined();
+  });
+
+  it("ignores key-release events so one tap moves exactly one row", () => {
+    const h = harness([
+      makeRecord({ id: "a1", description: "one" }),
+      makeRecord({ id: "a2", description: "two" }),
+    ]);
+    h.press(DOWN);          // activate → selection on main (idx 0)
+    h.press(DOWN_RELEASE);  // release half of the SAME tap — must be a no-op
+    expect(h.render().find(l => l.includes("main"))).toContain("⏺");
+    h.press(DOWN);          // a real second tap → first agent
+    h.press(DOWN_RELEASE);
+    expect(h.render().find(l => l.includes("one"))).toContain("⏺");
+    expect(h.render().find(l => l.includes("two"))).toContain("◯");
+  });
+
+  it("moves selection down/up and clamps at the ends", () => {
+    const agents = [
+      makeRecord({ id: "a1", description: "one" }),
+      makeRecord({ id: "a2", description: "two" }),
+    ];
+    const h = harness(agents);
+    h.press(DOWN); // activate → index 0 (main)
+    h.press(DOWN); // → 1 (a1)
+    expect(h.render().find(l => l.includes("one"))).toContain("⏺");
+    h.press(DOWN); // → 2 (a2)
+    h.press(DOWN); // clamp at 2
+    expect(h.render().find(l => l.includes("two"))).toContain("⏺");
+    expect(h.render().find(l => l.includes("one"))).toContain("◯");
+  });
+
+  it("↑ above 'main' deactivates (returns to the prompt)", () => {
+    const h = harness([makeRecord()]);
+    h.press(DOWN); // activate, index 0
+    expect(h.press(UP)).toEqual({ consume: true });
+    // back to inactive hint
+    expect(h.render().some(l => l.includes("← for agents"))).toBe(true);
+  });
+
+  it("Esc deactivates", () => {
+    const h = harness([makeRecord()]);
+    h.press(DOWN);
+    expect(h.press(ESC)).toEqual({ consume: true });
+    expect(h.render().some(l => l.includes("← for agents"))).toBe(true);
+  });
+
+  it("passes non-nav keys through and cancels navigation", () => {
+    const h = harness([makeRecord()]);
+    h.press(DOWN);
+    expect(h.press(RIGHT)).toBeUndefined();
+    expect(h.render().some(l => l.includes("← for agents"))).toBe(true);
+  });
+
+  it("ignores all input while disabled and hides the widget", () => {
+    const h = harness([makeRecord()]);
+    h.fleet.setEnabled(false);
+    expect(h.press(DOWN)).toBeUndefined();
+    expect(h.render()).toEqual([]);
+  });
+});
+
+describe("FleetList rendering", () => {
+  it("renders main + agent rows with markers, type, description and right-aligned stats", () => {
+    const h = harness([makeRecord({ description: "Sleep then report 1" })]);
+    const lines = h.render(120);
+    // hint + blank + main + one agent
+    expect(lines[0]).toContain("← for agents");
+    expect(lines.find(l => l.includes("main"))).toContain("⏺"); // main selected by default
+    const agentLine = lines.find(l => l.includes("Sleep then report 1"))!;
+    expect(agentLine).toContain("◯");
+    expect(agentLine).toContain(getDisplayName("general-purpose"));
+    expect(agentLine).toContain("↓ 13.1k tokens");
+    expect(agentLine).toMatch(/\d+s · ↓/); // "<seconds>s · ↓ ..." (timing-agnostic)
+  });
+
+  it("orders agents earliest-launched first (top)", () => {
+    const agents = [
+      makeRecord({ id: "new", description: "newest", startedAt: 2000 }),
+      makeRecord({ id: "old", description: "oldest", startedAt: 1000 }),
+    ];
+    const lines = harness(agents).render();
+    const oldIdx = lines.findIndex(l => l.includes("oldest"));
+    const newIdx = lines.findIndex(l => l.includes("newest"));
+    expect(oldIdx).toBeGreaterThanOrEqual(0);
+    expect(oldIdx).toBeLessThan(newIdx); // earliest sits above the later one
+  });
+
+  it("hides agents that have no session yet (pending)", () => {
+    const agents = [
+      makeRecord({ id: "live", description: "running one" }),
+      makeRecord({ id: "pending", description: "queued one", status: "queued", session: undefined }),
+    ];
+    const lines = harness(agents).render();
+    expect(lines.some(l => l.includes("running one"))).toBe(true);
+    expect(lines.some(l => l.includes("queued one"))).toBe(false);
+  });
+
+  it("collapses overflow into a '↓ N more' indicator", () => {
+    const agents = Array.from({ length: 8 }, (_, i) =>
+      makeRecord({ id: `a${i}`, description: `report ${i}` }));
+    const h = harness(agents);
+    const lines = h.render(120);
+    // 8 agents, cap 5 visible → "↓ 3 more"
+    expect(lines.some(l => l.includes("↓ 3 more"))).toBe(true);
+  });
+
+  it("never emits a line wider than the terminal (guards wrap-induced flicker)", () => {
+    const agents = Array.from({ length: 8 }, (_, i) =>
+      makeRecord({ id: `a${i}`, description: `a very long agent description number ${i} that keeps going` }));
+    const h = harness(agents);
+    for (const w of [4, 8, 12, 20, 40, 80, 200]) {
+      for (const line of h.render(w)) {
+        expect(visibleWidth(line)).toBeLessThanOrEqual(w);
+      }
+    }
+  });
+
+  it("windows the visible agents so the selection stays on screen", () => {
+    const agents = Array.from({ length: 8 }, (_, i) =>
+      makeRecord({ id: `a${i}`, description: `report ${i}` }));
+    const h = harness(agents);
+    h.press(DOWN); // activate (main)
+    // step down to the last agent (8 agents → roster index 8)
+    for (let i = 0; i < 8; i++) h.press(DOWN);
+    const lines = h.render(120);
+    expect(lines.find(l => l.includes("report 7"))).toContain("⏺");
+    expect(lines.some(l => l.includes("↑"))).toBe(true); // hidden-above indicator
+  });
+});
+
+describe("FleetList overlay lifecycle", () => {
+  it("Enter on 'main' just deactivates (no overlay)", () => {
+    const h = harness([makeRecord()]);
+    h.press(DOWN); // active, index 0 (main)
+    h.press(ENTER);
+    expect(h.overlayOpened()).toBe(false); // never opened an overlay
+    expect(h.render().some(l => l.includes("← for agents"))).toBe(true);
+  });
+
+  it("keeps the cursor on the viewed agent after closing, even if the list reordered", async () => {
+    const fakeSession = { subscribe: () => () => {}, messages: [] };
+    const agents = [
+      makeRecord({ id: "a1", description: "one", session: fakeSession as any }),
+      makeRecord({ id: "a2", description: "two", session: fakeSession as any }),
+      makeRecord({ id: "a3", description: "three", session: fakeSession as any }),
+    ];
+    const h = harness(agents);
+    h.press(DOWN); // activate (main, idx 0)
+    h.press(DOWN); // a1 (idx 1)
+    h.press(DOWN); // a2 (idx 2)
+    h.press(ENTER); // open a2
+    // a1 finishes and drops out while viewing → a2 shifts from idx 2 to idx 1.
+    agents.splice(0, 1);
+    await h.closeOverlay();
+    // Selection follows a2 ("two") to its new position, not whatever is at idx 2 now.
+    expect(h.render().find(l => l.includes("two"))).toContain("⏺");
+    expect(h.render().find(l => l.includes("three"))).toContain("◯");
+  });
+
+  it("does NOT auto-close when the viewed agent finishes (final output stays readable)", () => {
+    const agents = [makeRecord({ id: "live", description: "the one" })];
+    const h = harness(agents);
+    h.press(DOWN); // active (main)
+    h.press(DOWN); // → the agent
+    h.press(ENTER); // opens overlay
+    expect(h.overlayOpened()).toBe(true);
+    // The agent finishes, well past the linger window...
+    agents[0] = makeRecord({ id: "live", description: "the one", status: "completed", completedAt: Date.now() - 60_000 });
+    h.fleet.onAgentFinished("live");
+    expect(h.overlayClosed()).toBe(false);                          // viewer stays open
+    expect(h.render().some(l => l.includes("the one"))).toBe(true); // and stays listed while viewed
+  });
+
+  it("lingers a finished agent in the list, then drops it after the window", () => {
+    const recent = makeRecord({ id: "r", description: "recent done", status: "completed", completedAt: Date.now() });
+    expect(harness([recent]).render().some(l => l.includes("recent done"))).toBe(true);
+    const old = makeRecord({ id: "o", description: "old done", status: "completed", completedAt: Date.now() - 60_000 });
+    expect(harness([old]).render().some(l => l.includes("old done"))).toBe(false);
+  });
+});

--- a/test/fleet-wiring.test.ts
+++ b/test/fleet-wiring.test.ts
@@ -1,0 +1,141 @@
+/**
+ * fleet-wiring.test.ts — end-to-end wiring of the FleetView through the REAL
+ * extension (src/index.ts), not the FleetList class in isolation.
+ *
+ * The unit tests in fleet-list.test.ts drive FleetList with a fake ui/manager.
+ * These prove the bits only the extension can: that `tool_execution_start`
+ * hands the fleet the live UI (so it captures input), that spawning a background
+ * agent actually registers the `belowEditor` widget once the agent has a session,
+ * and that `session_shutdown` tears it down. runAgent is mocked (no LLM); the
+ * manager, settings load, completion routing, and lifecycle handlers are real.
+ */
+import { mkdirSync, mkdtempSync, rmSync, writeFileSync } from "node:fs";
+import { tmpdir } from "node:os";
+import { join } from "node:path";
+import { afterEach, beforeEach, describe, expect, it, vi } from "vitest";
+
+vi.mock("../src/agent-runner.js", async () => {
+  const actual = await vi.importActual<typeof import("../src/agent-runner.js")>("../src/agent-runner.js");
+  return { ...actual, runAgent: vi.fn() };
+});
+
+import { runAgent } from "../src/agent-runner.js";
+import subagentsExtension from "../src/index.js";
+
+function makePi() {
+  const tools = new Map<string, any>();
+  const lifecycle = new Map<string, any>();
+  const pi = {
+    registerMessageRenderer: vi.fn(),
+    registerTool: vi.fn((t: any) => tools.set(t.name, t)),
+    registerCommand: vi.fn(),
+    on: vi.fn((event: string, handler: any) => lifecycle.set(event, handler)),
+    events: { emit: vi.fn(), on: vi.fn(() => vi.fn()) },
+    appendEntry: vi.fn(),
+    sendMessage: vi.fn(),
+  } as any;
+  return { pi, tools, lifecycle };
+}
+
+/** A UI context with the surfaces the widget + fleet touch; setWidget is spied. */
+function uiCtx() {
+  return {
+    setStatus: vi.fn(),
+    setWidget: vi.fn(),
+    notify: vi.fn(),
+    onTerminalInput: vi.fn(() => vi.fn()),
+    getEditorText: vi.fn(() => ""),
+    custom: vi.fn(),
+  };
+}
+
+function ctxWith(ui: ReturnType<typeof uiCtx>) {
+  return {
+    hasUI: true,
+    ui,
+    cwd: process.cwd(),
+    model: undefined,
+    modelRegistry: { find: vi.fn(), getAvailable: vi.fn(() => []) },
+    sessionManager: { getSessionId: () => "s1", getBranch: () => [] },
+    getSystemPrompt: () => "parent",
+  } as any;
+}
+
+const textOf = (r: any): string => r.content[0].text;
+const flush = async () => {
+  await new Promise((r) => setImmediate(r));
+  await new Promise((r) => setImmediate(r));
+};
+
+describe("FleetView wiring (real extension lifecycle)", () => {
+  let tmpDir: string;
+  let agentDir: string;
+  let prevCwd: string;
+  let prevAgentDir: string | undefined;
+  let prevHome: string | undefined;
+
+  beforeEach(() => {
+    tmpDir = mkdtempSync(join(tmpdir(), "pi-fleet-"));
+    agentDir = mkdtempSync(join(tmpdir(), "pi-fleet-agentdir-"));
+    prevAgentDir = process.env.PI_CODING_AGENT_DIR;
+    prevHome = process.env.HOME;
+    process.env.PI_CODING_AGENT_DIR = agentDir;
+    process.env.HOME = agentDir;
+    prevCwd = process.cwd();
+    mkdirSync(join(tmpDir, ".pi"), { recursive: true });
+    // async join → completion routes straight to sendIndividualNudge (no batch
+    // debounce), so fleet.onAgentFinished fires synchronously on the result.
+    writeFileSync(join(tmpDir, ".pi", "subagents.json"), JSON.stringify({ schedulingEnabled: false, defaultJoinMode: "async" }));
+    process.chdir(tmpDir);
+  });
+
+  afterEach(() => {
+    process.chdir(prevCwd);
+    if (prevAgentDir == null) delete process.env.PI_CODING_AGENT_DIR;
+    else process.env.PI_CODING_AGENT_DIR = prevAgentDir;
+    if (prevHome == null) delete process.env.HOME;
+    else process.env.HOME = prevHome;
+    rmSync(tmpDir, { recursive: true, force: true });
+    rmSync(agentDir, { recursive: true, force: true });
+    vi.restoreAllMocks();
+  });
+
+  it("captures terminal input on tool_execution_start (fleet hooked into the UI)", async () => {
+    const { pi, lifecycle } = makePi();
+    subagentsExtension(pi);
+    const ui = uiCtx();
+    await lifecycle.get("tool_execution_start")?.({}, ctxWith(ui));
+    expect(ui.onTerminalInput).toHaveBeenCalled();
+  });
+
+  it("registers the belowEditor widget once a spawned agent has a session, then clears it on shutdown", async () => {
+    vi.mocked(runAgent).mockResolvedValue({
+      responseText: "done",
+      session: { dispose: vi.fn() } as any,
+      aborted: false,
+      steered: false,
+    });
+
+    const { pi, tools, lifecycle } = makePi();
+    subagentsExtension(pi);
+
+    const ui = uiCtx();
+    await lifecycle.get("tool_execution_start")?.({}, ctxWith(ui)); // fleet captures THIS ui
+
+    const spawn = await tools.get("Agent").execute(
+      "tc",
+      { prompt: "go", description: "live one", subagent_type: "general-purpose", run_in_background: true },
+      undefined,
+      undefined,
+      ctxWith(uiCtx()),
+    );
+    expect(textOf(spawn)).toMatch(/Agent ID:/);
+    await flush(); // completion → fleet.onAgentFinished → update → widget registers
+
+    const fleetRegs = ui.setWidget.mock.calls.filter(c => c[0] === "fleet" && typeof c[1] === "function");
+    expect(fleetRegs.length, "fleet widget should register with a render factory").toBeGreaterThan(0);
+
+    await lifecycle.get("session_shutdown")?.({}, ctxWith(uiCtx()));
+    expect(ui.setWidget).toHaveBeenCalledWith("fleet", undefined); // dispose cleared it
+  });
+});

--- a/test/settings.test.ts
+++ b/test/settings.test.ts
@@ -107,6 +107,15 @@ describe("settings persistence", () => {
     expect(loadSettings(projectDir)).toEqual({});
   });
 
+  it("round-trips fleetView (true and false); keeps boolean, drops non-boolean", () => {
+    saveSettings({ fleetView: false }, projectDir);
+    expect(loadSettings(projectDir)).toEqual({ fleetView: false });
+    saveSettings({ fleetView: true }, projectDir);
+    expect(loadSettings(projectDir)).toEqual({ fleetView: true });
+    writeProject({ fleetView: "on" } as any);
+    expect(loadSettings(projectDir)).toEqual({}); // non-boolean dropped
+  });
+
   it("sanitize drops non-boolean schedulingEnabled silently", async () => {
     writeProject({ schedulingEnabled: "yes" } as any);
     expect(loadSettings(projectDir)).toEqual({});
@@ -347,6 +356,7 @@ describe("settings persistence", () => {
         setScopeModels: vi.fn(),
         setDisableDefaultAgents: vi.fn(),
         setToolDescriptionMode: vi.fn(),
+        setFleetView: vi.fn(),
       };
     });
 
@@ -383,6 +393,7 @@ describe("settings persistence", () => {
           scopeModels: true,
           disableDefaultAgents: true,
           toolDescriptionMode: "compact",
+          fleetView: false,
         },
         appliers,
       );
@@ -394,6 +405,14 @@ describe("settings persistence", () => {
       expect(appliers.setScopeModels).toHaveBeenCalledWith(true);
       expect(appliers.setDisableDefaultAgents).toHaveBeenCalledWith(true);
       expect(appliers.setToolDescriptionMode).toHaveBeenCalledWith("compact");
+      expect(appliers.setFleetView).toHaveBeenCalledWith(false);
+    });
+
+    it("applies fleetView (true and false); skips it when absent", () => {
+      applySettings({ fleetView: true }, appliers);
+      expect(appliers.setFleetView).toHaveBeenCalledWith(true);
+      applySettings({}, appliers);
+      expect(appliers.setFleetView).toHaveBeenCalledTimes(1); // absence is "use default"
     });
 
     it("applies scopeModels: false", () => {
@@ -467,6 +486,7 @@ describe("settings persistence", () => {
         setScopeModels: vi.fn(),
         setDisableDefaultAgents: vi.fn(),
         setToolDescriptionMode: vi.fn(),
+        setFleetView: vi.fn(),
       };
     });
 


### PR DESCRIPTION
## What

  Adds **FleetView**: a persistent, navigable list of `main` + every active
  subagent rendered beneath the editor, mirroring Claude Code's bottom fleet bar.
  It auto-shows whenever subagents are running — no keypress needed.
  
  On by default, disable via **Settings - Fleet view**

    esc to interrupt · ← for agents · ↓ to manage

    ⏺ main
    ◯ general-purpose  report 1                         11s · ↓ 13.1k tokens
    ◯ general-purpose  report 2                          9s · ↓ 12.0k tokens
                                                                    ↓ 3 more


  ## Flow

  - `↓` / `←` at an **empty prompt** moves focus into the list (`⏺` = selected, `◯` = others)
  - `↑` / `↓` select · `Enter` opens the agent's **live, auto-updating** conversation overlay
  - `Esc` (or `↑` above `main`) returns to the prompt; selecting `main` returns to the normal view
  - Typing at a non-empty prompt behaves normally — the list only captures arrows when the prompt is empty

  ## Behavior decisions

  - **Earliest-launched first**, so the agents you started sooner sit at the top
  - Only **openable** agents (those with a session) are listed — pending/queued ones appear once they start, so `Enter` never dead-ends
  - **Finished agents linger ~4s** before dropping out (elapsed frozen at completion)
  - A viewer **stays open through its agent's completion** so the final output stays readable; you close it with `Esc`
  - Selection **follows the viewed agent by id**, so closing returns you to the same agent even if the list reordered while it was open

  ## Implementation

  - `belowEditor` widget; all key handling via `onTerminalInput` (fires before the editor, `consume`s only the keys it uses)
  - Acts on key-**press** only — ignores kitty-protocol release events (otherwise each tap moved twice / `Enter` only hit the overshot last agent)
  - Every rendered line is width-clamped — the narrow-terminal crash/flicker class previously fixed in v0.2.7 and #7
  - Reuses the existing `ConversationViewer` overlay unchanged
  - Toggle via `/agents → Settings → Fleet view` (default on; pure-UI, no LLM-context cost)

  ## Files

  - New: `src/ui/fleet-list.ts`, `test/fleet-list.test.ts` (23 tests)
  - Wiring: `src/index.ts` · setting: `src/settings.ts` · docs: `README.md`, `CHANGELOG.md`

  ## Testing

  `npm run test` (640 pass / 4 skip), `typecheck`, `lint`, `build` — all green.
  Fleet tests cover navigation, key-release filtering, ordering, pending-hidden,
  linger, no-auto-close, selection-follows-viewed-agent, and a width-safety
  sweep down to 4 columns.


https://github.com/user-attachments/assets/f579608c-4136-4afc-9e10-1af0f77044e4