### PR TITLE
fix: let subagents see asynchronously-registered extension tools (MCP)

### DIFF
--- a/src/agent-runner.ts
+++ b/src/agent-runner.ts
@@ -547,20 +547,57 @@ export async function runAgent(
     }
   }
 
-  // Build the master tool allowlist applied at session construction.
-  // pi-mono's `allowedToolNames` gates BOTH registration and the initial active
-  // set, so listing the exact final set here means the session is correctly
-  // scoped from the first instant — no post-construction narrowing required.
+  // Tool scoping runs in one of two modes.
+  //
+  //  • Dynamic denylist (default whenever extension tools flow freely — i.e.
+  //    extensions load and there is no `ext:` narrowing). Some extensions register
+  //    their tools ASYNCHRONOUSLY: pi-mcp, for example, only calls registerTool
+  //    from its `session_start` handler, after connecting to MCP servers — long
+  //    after `loader.reload()` here. A static allowlist snapshot taken now would
+  //    omit those tools permanently, because pi-mono's `allowedToolNames` gates
+  //    tool *registration* (via `_refreshToolRegistry`'s `isAllowedTool`), not just
+  //    the active set — so a name absent from the snapshot is dropped forever, even
+  //    once the tool eventually registers. Instead we leave `allowedToolNames`
+  //    unset (the live `isAllowedTool` then admits tools whenever they register)
+  //    and express scope as a denylist via `excludeTools`: every built-in the agent
+  //    did NOT ask for, this extension's own orchestration tools, and the agent's
+  //    `disallowedTools`. The initial active set is repaired post-bind below, since
+  //    an unset allowlist only activates pi's four default built-ins at turn 1.
+  //
+  //  • Static allowlist (the historical path): used when no extension tools apply
+  //    (`noExtensions`/`isolated`) or when `ext:` selectors narrow them. Here the
+  //    exact final set is known up front — no async tools can appear — so we pass it
+  //    as `allowedToolNames` and the session is correctly scoped from the first
+  //    instant. (Narrowing a specific not-yet-registered async tool via `ext:` still
+  //    has the snapshot limitation, but whole-extension inclusion — the common case
+  //    — goes through the dynamic path.)
+  const dynamicExtensionTools = !noExtensions && extNames.size === 0;
+
   const builtinToolNameSet = new Set(toolNames);
-  const allowedTools = [...toolNames, ...extensionToolNames].filter((t) => {
-    if (EXCLUDED_TOOL_NAMES.includes(t)) return false;
-    if (disallowedSet?.has(t)) return false;
-    if (builtinToolNameSet.has(t)) return true;
-    // Reached only for extension tools. The extension set was already filtered
-    // at the loader (extensionsOverride / noExtensions) and at enumeration
-    // (`ext:` opt-in flip), so any extension tool in `extensionToolNames` is allowed.
-    return !noExtensions;
-  });
+
+  let sessionTools: string[] | undefined;
+  let sessionExcludeTools: string[] | undefined;
+  if (dynamicExtensionTools) {
+    const denyTools = new Set<string>(EXCLUDED_TOOL_NAMES);
+    // Keep only the built-ins the agent asked for — deny the rest.
+    for (const name of BUILTIN_TOOL_NAMES) {
+      if (!builtinToolNameSet.has(name)) denyTools.add(name);
+    }
+    if (disallowedSet) {
+      for (const name of disallowedSet) denyTools.add(name);
+    }
+    sessionExcludeTools = [...denyTools];
+  } else {
+    sessionTools = [...toolNames, ...extensionToolNames].filter((t) => {
+      if (EXCLUDED_TOOL_NAMES.includes(t)) return false;
+      if (disallowedSet?.has(t)) return false;
+      if (builtinToolNameSet.has(t)) return true;
+      // Reached only for extension tools. The extension set was already filtered
+      // at the loader (extensionsOverride / noExtensions) and at enumeration
+      // (`ext:` opt-in flip), so any extension tool in `extensionToolNames` is allowed.
+      return !noExtensions;
+    });
+  }
 
   const settingsManager = SettingsManager.create(configCwd, agentDir);
   const configuredSessionDir = resolveConfiguredSessionDir(agentConfig?.sessionDir, effectiveCwd);
