### PR TITLE
feat: allow subagents to spawn nested subagents (depth-capped)

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -7,6 +7,9 @@ and this project adheres to [Semantic Versioning](https://semver.org/spec/v2.0.0
 
 ## [Unreleased]
 
+### Added
+- **Subagent nesting — a subagent may spawn its own subagents up to a configurable depth.** The `Agent`/`get_subagent_result`/`steer_subagent` tools are no longer unconditionally stripped from every subagent; instead a subagent whose own nesting depth is below `MAX_NESTING_DEPTH` (default `2`) keeps them and may spawn children, while a subagent at or above the cap has them stripped as before. Depth is tracked in-process by AgentSession id: the spawn site reads the parent id via `ctx.sessionManager.getSessionId()`, each child records its depth right after `createAgentSession`, and the grandchild is gated at `childDepth + 1` — `main(0) → child(1) → grandchild(2, capped)`. Single-level callers are unaffected (a depth-1 child behaves exactly as before, it additionally retains the ability to spawn one more level). Resumed/orphaned sessions fall back to depth 0. New `src/depth.ts`.
+
 ## [0.13.0] - 2026-06-30
 
 ### Added

--- a/README.md
+++ b/README.md
@@ -351,6 +351,21 @@ Background agents are subject to a configurable concurrency limit (default: 4). 
 
 Foreground agents bypass the queue — they block the parent anyway.
 
+## Subagent Nesting
+
+By default a subagent cannot spawn further subagents — the `Agent`, `get_subagent_result`, and `steer_subagent` tools are stripped from its toolset to prevent runaway recursion. Nesting lifts this restriction with a depth cap.
+
+A subagent whose own nesting **depth** is below `MAX_NESTING_DEPTH` (default `2`) keeps those tools and may spawn its own children; a subagent at or above the cap has them stripped as before.
+
+```
+main (depth 0) → child (depth 1, can nest) → grandchild (depth 2, capped)
+```
+
+Depth is tracked in-process by AgentSession id: the spawn site reads the parent's id (`ctx.sessionManager.getSessionId()`), and each child records its depth right after it is created, so the grandchild is gated at `childDepth + 1`. A resumed/orphaned session falls back to depth 0 — it is treated as a fresh top-level session and may spawn again (the cap still holds from it downward).
+
+- **Cap:** `MAX_NESTING_DEPTH` in `src/depth.ts` (default `2`). Single-level callers are unaffected — a depth-1 child behaves exactly as before, it simply *also* retains the ability to spawn one more level.
+- **Note:** the gate is name-based. At depth `< MAX`, an extension that registers a tool literally named `steer_subagent` (or `Agent`) is allowed through alongside this extension's own tool, since the filter cannot tell them apart. This matches the pre-existing name-based exclusion.
+
 ## Join Strategies
 
 When background agents complete, they notify the main agent. The **join mode** controls how these notifications are delivered. It applies only to background agents.

--- a/src/agent-manager.ts
+++ b/src/agent-manager.ts
@@ -12,6 +12,7 @@ import { isAbsolute } from "node:path";
 import type { Model } from "@earendil-works/pi-ai";
 import type { AgentSession, ExtensionAPI, ExtensionContext } from "@earendil-works/pi-coding-agent";
 import { resumeAgent, runAgent, type ToolActivity } from "./agent-runner.js";
+import { forgetSessionDepth } from "./depth.js";
 import type { AgentInvocation, AgentRecord, IsolationMode, SubagentType, ThinkingLevel } from "./types.js";
 import { addUsage } from "./usage.js";
 import { cleanupWorktree, createWorktree, pruneWorktrees, } from "./worktree.js";
@@ -524,6 +525,8 @@ export class AgentManager {
 
   /** Dispose a record's session and remove it from the map. */
   private removeRecord(id: string, record: AgentRecord): void {
+    // Drop depth entry before disposing so a resumed session re-seeds from 0.
+    if (record.session) forgetSessionDepth(record.session.sessionId);
     record.session?.dispose?.();
     record.session = undefined;
     this.agents.delete(id);
@@ -604,6 +607,7 @@ export class AgentManager {
     // Clear queue
     this.queue = [];
     for (const record of this.agents.values()) {
+      if (record.session) forgetSessionDepth(record.session.sessionId);
       record.session?.dispose();
     }
     this.agents.clear();

--- a/src/agent-runner.ts
+++ b/src/agent-runner.ts
@@ -19,6 +19,7 @@ import {
 import { BUILTIN_TOOL_NAMES, getAgentConfig, getConfig, getMemoryToolNames, getReadOnlyMemoryToolNames, getToolNamesForType } from "./agent-types.js";
 import { buildParentContext, extractText } from "./context.js";
 import { DEFAULT_AGENTS } from "./default-agents.js";
+import { canNest, getSessionDepth, recordSessionDepth } from "./depth.js";
 import { detectEnv } from "./env.js";
 import { buildMemoryBlock, buildReadOnlyMemoryBlock } from "./memory.js";
 import { buildAgentPrompt, type PromptExtras } from "./prompts.js";
@@ -551,9 +552,16 @@ export async function runAgent(
   // pi-mono's `allowedToolNames` gates BOTH registration and the initial active
   // set, so listing the exact final set here means the session is correctly
   // scoped from the first instant — no post-construction narrowing required.
+  // Nesting depth: a subagent whose own depth is under MAX_NESTING_DEPTH keeps
+  // the spawn/steer/result tools so it can spawn its own children up to the cap;
+  // at or above the cap the tools are stripped (prevents runaway recursion).
+  const parentSessionId = ctx.sessionManager?.getSessionId?.() ?? "";
+  const childDepth = getSessionDepth(parentSessionId) + 1;
+  const allowNesting = canNest(childDepth);
+
   const builtinToolNameSet = new Set(toolNames);
   const allowedTools = [...toolNames, ...extensionToolNames].filter((t) => {
-    if (EXCLUDED_TOOL_NAMES.includes(t)) return false;
+    if (!allowNesting && EXCLUDED_TOOL_NAMES.includes(t)) return false;
     if (disallowedSet?.has(t)) return false;
     if (builtinToolNameSet.has(t)) return true;
     // Reached only for extension tools. The extension set was already filtered
@@ -584,6 +592,11 @@ export async function runAgent(
   }
 
   const { session } = await createAgentSession(sessionOpts);
+
+  // Record this child's depth so that, if it later spawns a grandchild, its own
+  // ctx.sessionManager.getSessionId() resolves to `childDepth` and the grandchild
+  // is gated at childDepth + 1. Keyed by session id (see depth.ts).
+  recordSessionDepth(session.sessionId, childDepth);
 
   const baseSessionName = agentConfig?.name ?? type;
   session.setSessionName(

--- a/src/depth.ts
+++ b/src/depth.ts
@@ -1,0 +1,50 @@
+/**
+ * depth.ts — Subagent nesting-depth tracking, keyed by AgentSession id.
+ *
+ * Why session id as the key: it is the only stable per-session handle reachable
+ * from both ends of a spawn. The spawn site knows the parent via
+ * `ctx.sessionManager.getSessionId()` (the handler runs in the parent's
+ * context); the runner learns the child's id from `session.sessionId` right
+ * after `createAgentSession`. A Map between the two carries the depth forward
+ * without threading a counter through SpawnArgs/RunOptions.
+ *
+ * Depth convention: the top-level pi session is depth 0. Each spawn increments
+ * by 1. A subagent may itself spawn iff its OWN depth < MAX_NESTING_DEPTH, so
+ * the deepest spawnable level is exactly MAX_NESTING_DEPTH. With the default
+ * of 2: main(0) → child(1) → grandchild(2, cannot spawn further).
+ *
+ * Resume of an orphaned session falls back to depth 0 — it is treated as a
+ * fresh top-level session and may spawn again. This is safe (the cap still
+ * holds from the resumed session downward) and avoids persisting depth state.
+ */
+
+/** Maximum depth at which a subagent may itself spawn further subagents. */
+export const MAX_NESTING_DEPTH = 2;
+
+/** sessionId → depth. Module-global: one process, one agent tree. */
+const sessionDepth = new Map<string, number>();
+
+/** Depth of the session with this id, or 0 when unknown (main / resumed-orphan). */
+export function getSessionDepth(sessionId: string): number {
+  return sessionDepth.get(sessionId) ?? 0;
+}
+
+/** Record a child session's depth right after it is created. No-op if no id. */
+export function recordSessionDepth(sessionId: string, depth: number): void {
+  if (sessionId) sessionDepth.set(sessionId, depth);
+}
+
+/** Drop a session's depth entry once it is cleaned up. No-op if absent. */
+export function forgetSessionDepth(sessionId: string): void {
+  sessionDepth.delete(sessionId);
+}
+
+/** Whether a subagent at `depth` is itself allowed to spawn further subagents. */
+export function canNest(depth: number): boolean {
+  return depth < MAX_NESTING_DEPTH;
+}
+
+/** Test-only: clear all tracked depth. Keeps the module-global Map honest between tests. */
+export function _resetForTesting(): void {
+  sessionDepth.clear();
+}

--- a/test/agent-runner.test.ts
+++ b/test/agent-runner.test.ts
@@ -113,6 +113,7 @@ import {
   resumeAgent,
   runAgent,
 } from "../src/agent-runner.js";
+import { _resetForTesting, MAX_NESTING_DEPTH, recordSessionDepth } from "../src/depth.js";
 
 function createSession(finalText: string) {
   const listeners: Array<(event: any) => void> = [];
@@ -143,12 +144,13 @@ const ctx = {
   model: undefined,
   modelRegistry: { find: vi.fn(), getAvailable: vi.fn(() => []) },
   getSystemPrompt: vi.fn(() => "parent prompt"),
-  sessionManager: { getBranch: vi.fn(() => []) },
+  sessionManager: { getBranch: vi.fn(() => []), getSessionId: vi.fn(() => "test-parent") },
 } as any;
 
 const pi = {} as any;
 
 beforeEach(() => {
+  _resetForTesting();
   createAgentSession.mockReset();
   defaultResourceLoaderCtor.mockClear();
   getAgentDir.mockClear();
@@ -606,7 +608,7 @@ describe("agent-runner master tool allowlist", () => {
     expect(tools).toContain("read");
   });
 
-  it("EXCLUDED_TOOL_NAMES never reach the allowlist even if an extension registers them", async () => {
+  it("EXCLUDED_TOOL_NAMES are retained for a nesting-capable child (depth < MAX)", async () => {
     vi.mocked(getConfig).mockReturnValueOnce(makeConfig({ extensions: true }));
     vi.mocked(getAgentConfig).mockReturnValueOnce(makeAgentConfig({ extensions: true }));
     vi.mocked(getToolNamesForType).mockReturnValueOnce(BUILTINS_7);
@@ -616,6 +618,28 @@ describe("agent-runner master tool allowlist", () => {
     const { session } = createSession("OK");
     createAgentSession.mockResolvedValue({ session });
 
+    // ctx.sessionManager.getSessionId() -> "test-parent" (depth 0) => child depth 1 < MAX => nesting on.
+    await runAgent(ctx, "Explore", "go", { pi });
+
+    const tools = lastToolsPassed();
+    expect(tools).toContain("Agent");
+    expect(tools).toContain("get_subagent_result");
+    expect(tools).toContain("steer_subagent");
+    expect(tools).toContain("ok_ext");
+  });
+
+  it("EXCLUDED_TOOL_NAMES are stripped at the nesting cap (depth >= MAX)", async () => {
+    vi.mocked(getConfig).mockReturnValueOnce(makeConfig({ extensions: true }));
+    vi.mocked(getAgentConfig).mockReturnValueOnce(makeAgentConfig({ extensions: true }));
+    vi.mocked(getToolNamesForType).mockReturnValueOnce(BUILTINS_7);
+    withExtensions({
+      "/ext/evil.ts": ["Agent", "get_subagent_result", "steer_subagent", "ok_ext"],
+    });
+    const { session } = createSession("OK");
+    createAgentSession.mockResolvedValue({ session });
+
+    // Parent already at MAX-1 => this child lands at depth MAX and is capped (cannot nest).
+    recordSessionDepth("test-parent", MAX_NESTING_DEPTH - 1);
     await runAgent(ctx, "Explore", "go", { pi });
 
     const tools = lastToolsPassed();

--- a/test/depth.test.ts
+++ b/test/depth.test.ts
@@ -1,0 +1,40 @@
+import { beforeEach, describe, expect, it } from "vitest";
+import {
+  _resetForTesting,
+  canNest,
+  forgetSessionDepth,
+  getSessionDepth,
+  MAX_NESTING_DEPTH,
+  recordSessionDepth,
+} from "../src/depth.js";
+
+describe("depth", () => {
+  beforeEach(() => _resetForTesting());
+
+  it("defaults unknown sessions to depth 0", () => {
+    expect(getSessionDepth("unknown")).toBe(0);
+  });
+
+  it("records and reads back a session depth", () => {
+    recordSessionDepth("child-1", 1);
+    expect(getSessionDepth("child-1")).toBe(1);
+  });
+
+  it("forgets a session depth", () => {
+    recordSessionDepth("child-1", 1);
+    forgetSessionDepth("child-1");
+    expect(getSessionDepth("child-1")).toBe(0);
+  });
+
+  it("allows nesting below the cap and blocks at/above it", () => {
+    expect(canNest(0)).toBe(true);
+    expect(canNest(MAX_NESTING_DEPTH - 1)).toBe(true);
+    expect(canNest(MAX_NESTING_DEPTH)).toBe(false);
+    expect(canNest(MAX_NESTING_DEPTH + 1)).toBe(false);
+  });
+
+  it("ignores empty session ids when recording", () => {
+    recordSessionDepth("", 1);
+    expect(getSessionDepth("")).toBe(0);
+  });
+});


### PR DESCRIPTION
## What

Allows a subagent to spawn its own subagents, up to a configurable depth cap (`MAX_NESTING_DEPTH`, default `2`). Today `Agent` / `get_subagent_result` / `steer_subagent` are unconditionally stripped from every subagent's toolset, so subagents can never delegate further — this lifts that restriction with a depth guard that still prevents runaway recursion.

## Why

Multi-step orchestration patterns (plan → critic → implement, or fan-out → merge) currently force the whole tree to live inside a single top-level agent's context. Letting a child spawn one more level keeps each layer's context clean and lets the existing subagent machinery (queueing, join strategies, FleetView, worktree isolation) compose recursively — which it already supports structurally, except for this one tool-stripping rule.

## How it works

Depth is tracked in-process by AgentSession id (`src/depth.ts`):

- The spawn site reads the parent's id via `ctx.sessionManager.getSessionId()`.
- Each child computes `childDepth = getSessionDepth(parentId) + 1` and records it right after `createAgentSession`, so if it later spawns, its own id resolves to `childDepth` and the grandchild is gated at `childDepth + 1`.
- A subagent keeps the spawn tools iff `canNest(childDepth)` = `childDepth < MAX_NESTING_DEPTH`.

```
main (0) → child (1, can nest) → grandchild (2, capped: tools stripped)
```

On session teardown (`removeRecord` / `dispose()`), `forgetSessionDepth` drops the entry so a resumed session re-seeds from 0.

## Behavior notes

- **Single-level callers are unaffected.** A depth-1 child behaves exactly as before — it simply *also* retains the ability to spawn one more level. Existing configs see no change other than that extra capability.
- **Default-on is safe because of the cap.** The original reason to strip the tools was runaway recursion; `MAX_NESTING_DEPTH` removes that risk while enabling delegation. I'm happy to gate this behind a setting (default off) if the default-on behavior change is a concern — flagging it explicitly for review.
- **Name-based filter caveat (unchanged from today):** the exclusion is by tool name. At depth `< MAX`, an unrelated extension that registers a tool literally named `steer_subagent`/`Agent` is allowed through alongside this extension's own — the filter cannot tell them apart. This is pre-existing behavior; nesting just extends the "allowed" side to one more level.
- **Resume/orphan:** a resumed or orphaned session has no recorded depth and falls back to 0 — treated as a fresh top-level session that may spawn again (the cap still holds from it downward). Depth is intentionally not persisted.

## Configurability

`MAX_NESTING_DEPTH` is a single constant in `src/depth.ts`. Easy to expose as a setting if desired.

## Testing

- New `src/depth.ts` + `test/depth.test.ts` (get/record/forget/canNest boundaries, empty-id no-op).
- `test/agent-runner.test.ts`: the ctx mock now exposes `getSessionId`, `beforeEach` resets depth state, and the existing "EXCLUDED_TOOL_NAMES never reach the allowlist" case is split into two — (a) a nesting-capable child (depth 1 `< MAX`) **retains** the three tools, and (b) a capped child (depth `≥ MAX`, via `recordSessionDepth(parent, MAX-1)`) still **strips** them, preserving the original protection.
- `npm run typecheck` ✅ · `npm run lint` (biome) ✅ · `npm test` → 676 passed / 4 skipped. The 5 `agent-runner-e2e.test.ts` failures are pre-existing and environmental (they need a real pi-mono session; they fail identically on pristine `v0.13.0` without these changes).
