### PR TITLE
feat: persist structured subagent usage

### DIFF
--- a/README.md
+++ b/README.md
@@ -436,7 +436,7 @@ Agent lifecycle events are emitted via `pi.events.emit()` so other extensions ca
 |-------|------|------------|
 | `subagents:created` | Background agent registered | `id`, `type`, `description`, `isBackground` |
 | `subagents:started` | Agent transitions to running (including queued→running) | `id`, `type`, `description` |
-| `subagents:completed` | Agent finished successfully (background and foreground) | `id`, `type`, `durationMs`, `tokens` (lifetime `{ input, output, total }`), `toolUses`, `result` |
+| `subagents:completed` | Agent finished successfully (background and foreground) | `id`, `type`, `durationMs`, `tokens` (lifetime `{ input, output, total }`), `usageRecords`, `toolUses`, `result` |
 | `subagents:failed` | Agent errored, stopped, or aborted (background and foreground) | same as completed + `error`, `status` |
 | `subagents:steered` | Steering message sent | `id`, `message` |
 | `subagents:compacted` | Agent's session successfully compacted | `id`, `type`, `description`, `reason` (`"manual"` / `"threshold"` / `"overflow"`), `tokensBefore`, `compactionCount` |
@@ -447,6 +447,8 @@ Agent lifecycle events are emitted via `pi.events.emit()` so other extensions ca
 | `subagents:settings_changed` | `/agents` → Settings mutation was applied | `settings`, `persisted` (`boolean` — `false` on write failure) |
 
 `tokens.total` = `input + output + cacheWrite`. `cacheRead` is excluded — each turn's `cacheRead` is the cumulative cached prefix re-read on that one API call, so summing per-message would over-count it. Use `contextUsage.percent` (surfaced as `(NN%)` in the widget) for current context size.
+
+`usageRecords` preserves each finalized assistant message from the completed invocation as `{ timestamp, provider, model, usage }`, where `usage` is pi's standard usage object including input, output, cache reads/writes, total tokens, and itemized cost. A resumed invocation contains only its newly generated usage records, while `tokens` remains the agent's lifetime billed-token total. The same records are stored in the parent session's `subagents:record` custom entry, so analytics extensions can reconstruct subagent usage after restart without reading temporary transcript files. Prompt, response, and tool content are not duplicated.
 
 ## Cross-Extension RPC
 

--- a/src/agent-manager.ts
+++ b/src/agent-manager.ts
@@ -13,7 +13,7 @@ import type { Model } from "@earendil-works/pi-ai";
 import type { AgentSession, ExtensionAPI, ExtensionContext } from "@earendil-works/pi-coding-agent";
 import { resumeAgent, runAgent, type ToolActivity } from "./agent-runner.js";
 import type { AgentInvocation, AgentRecord, IsolationMode, SubagentType, ThinkingLevel } from "./types.js";
-import { addUsage } from "./usage.js";
+import { type AssistantUsageRecord, addUsage } from "./usage.js";
 import { cleanupWorktree, createWorktree, pruneWorktrees, } from "./worktree.js";
 
 export type OnAgentComplete = (record: AgentRecord) => void;
@@ -91,8 +91,8 @@ interface SpawnOptions {
   onSessionCreated?: (session: AgentSession) => void;
   /** Called at the end of each agentic turn with the cumulative count. */
   onTurnEnd?: (turnCount: number) => void;
-  /** Called once per assistant message_end with that message's usage delta. */
-  onAssistantUsage?: (usage: { input: number; output: number; cacheWrite: number }) => void;
+  /** Called once per assistant message_end with complete usage and attribution metadata. */
+  onAssistantUsage?: (usage: AssistantUsageRecord) => void;
   /** Called when the session successfully compacts. */
   onCompaction?: (info: CompactionInfo) => void;
 }
@@ -126,6 +126,11 @@ export class AgentManager {
     // Cleanup completed agents after 10 minutes (but keep sessions for resume)
     this.cleanupInterval = setInterval(() => this.cleanup(), 60_000);
     this.cleanupInterval.unref();
+  }
+
+  private recordAssistantUsage(record: AgentRecord, usage: AssistantUsageRecord): void {
+    addUsage(record.lifetimeUsage, usage.usage);
+    record.usageRecords.push(usage);
   }
 
   /** Update the max concurrent background agents limit. */