@@ -576,9 +613,12 @@ export async function runAgent(
     settingsManager,
     modelRegistry: ctx.modelRegistry,
     model,
-    tools: allowedTools,
+    tools: sessionTools,
     resourceLoader: loader,
   };
+  if (sessionExcludeTools) {
+    sessionOpts.excludeTools = sessionExcludeTools;
+  }
   if (thinkingLevel) {
     sessionOpts.thinkingLevel = thinkingLevel;
   }
@@ -602,6 +642,17 @@ export async function runAgent(
       });
     },
   });
+
+  // Dynamic mode: with `allowedToolNames` unset the session starts with only pi's
+  // four default built-ins active. Now that extensions have bound (and any eager
+  // MCP servers connected during session_start), activate the full allowed
+  // registry — the agent's chosen built-ins plus every extension tool registered
+  // so far. Tools that register later (e.g. lazy MCP servers) auto-activate via
+  // pi's tool-refresh path, precisely because the allowlist is unset. The registry
+  // is already scoped by `excludeTools`, so activating all of it stays in scope.
+  if (dynamicExtensionTools) {
+    session.setActiveToolsByName(session.getAllTools().map((t) => t.name));
+  }
 
   options.onSessionCreated?.(session);
 

--- a/test/agent-runner.test.ts
+++ b/test/agent-runner.test.ts
@@ -112,6 +112,7 @@ import {
   parseExtSelectors,
   resumeAgent,
   runAgent,
+  SUBAGENT_TOOL_NAMES,
 } from "../src/agent-runner.js";
 
 function createSession(finalText: string) {
@@ -132,6 +133,13 @@ function createSession(finalText: string) {
     steer: vi.fn(),
     getActiveToolNames: vi.fn(() => ["read"]),
     setActiveToolsByName: vi.fn(),
+    // Faithfully simulate pi-mono's registry: built-ins plus every loaded
+    // extension tool, gated by the session's allowlist/denylist. Dynamic mode
+    // reads this post-bind to activate the full allowed set.
+    getAllTools: vi.fn(() => {
+      const opts = createAgentSession.mock.calls[0]?.[0];
+      return opts ? effectiveAllowedTools(opts).map((name) => ({ name })) : [];
+    }),
     setSessionName: vi.fn(),
     bindExtensions: vi.fn(async () => {}),
   };
@@ -445,11 +453,21 @@ describe("getAgentConversation", () => {
   });
 });
 
-// ─── master tool allowlist (issue #47) ──────────────────────────────────
-// Tool gating happens at `createAgentSession` time via the `tools:`
-// parameter. pi-mono's `allowedToolNames` is the master gate: it controls
-// BOTH which tools get registered and which enter the initial active set.
-// No post-construction `setActiveToolsByName` filter is needed.
+// ─── tool scoping (issues #47, async-MCP fix) ────────────────────────────
+// runAgent scopes a subagent's tools in one of two ways at `createAgentSession`
+// time:
+//   • Static allowlist (`tools:`) — when the exact set is known up front
+//     (`ext:` narrowing, or no extensions). pi-mono's `allowedToolNames` gates
+//     both registration and the initial active set.
+//   • Dynamic denylist (`excludeTools:`, `tools:` unset) — the default when
+//     extension tools flow freely. An unset allowlist lets asynchronously
+//     registered tools (e.g. pi-mcp, which registers on session_start after
+//     connecting to servers) through pi-mono's live `isAllowedTool` gate; the
+//     denylist removes the built-ins the agent didn't ask for plus this
+//     extension's own orchestration tools. The initial active set is repaired
+//     post-bind via `setActiveToolsByName` (an unset allowlist otherwise starts
+//     with only pi's four default built-ins).
+// `lastToolsPassed()` normalizes both into the effective allowed set.
 
 import {
   getAgentConfig,
@@ -499,8 +517,29 @@ function withExtensions(spec: Record<string, string[]>) {
   };
 }
 
