### PR TITLE
fix: don't let re-activations clobber the Symbol.for manager registry

### DIFF
--- a/src/index.ts
+++ b/src/index.ts
@@ -438,14 +438,25 @@ export default function (pi: ExtensionAPI) {
 
   // Expose manager via Symbol.for() global registry for cross-package access.
   // Standard Node.js pattern for cross-package singletons (used by OpenTelemetry, etc.).
+  //
+  // Claim the slot only if it's free: subagent sessions re-activate this
+  // extension in the same process (session.bindExtensions in agent-runner.ts),
+  // and unconditionally overwriting would point the registry at a short-lived
+  // child manager — and the child's shutdown would then delete the root
+  // session's entry. The first activation (the root session) wins; child
+  // activations leave it alone.
   const MANAGER_KEY = Symbol.for("pi-subagents:manager");
-  (globalThis as any)[MANAGER_KEY] = {
+  const registryEntry = {
     waitForAll: () => manager.waitForAll(),
     hasRunning: () => manager.hasRunning(),
     spawn: (piRef: any, ctx: any, type: string, prompt: string, options: any) =>
       manager.spawn(piRef, ctx, type, prompt, options),
     getRecord: (id: string) => manager.getRecord(id),
   };
+  const ownsManagerRegistry = (globalThis as any)[MANAGER_KEY] === undefined;
+  if (ownsManagerRegistry) {
+    (globalThis as any)[MANAGER_KEY] = registryEntry;
+  }
 
   // --- Cross-extension RPC via pi.events ---
   let currentCtx: ExtensionContext | undefined;
@@ -500,7 +511,11 @@ export default function (pi: ExtensionAPI) {
     unsubStopRpc();
     unsubPingRpc();
     currentCtx = undefined;
-    delete (globalThis as any)[MANAGER_KEY];
+    // Only release the global slot if this activation claimed it — a child
+    // session's shutdown must not delete the root session's registry entry.
+    if (ownsManagerRegistry && (globalThis as any)[MANAGER_KEY] === registryEntry) {
+      delete (globalThis as any)[MANAGER_KEY];
+    }
     scheduler.stop();
     manager.abortAll();
     for (const timer of pendingNudges.values()) clearTimeout(timer);

--- a/test/manager-registry-guard.test.ts
+++ b/test/manager-registry-guard.test.ts
@@ -1,0 +1,108 @@
+/**
+ * manager-registry-guard.test.ts — the Symbol.for("pi-subagents:manager")
+ * global registry across multiple activations in one process.
+ *
+ * Subagent sessions re-activate this extension in the same process
+ * (session.bindExtensions in agent-runner.ts). The old code let every
+ * activation overwrite the global slot — pointing cross-package consumers at
+ * a short-lived child manager — and every child's session_shutdown DELETED
+ * the slot, so the root session's entry was lost as soon as any subagent ran.
+ *
+ * The fix: the first activation claims the slot, later activations leave it
+ * alone, and only the owner's shutdown releases it.
+ */
+import { afterEach, describe, expect, it, vi } from "vitest";
+
+vi.mock("../src/agent-runner.js", async () => {
+  const actual = await vi.importActual<typeof import("../src/agent-runner.js")>("../src/agent-runner.js");
+  return { ...actual, runAgent: vi.fn() };
+});
+
+import { runAgent } from "../src/agent-runner.js";
+import subagentsExtension from "../src/index.js";
+
+const MANAGER_KEY = Symbol.for("pi-subagents:manager");
+
+function makePi() {
+  const tools = new Map<string, any>();
+  const lifecycle = new Map<string, any>();
+  const pi = {
+    registerMessageRenderer: vi.fn(),
+    registerTool: vi.fn((t: any) => tools.set(t.name, t)),
+    registerCommand: vi.fn(),
+    on: vi.fn((event: string, handler: any) => lifecycle.set(event, handler)),
+    events: {
+      emit: vi.fn(),
+      on: vi.fn(() => vi.fn()),
+    },
+    appendEntry: vi.fn(),
+    sendMessage: vi.fn(),
+  } as any;
+  return { pi, tools, lifecycle };
+}
+
+function ctx() {
+  return {
+    hasUI: false,
+    ui: { setStatus: vi.fn(), setWidget: vi.fn(), notify: vi.fn() },
+    cwd: process.cwd(),
+    model: undefined,
+    modelRegistry: { find: vi.fn(), getAvailable: vi.fn(() => []) },
+    sessionManager: { getSessionId: vi.fn(() => "s1"), getBranch: vi.fn(() => []) },
+    getSystemPrompt: vi.fn(() => "parent"),
+  } as any;
+}
+
+const textOf = (r: any): string => r.content[0].text;
+
+async function spawnBackground(tools: Map<string, any>): Promise<string> {
+  vi.mocked(runAgent).mockImplementation(() => new Promise(() => {}) as any); // never resolves
+  const r = await tools.get("Agent").execute(
+    "tc-spawn",
+    { prompt: "go", description: "registry test agent", subagent_type: "general-purpose", run_in_background: true },
+    undefined,
+    undefined,
+    ctx(),
+  );
+  return /Agent ID: (\S+)/.exec(textOf(r))![1];
+}
+
+// Restore the global slot around every test.
+const priorGlobal = (globalThis as any)[MANAGER_KEY];
+afterEach(() => {
+  if (priorGlobal === undefined) delete (globalThis as any)[MANAGER_KEY];
+  else (globalThis as any)[MANAGER_KEY] = priorGlobal;
+  vi.mocked(runAgent).mockReset();
+});
+
+describe("Symbol.for manager registry across activations", () => {
+  it("child activation does not overwrite the root entry; child shutdown does not delete it", async () => {
+    delete (globalThis as any)[MANAGER_KEY];
+
+    // Root session activates first and owns the registry.
+    const root = makePi();
+    subagentsExtension(root.pi);
+    const rootEntry = (globalThis as any)[MANAGER_KEY];
+    expect(rootEntry).toBeDefined();
+
+    // Spawn a background agent through the ROOT so its record is findable.
+    const id = await spawnBackground(root.tools);
+    expect(rootEntry.getRecord(id)).toBeDefined();
+
+    // A child agent session re-activates the extension in-process.
+    const child = makePi();
+    subagentsExtension(child.pi);
+
+    // Registry still points at the root's entry (child did not clobber it) …
+    expect((globalThis as any)[MANAGER_KEY]).toBe(rootEntry);
+    expect((globalThis as any)[MANAGER_KEY].getRecord(id)).toBeDefined();
+
+    // … and the child's shutdown does not delete the root's entry.
+    await child.lifecycle.get("session_shutdown")?.();
+    expect((globalThis as any)[MANAGER_KEY]).toBe(rootEntry);
+
+    // The root's own shutdown releases the slot.
+    await root.lifecycle.get("session_shutdown")?.();
+    expect((globalThis as any)[MANAGER_KEY]).toBeUndefined();
+  });
+});


### PR DESCRIPTION
## Summary

Subagent sessions re-activate this extension in the same process (`session.bindExtensions` inside `runAgent`, `src/agent-runner.ts`) — every subagent spawn runs the whole extension's activation code again inside the child's own session. The `Symbol.for("pi-subagents:manager")` global registry didn't account for that: every activation unconditionally overwrote the slot with its own manager, and every activation's `session_shutdown` unconditionally deleted it.

Net effect: after the first subagent in a session completes, `globalThis[Symbol.for("pi-subagents:manager")]` points at that child's (usually already-shutting-down) manager instead of the root session's — and the child's own shutdown then deletes the slot entirely, even though the root session is still alive and may still have running background agents.

This isn't hypothetical — `test/helpers/print-mode-runner.ts` in this repo documents a real cross-package consumer: headless/print-mode hosts (the `pi-chonky-step` pattern) poll this exact global's `hasRunning()`/`waitForAll()` to decide whether to keep the process alive while background subagents finish. Under the old code, that check can report `false`/empty after any single subagent completes, even while the root session has real background agents still running — a headless host could exit and kill them mid-run.

## Fix

First activation to see an empty slot claims it (`ownsManagerRegistry`); later activations (children) leave it alone. Only the owning activation's shutdown releases it, and only if the slot still holds *that* activation's own entry (identity check), so a stale/superseded owner's shutdown can't delete a successor's live entry.

```ts
const ownsManagerRegistry = (globalThis as any)[MANAGER_KEY] === undefined;
if (ownsManagerRegistry) {
  (globalThis as any)[MANAGER_KEY] = registryEntry;
}
// ...on session_shutdown:
if (ownsManagerRegistry && (globalThis as any)[MANAGER_KEY] === registryEntry) {
  delete (globalThis as any)[MANAGER_KEY];
}
```

## Test plan

- [x] `test/manager-registry-guard.test.ts` — drives two real activations of the extension through the real `session_shutdown` lifecycle: spawns a background agent through the root, activates a second ("child") instance, asserts the registry still resolves to the root's manager and the root's record, asserts the child's shutdown does not delete the slot, and asserts the root's own shutdown does release it
- [x] `npm run lint` / `npm run typecheck` / `npm run test` / `npm run build` all pass

## Related

While tracing this I found a second, related but distinct issue in the same area — child agent sessions never fire `session_shutdown` at all on ordinary completion (only on `reload`), so each child's own `AgentManager` (interval, worktree tracking) is never disposed. That one can't be fixed from this side of the boundary (needs a `pi-coding-agent` teardown hook), so I filed it separately as #126 rather than folding it into this PR.