@@ -166,6 +171,7 @@ export class AgentManager {
       startedAt: Date.now(),
       abortController,
       lifetimeUsage: { input: 0, output: 0, cacheWrite: 0 },
+      usageRecords: [],
       compactionCount: 0,
       // Raw tri-state (not coerced to a boolean): true = background, false =
       // foreground (has an inline tool-result surface), undefined = caller never
@@ -267,7 +273,7 @@ export class AgentManager {
       onTurnEnd: options.onTurnEnd,
       onTextDelta: options.onTextDelta,
       onAssistantUsage: (usage) => {
-        addUsage(record.lifetimeUsage, usage);
+        this.recordAssistantUsage(record, usage);
         options.onAssistantUsage?.(usage);
       },
       onCompaction: (info) => {
@@ -445,6 +451,8 @@ export class AgentManager {
     record.completedAt = undefined;
     record.result = undefined;
     record.error = undefined;
+    record.resultConsumed = true;
+    record.usageRecords = [];
 
     try {
       const responseText = await resumeAgent(record.session, prompt, {
@@ -452,7 +460,7 @@ export class AgentManager {
           if (activity.type === "end") record.toolUses++;
         },
         onAssistantUsage: (usage) => {
-          addUsage(record.lifetimeUsage, usage);
+          this.recordAssistantUsage(record, usage);
         },
         onCompaction: (info) => {
           record.compactionCount++;
@@ -469,6 +477,7 @@ export class AgentManager {
       record.completedAt = Date.now();
     }
 
+    try { this.onComplete?.(record); } catch { /* ignore completion side-effect errors */ }
     return record;
   }
 

--- a/src/agent-runner.ts
+++ b/src/agent-runner.ts
@@ -24,6 +24,7 @@ import { buildMemoryBlock, buildReadOnlyMemoryBlock } from "./memory.js";
 import { buildAgentPrompt, type PromptExtras } from "./prompts.js";
 import { preloadSkills } from "./skill-loader.js";
 import type { SubagentType, ThinkingLevel } from "./types.js";
+import { type AssistantUsageRecord, createAssistantUsageRecord } from "./usage.js";
 
 /**
  * Tool names registered by THIS extension. Single source of truth so the
@@ -232,7 +233,7 @@ export interface RunOptions {
    * Lets callers maintain a lifetime accumulator that survives compaction
    * (which replaces session.state.messages and resets stats-derived sums).
    */
-  onAssistantUsage?: (usage: { input: number; output: number; cacheWrite: number }) => void;
+  onAssistantUsage?: (usage: AssistantUsageRecord) => void;
   /**
    * Called when the session successfully compacts. `tokensBefore` is upstream's
    * pre-compaction context size estimate. Aborted compactions don't fire.
@@ -639,13 +640,8 @@ export async function runAgent(
     if (event.type === "tool_execution_end") {
       options.onToolActivity?.({ type: "end", toolName: event.toolName });
     }
-    if (event.type === "message_end" && event.message.role === "assistant") {
-      const u = (event.message as any).usage;
-      if (u) options.onAssistantUsage?.({
-        input: u.input ?? 0,
-        output: u.output ?? 0,
-        cacheWrite: u.cacheWrite ?? 0,
-      });
+    if (event.type === "message_end" && event.message.role === "assistant" && event.message.usage) {
+      options.onAssistantUsage?.(createAssistantUsageRecord(event.message));
     }
     if (event.type === "compaction_end" && !event.aborted && event.result) {
       options.onCompaction?.({ reason: event.reason, tokensBefore: event.result.tokensBefore });
@@ -684,7 +680,7 @@ export async function resumeAgent(
   prompt: string,
   options: {
     onToolActivity?: (activity: ToolActivity) => void;
-    onAssistantUsage?: (usage: { input: number; output: number; cacheWrite: number }) => void;
+    onAssistantUsage?: (usage: AssistantUsageRecord) => void;
     onCompaction?: (info: { reason: "manual" | "threshold" | "overflow"; tokensBefore: number }) => void;
     signal?: AbortSignal;
   } = {},
@@ -696,13 +692,8 @@ export async function resumeAgent(
     ? session.subscribe((event: AgentSessionEvent) => {
         if (event.type === "tool_execution_start") options.onToolActivity?.({ type: "start", toolName: event.toolName });
         if (event.type === "tool_execution_end") options.onToolActivity?.({ type: "end", toolName: event.toolName });
-        if (event.type === "message_end" && event.message.role === "assistant") {
-          const u = (event.message as any).usage;
-          if (u) options.onAssistantUsage?.({
-            input: u.input ?? 0,
-            output: u.output ?? 0,
-            cacheWrite: u.cacheWrite ?? 0,
-          });
+        if (event.type === "message_end" && event.message.role === "assistant" && event.message.usage) {
+          options.onAssistantUsage?.(createAssistantUsageRecord(event.message));
         }
         if (event.type === "compaction_end" && !event.aborted && event.result) {
           options.onCompaction?.({ reason: event.reason, tokensBefore: event.result.tokensBefore });

--- a/src/index.ts
+++ b/src/index.ts
@@ -48,7 +48,7 @@ import {
 } from "./ui/agent-widget.js";
 import { FleetList, type FleetUICtx } from "./ui/fleet-list.js";
 import { showSchedulesMenu } from "./ui/schedule-menu.js";
-import { addUsage, getLifetimeTotal, getSessionContextPercent, type LifetimeUsage } from "./usage.js";
+import { type AssistantUsageRecord, addUsage, getLifetimeTotal, getSessionContextPercent, type LifetimeUsage } from "./usage.js";
 
 // ---- Shared helpers ----
 
@@ -113,8 +113,8 @@ function createActivityTracker(maxTurns?: number, onStreamUpdate?: () => void) {
     onSessionCreated: (session: any) => {
       state.session = session;
     },
-    onAssistantUsage: (usage: { input: number; output: number; cacheWrite: number }) => {
-      addUsage(state.lifetimeUsage, usage);
+    onAssistantUsage: (usage: AssistantUsageRecord) => {
+      addUsage(state.lifetimeUsage, usage.usage);
       onStreamUpdate?.();
     },
   };
@@ -373,6 +373,7 @@ export default function (pi: ExtensionAPI) {
       toolUses: record.toolUses,
       durationMs,
       tokens,
+      usageRecords: [...record.usageRecords],
     };
   }
 
@@ -392,6 +393,7 @@ export default function (pi: ExtensionAPI) {
       id: record.id, type: record.type, description: record.description,
       status: record.status, result: record.result, error: record.error,
       startedAt: record.startedAt, completedAt: record.completedAt,
+      usageRecords: [...record.usageRecords],
     });
 
     // Skip notification if result was already consumed via get_subagent_result

--- a/src/types.ts
+++ b/src/types.ts
@@ -4,7 +4,7 @@
 
 import type { ThinkingLevel } from "@earendil-works/pi-ai";
 import type { AgentSession } from "@earendil-works/pi-coding-agent";
-import type { LifetimeUsage } from "./usage.js";
+import type { AssistantUsageRecord, LifetimeUsage } from "./usage.js";
 
 export type { ThinkingLevel };
 
@@ -111,6 +111,8 @@ export interface AgentRecord {
    * excluded — see issue #38). Initialized to zeros at spawn.
    */
   lifetimeUsage: LifetimeUsage;
+  /** Complete per-message usage records for the current invocation. Reset before resume. */
+  usageRecords: AssistantUsageRecord[];
   /** Number of times this agent's session has compacted. Initialized to 0 at spawn. */
   compactionCount: number;
   /**

--- a/src/usage.ts
+++ b/src/usage.ts
@@ -1,5 +1,54 @@
 /** usage.ts — Token usage: shapes, accumulator operators, session-stats readers. */
 
+import type { AssistantMessage, Usage } from "@earendil-works/pi-ai";
+
+/** A finalized assistant message's complete, attribution-ready usage metadata. */
+export interface AssistantUsageRecord {
+  timestamp: number;
+  provider: string;
+  model: string;
+  usage: Usage;
+}
+
+/**
+ * Copy and normalize a finalized assistant message's usage for persistence.
+ * The fallbacks keep custom providers with partial usage payloads observable.
+ */
+export function createAssistantUsageRecord(message: AssistantMessage): AssistantUsageRecord {
+  const source = message.usage as Partial<Usage> | undefined;
+  const input = typeof source?.input === "number" ? source.input : 0;
+  const output = typeof source?.output === "number" ? source.output : 0;
+  const cacheRead = typeof source?.cacheRead === "number" ? source.cacheRead : 0;
+  const cacheWrite = typeof source?.cacheWrite === "number" ? source.cacheWrite : 0;
+  const costSource = source?.cost as Partial<Usage["cost"]> | undefined;
+  const cost = {
+    input: typeof costSource?.input === "number" ? costSource.input : 0,
+    output: typeof costSource?.output === "number" ? costSource.output : 0,
+    cacheRead: typeof costSource?.cacheRead === "number" ? costSource.cacheRead : 0,
+    cacheWrite: typeof costSource?.cacheWrite === "number" ? costSource.cacheWrite : 0,
+    total: typeof costSource?.total === "number"
+      ? costSource.total
+      : (costSource?.input ?? 0) + (costSource?.output ?? 0) + (costSource?.cacheRead ?? 0) + (costSource?.cacheWrite ?? 0),
+  };
+
+  return {
+    timestamp: typeof message.timestamp === "number" ? message.timestamp : Date.now(),
+    provider: message.provider ?? "unknown",
+    model: message.model ?? "unknown",
+    usage: {
+      ...source,
+      input,
+      output,
+      cacheRead,
+      cacheWrite,
+      totalTokens: typeof source?.totalTokens === "number"
+        ? source.totalTokens
+        : input + output + cacheRead + cacheWrite,
+      cost,
+    },
+  };
+}
+
 /**
  * Lifetime usage components, accumulated via `message_end` events. Survives
  * compaction (which replaces session.state.messages and would reset any

--- a/test/agent-manager.test.ts
+++ b/test/agent-manager.test.ts
@@ -381,21 +381,47 @@ describe("AgentManager — lifetime usage + compaction count are eagerly initial
     const record = manager.getRecord(id)!;
 
     expect(record.lifetimeUsage).toEqual({ input: 0, output: 0, cacheWrite: 0 });
+    expect(record.usageRecords).toEqual([]);
     expect(record.compactionCount).toBe(0);
 
     manager.abort(id);
   });
 
-  it("onAssistantUsage from runAgent accumulates into record.lifetimeUsage", async () => {
+  it("onAssistantUsage from runAgent accumulates totals and preserves records", async () => {
     manager = new AgentManager();
 
-    // Capture the options passed to runAgent so we can drive callbacks
+    const first = {
+      timestamp: 123,
+      provider: "openai-codex",
+      model: "gpt-5.4",
+      usage: {
+        input: 100,
+        output: 50,
+        cacheRead: 500,
+        cacheWrite: 10,
+        totalTokens: 660,
+        cost: { input: 0.1, output: 0.2, cacheRead: 0.03, cacheWrite: 0.04, total: 0.37 },
+      },
+    };
+    const second = {
+      timestamp: 456,
+      provider: "anthropic",
+      model: "claude-sonnet-4-5",
+      usage: {
+        input: 200,
+        output: 80,
+        cacheRead: 900,
+        cacheWrite: 20,
+        totalTokens: 1200,
+        cost: { input: 0.2, output: 0.3, cacheRead: 0.05, cacheWrite: 0.06, total: 0.61 },
+      },
+    };
+
     let captured: any;
     vi.mocked(runAgent).mockImplementation(async (_ctx, _type, _prompt, opts: any) => {
       captured = opts;
-      // Two assistant messages with usage
-      opts.onAssistantUsage?.({ input: 100, output: 50, cacheWrite: 10 });
-      opts.onAssistantUsage?.({ input: 200, output: 80, cacheWrite: 20 });
+      opts.onAssistantUsage?.(first);
+      opts.onAssistantUsage?.(second);
       return { responseText: "done", session: mockSession(), aborted: false, steered: false };
     });
 
@@ -409,6 +435,7 @@ describe("AgentManager — lifetime usage + compaction count are eagerly initial
     expect(manager.getRecord(id)!.lifetimeUsage).toEqual({
       input: 300, output: 130, cacheWrite: 30,
     });
+    expect(manager.getRecord(id)!.usageRecords).toEqual([first, second]);
   });
 
   it("onCompaction from runAgent increments record.compactionCount", async () => {
@@ -440,16 +467,27 @@ describe("AgentManager — lifetime usage + compaction count are eagerly initial
     expect(manager.getRecord(id)!.compactionCount).toBe(2);
   });
 
-  it("resume() also accumulates usage and increments compactions on the same record", async () => {
-    manager = new AgentManager();
+  it("resume() persists only new usage while keeping lifetime totals", async () => {
+    const completions: AgentRecord[] = [];
+    manager = new AgentManager((record) => completions.push(record));
 
-    // First, spawn with a session that resume can latch onto
+    const initialUsage = {
+      timestamp: 123,
+      provider: "openai-codex",
+      model: "gpt-5.4",
+      usage: {
+        input: 10,
+        output: 5,
+        cacheRead: 100,
+        cacheWrite: 1,
+        totalTokens: 116,
+        cost: { input: 0.01, output: 0.01, cacheRead: 0.01, cacheWrite: 0.01, total: 0.04 },
+      },
+    };
     const session = { ...mockSession() };
-    vi.mocked(runAgent).mockResolvedValue({
-      responseText: "first",
-      session: session as any,
-      aborted: false,
-      steered: false,
+    vi.mocked(runAgent).mockImplementation(async (_ctx, _type, _prompt, opts: any) => {
+      opts.onAssistantUsage?.(initialUsage);
+      return { responseText: "first", session: session as any, aborted: false, steered: false };
     });
 
     const id = manager.spawn(mockPi, mockCtx, "general-purpose", "test", {
@@ -458,22 +496,38 @@ describe("AgentManager — lifetime usage + compaction count are eagerly initial
     });
     await manager.getRecord(id)!.promise;
 
-    // Pre-resume: lifetimeUsage from spawn was zero (mock didn't call onAssistantUsage)
-    expect(manager.getRecord(id)!.lifetimeUsage).toEqual({ input: 0, output: 0, cacheWrite: 0 });
-    expect(manager.getRecord(id)!.compactionCount).toBe(0);
+    expect(manager.getRecord(id)!.lifetimeUsage).toEqual({ input: 10, output: 5, cacheWrite: 1 });
+    expect(manager.getRecord(id)!.usageRecords).toEqual([initialUsage]);
+    expect(completions).toHaveLength(1);
+    completions.length = 0;
 
-    // Now resume — drive callbacks via the mocked resumeAgent
     const { resumeAgent: resumeMock } = await import("../src/agent-runner.js");
+    const resumedUsage = {
+      timestamp: 789,
+      provider: "openai-codex",
+      model: "gpt-5.4",
+      usage: {
+        input: 70,
+        output: 30,
+        cacheRead: 200,
+        cacheWrite: 5,
+        totalTokens: 305,
+        cost: { input: 0.07, output: 0.03, cacheRead: 0.01, cacheWrite: 0.01, total: 0.12 },
+      },
+    };
     vi.mocked(resumeMock).mockImplementation(async (_session, _prompt, opts: any) => {
-      opts.onAssistantUsage?.({ input: 70, output: 30, cacheWrite: 5 });
+      opts.onAssistantUsage?.(resumedUsage);
       opts.onCompaction?.({ reason: "overflow", tokensBefore: 999 });
       return "second";
     });
 
-    await manager.resume(id, "more");
+    const resumed = await manager.resume(id, "more");
 
-    expect(manager.getRecord(id)!.lifetimeUsage).toEqual({ input: 70, output: 30, cacheWrite: 5 });
-    expect(manager.getRecord(id)!.compactionCount).toBe(1);
+    expect(resumed!.lifetimeUsage).toEqual({ input: 80, output: 35, cacheWrite: 6 });
+    expect(resumed!.usageRecords).toEqual([resumedUsage]);
+    expect(resumed!.compactionCount).toBe(1);
+    expect(resumed!.resultConsumed).toBe(true);
+    expect(completions).toEqual([resumed]);
   });
 });
 

--- a/test/agent-runner.test.ts
+++ b/test/agent-runner.test.ts
@@ -113,6 +113,7 @@ import {
   resumeAgent,
   runAgent,
 } from "../src/agent-runner.js";
+import type { AssistantUsageRecord } from "../src/usage.js";
 
 function createSession(finalText: string) {
   const listeners: Array<(event: any) => void> = [];
@@ -259,20 +260,44 @@ describe("agent-runner final output capture", () => {
 // callback. The callback feeds the AgentRecord lifetime accumulator, which
 // is the source of truth for total tokens (survives compaction).
 describe("agent-runner usage callback wiring", () => {
-  function emitMessageEnd(listeners: Array<(e: any) => void>, usage: any) {
-    const event = { type: "message_end", message: { role: "assistant", usage } };
+  function emitMessageEnd(listeners: Array<(e: any) => void>, usage: any, timestamp = 123) {
+    const event = {
+      type: "message_end",
+      message: {
+        role: "assistant",
+        provider: "openai-codex",
+        model: "gpt-5.4",
+        timestamp,
+        usage,
+      },
+    };
     for (const l of listeners) l(event);
   }
 
-  it("runAgent forwards full usage from message_end events", async () => {
+  it("runAgent forwards structured usage records from message_end events", async () => {
     const { session, listeners } = createSession("OK");
     createAgentSession.mockResolvedValue({ session });
 
-    const seen: Array<{ input: number; output: number; cacheWrite: number }> = [];
+    const firstUsage = {
+      input: 100,
+      output: 50,
+      cacheRead: 500,
+      cacheWrite: 10,
+      totalTokens: 660,
+      cost: { input: 0.1, output: 0.2, cacheRead: 0.03, cacheWrite: 0.04, total: 0.37 },
+    };
+    const secondUsage = {
+      input: 200,
+      output: 80,
+      cacheRead: 900,
+      cacheWrite: 20,
+      totalTokens: 1200,
+      cost: { input: 0.2, output: 0.3, cacheRead: 0.05, cacheWrite: 0.06, total: 0.61 },
+    };
+    const seen: AssistantUsageRecord[] = [];
     session.prompt = vi.fn(async () => {
-      // Two assistant messages over the run
-      emitMessageEnd(listeners, { input: 100, output: 50, cacheWrite: 10 });
-      emitMessageEnd(listeners, { input: 200, output: 80, cacheWrite: 20 });
+      emitMessageEnd(listeners, firstUsage, 123);
+      emitMessageEnd(listeners, secondUsage, 456);
       session.messages.push({ role: "assistant", content: [{ type: "text", text: "OK" }] });
     });
 
@@ -282,8 +307,8 @@ describe("agent-runner usage callback wiring", () => {
     });
 
     expect(seen).toEqual([
-      { input: 100, output: 50, cacheWrite: 10 },
-      { input: 200, output: 80, cacheWrite: 20 },
+      { timestamp: 123, provider: "openai-codex", model: "gpt-5.4", usage: firstUsage },
+      { timestamp: 456, provider: "openai-codex", model: "gpt-5.4", usage: secondUsage },
     ]);
   });
 
@@ -291,9 +316,9 @@ describe("agent-runner usage callback wiring", () => {
     const { session, listeners } = createSession("OK");
     createAgentSession.mockResolvedValue({ session });
 
-    const seen: any[] = [];
+    const seen: AssistantUsageRecord[] = [];
     session.prompt = vi.fn(async () => {
-      emitMessageEnd(listeners, { input: 50 }); // output, cacheWrite missing
+      emitMessageEnd(listeners, { input: 50 });
       session.messages.push({ role: "assistant", content: [{ type: "text", text: "OK" }] });
     });
 
@@ -302,7 +327,19 @@ describe("agent-runner usage callback wiring", () => {
       onAssistantUsage: (u) => seen.push(u),
     });
 
-    expect(seen).toEqual([{ input: 50, output: 0, cacheWrite: 0 }]);
+    expect(seen).toEqual([{
+      timestamp: 123,
+      provider: "openai-codex",
+      model: "gpt-5.4",
+      usage: {
+        input: 50,
+        output: 0,
+        cacheRead: 0,
+        cacheWrite: 0,
+        totalTokens: 50,
+        cost: { input: 0, output: 0, cacheRead: 0, cacheWrite: 0, total: 0 },
+      },
+    }]);
   });
 
   it("runAgent skips the callback when message_end has no usage field", async () => {
@@ -322,7 +359,7 @@ describe("agent-runner usage callback wiring", () => {
 
   it("resumeAgent forwards usage on message_end the same way", async () => {
     const { session, listeners } = createSession("RESUMED");
-    const seen: any[] = [];
+    const seen: AssistantUsageRecord[] = [];
 
     session.prompt = vi.fn(async () => {
       emitMessageEnd(listeners, { input: 10, output: 20, cacheWrite: 5 });
@@ -333,7 +370,19 @@ describe("agent-runner usage callback wiring", () => {
       onAssistantUsage: (u) => seen.push(u),
     });
 
-    expect(seen).toEqual([{ input: 10, output: 20, cacheWrite: 5 }]);
+    expect(seen).toEqual([{
+      timestamp: 123,
+      provider: "openai-codex",
+      model: "gpt-5.4",
+      usage: {
+        input: 10,
+        output: 20,
+        cacheRead: 0,
+        cacheWrite: 5,
+        totalTokens: 35,
+        cost: { input: 0, output: 0, cacheRead: 0, cacheWrite: 0, total: 0 },
+      },
+    }]);
   });
 
   it("forwards compaction_end events to onCompaction (only when not aborted)", async () => {

--- a/test/usage-persistence-wiring.test.ts
+++ b/test/usage-persistence-wiring.test.ts
@@ -1,0 +1,138 @@
+import type { AgentSession, ExtensionAPI, ExtensionContext } from "@earendil-works/pi-coding-agent";
+import { afterEach, describe, expect, it, vi } from "vitest";
+import type { AssistantUsageRecord } from "../src/usage.js";
+
+vi.mock("../src/agent-runner.js", async () => {
+  const actual = await vi.importActual<typeof import("../src/agent-runner.js")>("../src/agent-runner.js");
+  return { ...actual, runAgent: vi.fn() };
+});
+
+import { runAgent } from "../src/agent-runner.js";
+import subagentsExtension from "../src/index.js";
+
+const usageRecord: AssistantUsageRecord = {
+  timestamp: 123,
+  provider: "openai-codex",
+  model: "gpt-5.4",
+  usage: {
+    input: 120,
+    output: 40,
+    cacheRead: 1000,
+    cacheWrite: 20,
+    totalTokens: 1180,
+    cost: { input: 0.12, output: 0.08, cacheRead: 0.03, cacheWrite: 0.02, total: 0.25 },
+  },
+};
+
+type TestTool = {
+  execute: (
+    toolCallId: string,
+    params: unknown,
+    signal: AbortSignal | undefined,
+    onUpdate: unknown,
+    context: ExtensionContext,
+  ) => Promise<unknown>;
+};
+type LifecycleHandler = (event: unknown, context: ExtensionContext) => Promise<void> | void;
+
+function makePi() {
+  const tools = new Map<string, TestTool>();
+  const lifecycle = new Map<string, LifecycleHandler>();
+  const piMock = {
+    registerMessageRenderer: vi.fn(),
+    registerTool: vi.fn((tool: unknown) => {
+      const candidate = tool as { name?: unknown };
+      if (typeof candidate.name === "string") tools.set(candidate.name, tool as TestTool);
+    }),
+    registerCommand: vi.fn(),
+    on: vi.fn((event: string, handler: LifecycleHandler) => lifecycle.set(event, handler)),
+    events: { emit: vi.fn(), on: vi.fn(() => vi.fn()) },
+    appendEntry: vi.fn(),
+    sendMessage: vi.fn(),
+  };
+  return { pi: piMock as unknown as ExtensionAPI, piMock, tools, lifecycle };
+}
+
+function makeContext(): ExtensionContext {
+  return {
+    hasUI: false,
+    ui: { setStatus: vi.fn(), setWidget: vi.fn(), notify: vi.fn() },
+    cwd: "/tmp",
+    model: undefined,
+    modelRegistry: { find: vi.fn(), getAvailable: vi.fn(() => []) },
+    sessionManager: { getSessionId: vi.fn(() => "usage-session"), getBranch: vi.fn(() => []) },
+    getSystemPrompt: vi.fn(() => "parent"),
+  } as unknown as ExtensionContext;
+}
+
+function getAgentTool(tools: Map<string, TestTool>): TestTool {
+  const tool = tools.get("Agent");
+  if (!tool) throw new Error("Agent tool was not registered");
+  return tool;
+}
+
+describe("structured usage completion wiring", () => {
+  afterEach(() => vi.restoreAllMocks());
+
+  it("emits and persists complete usage records without changing billed token totals", async () => {
+    vi.mocked(runAgent).mockImplementation(async (_ctx, _type, _prompt, options) => {
+      options.onAssistantUsage?.(usageRecord);
+      return {
+        responseText: "done",
+        session: { dispose: vi.fn() } as unknown as AgentSession,
+        aborted: false,
+        steered: false,
+      };
+    });
+    const { pi, piMock, tools, lifecycle } = makePi();
+    const context = makeContext();
+    subagentsExtension(pi);
+
+    await getAgentTool(tools).execute(
+      "usage-tool-call",
+      { prompt: "go", description: "Collect usage", subagent_type: "general-purpose" },
+      undefined,
+      undefined,
+      context,
+    );
+
+    expect(piMock.events.emit).toHaveBeenCalledWith("subagents:completed", expect.objectContaining({
+      tokens: { input: 120, output: 40, total: 180 },
+      usageRecords: [usageRecord],
+    }));
+    expect(piMock.appendEntry).toHaveBeenCalledWith("subagents:record", expect.objectContaining({
+      usageRecords: [usageRecord],
+    }));
+
+    await lifecycle.get("session_shutdown")?.({}, context);
+  });
+
+  it("emits and persists usage collected before a failed run", async () => {
+    vi.mocked(runAgent).mockImplementation(async (_ctx, _type, _prompt, options) => {
+      options.onAssistantUsage?.(usageRecord);
+      throw new Error("provider disconnected");
+    });
+    const { pi, piMock, tools, lifecycle } = makePi();
+    const context = makeContext();
+    subagentsExtension(pi);
+
+    await getAgentTool(tools).execute(
+      "failed-usage-tool-call",
+      { prompt: "go", description: "Collect failed usage", subagent_type: "general-purpose" },
+      undefined,
+      undefined,
+      context,
+    );
+
+    expect(piMock.events.emit).toHaveBeenCalledWith("subagents:failed", expect.objectContaining({
+      status: "error",
+      usageRecords: [usageRecord],
+    }));
+    expect(piMock.appendEntry).toHaveBeenCalledWith("subagents:record", expect.objectContaining({
+      status: "error",
+      usageRecords: [usageRecord],
+    }));
+
+    await lifecycle.get("session_shutdown")?.({}, context);
+  });
+});


### PR DESCRIPTION
## Summary

- capture each finalized assistant message as `{ timestamp, provider, model, usage }`
- expose `usageRecords` on `subagents:completed` and `subagents:failed`
- persist the same records in the parent session's `subagents:record` entry
- keep the existing billed-token/UI semantics unchanged (`input + output + cacheWrite`)
- emit only newly generated records for resumed invocations to avoid duplicate analytics entries

This gives cross-session analytics extensions a durable source for subagent model attribution, cache usage, and itemized cost without reading temporary sidechain transcripts or duplicating message content.

Closes #137.

## Validation

- `npm run lint`
- `npm run typecheck`
- `npm run test` (677 passed, 4 live tests skipped)
- `npm run build`
- `npm run test:e2e` (37 passed, 4 live tests skipped)