+/**
+ * The tool names the agent will actually be allowed to use, derived from the
+ * `createAgentSession` call — normalizing the two scoping shapes:
+ *   - static allowlist → `tools` is the exact set (minus any `excludeTools`).
+ *   - dynamic denylist → `tools` unset; the effective set is every built-in plus
+ *     every loaded extension tool, minus `excludeTools`. This mirrors pi-mono's
+ *     live `isAllowedTool` gate together with the post-bind activation of the
+ *     full registry.
+ */
+function effectiveAllowedTools(opts: Record<string, any>): string[] {
+  const excluded = new Set<string>(opts.excludeTools ?? []);
+  if (opts.tools) {
+    return opts.tools.filter((t: string) => !excluded.has(t));
+  }
+  const all: string[] = [...BUILTINS_7];
+  for (const ext of loaderExtensionsRef.current.extensions) {
+    for (const name of ext.tools.keys()) all.push(name);
+  }
+  return [...new Set(all)].filter((t) => !excluded.has(t));
+}
+
 function lastToolsPassed(): string[] {
-  return createAgentSession.mock.calls[0][0].tools;
+  return effectiveAllowedTools(createAgentSession.mock.calls[0][0]);
 }
 
 function lastLoaderOpts(): Record<string, unknown> {
@@ -641,7 +680,7 @@ describe("agent-runner master tool allowlist", () => {
     expect(tools).toEqual(BUILTINS_7.filter((t) => t !== "bash"));
   });
 
-  it("does not call setActiveToolsByName post-construction (gating is at construction)", async () => {
+  it("dynamic mode: leaves the allowlist unset, denies via excludeTools, activates post-bind", async () => {
     vi.mocked(getConfig).mockReturnValueOnce(makeConfig({ extensions: true }));
     vi.mocked(getAgentConfig).mockReturnValueOnce(
       makeAgentConfig({ extensions: true, disallowedTools: ["bash"] }),
@@ -653,7 +692,25 @@ describe("agent-runner master tool allowlist", () => {
 
     await runAgent(ctx, "Explore", "go", { pi });
 
-    expect(session.setActiveToolsByName).not.toHaveBeenCalled();
+    // Allowlist unset so async tools (e.g. MCP on session_start) can register;
+    // scope is a denylist of this extension's own tools plus `disallowedTools`.
+    const opts = createAgentSession.mock.calls[0][0];
+    expect(opts.tools).toBeUndefined();
+    expect(new Set(opts.excludeTools)).toEqual(
+      new Set([...Object.values(SUBAGENT_TOOL_NAMES), "bash"]),
+    );
+
+    // The active set is repaired AFTER bindExtensions (tools may register during
+    // session_start), activating the full allowed registry — the extension tool
+    // included, the denied built-in excluded.
+    expect(session.setActiveToolsByName).toHaveBeenCalledTimes(1);
+    const setOrder = session.setActiveToolsByName.mock.invocationCallOrder[0];
+    const bindOrder = session.bindExtensions.mock.invocationCallOrder[0];
+    expect(setOrder).toBeGreaterThan(bindOrder);
+    const activated = new Set(session.setActiveToolsByName.mock.calls[0][0]);
+    expect(activated.has("mcp")).toBe(true);
+    expect(activated.has("read")).toBe(true);
+    expect(activated.has("bash")).toBe(false);
   });
 });
 


### PR DESCRIPTION
Subagents could not use tools provided by MCP extensions (e.g. pi-mcp-extension), even though those tools work in the main agent. pi-mcp registers its tools asynchronously from its session_start handler, after connecting to MCP servers — never during synchronous extension load. runAgent, however, snapshotted extension.tools.keys() into a static `tools:` allowlist right after loader.reload() and before bindExtensions() fires session_start. In pi-mono that allowlist (allowedToolNames) is frozen at construction and gates the tool *registry* itself, so MCP tools — registered later — were dropped permanently, not just deactivated.

Scope extension tools via the session's live denylist instead of a frozen allowlist, matching how the main agent stays in sync. When extensions load and there is no `ext:` narrowing, pass `tools: undefined` (allowlist unset, so the live isAllowedTool gate admits tools whenever they register) and express scope as `excludeTools` = this extension's own orchestration tools + built-ins the agent didn't ask for + disallowedTools. Because an unset allowlist only activates pi's four default built-ins at turn 1, repair the active set post-bind via setActiveToolsByName(getAllTools()); tools registered later (lazy MCP servers) auto-activate through pi's refresh path. The static-allowlist path is retained unchanged for noExtensions/isolated and for `ext:` narrowing, where the exact set is known up front.

May solve issue #125.

I (the human) tested this manually by setting my local checkout of pi-subagents as the extension, then asking the LLM to spawn a subagent and use a search tool. Previously, it couldn't -- and now it can.