### PR TITLE
feat: allow agents to suppress sidechain transcripts

### DIFF
--- a/README.md
+++ b/README.md
@@ -138,7 +138,7 @@ Individual agent results render Claude Code-style in the conversation:
 
 Completed results can be expanded (ctrl+o in pi) to show the full agent output inline.
 
-By default, foreground and background agents stream their full conversation to a sidechain `.output` transcript file. Set `output_transcript: false` to create no sidechain transcript path or file. This setting does not override `persist_session`; set `persist_session: false` as well when the whole agent conversation must remain in memory. Background agent completion notifications render as styled boxes:
+By default, foreground and background agents each stream their full conversation to a per-subagent transcript — a JSON-lines file at `<os-tmpdir>/pi-subagents-<uid>/<cwd>/<session>/tasks/<agent-id>.output` (owner-only `0700`, cleared on reboot). Set `output_transcript: false` on a custom agent to write no transcript path or file for it, or set `outputTranscript: false` in `subagents.json` to make transcripts opt-in for the whole project (frontmatter overrides the project default). This governs **only** the transcript: it is independent of `persist_session` (the pi session on disk), and it does not affect `isolation: worktree` (which commits the agent's work to a git branch) or `memory:` (durable files) — set those accordingly if the goal is to keep a run off disk entirely. Background agent completion notifications render as styled boxes:
 
 ```
 ✓ Find auth files completed
@@ -219,8 +219,8 @@ All fields are optional — sensible defaults for everything.
 | `model` | inherit parent | Model — `provider/modelId` or fuzzy name (`"haiku"`, `"sonnet"`). Resolved tolerantly (`.`/`-` and a trailing date stamp are interchangeable) and falls back to the same model under another provider if the named one doesn't have it |
 | `thinking` | inherit | off, minimal, low, medium, high, xhigh |
 | `max_turns` | unlimited | Max agentic turns before graceful shutdown. `0` or omit for unlimited |
-| `persist_session` | `false` | Persist this subagent as a normal pi session instead of keeping the session in memory only. The sidechain output transcript is still written either way unless `output_transcript: false` |
-| `output_transcript` | `true` | Write the sidechain `.output` transcript. Set `false` to create no sidechain transcript file or path; this does not override `persist_session` |
+| `persist_session` | `false` | Persist this subagent as a normal pi session instead of keeping the session in memory only. The subagent's `.output` transcript is still written either way unless `output_transcript: false` |
+| `output_transcript` | `true` (or `subagents.json` `outputTranscript`) | Write this subagent's `.output` transcript. Set `false` to write no transcript file or path. Governs only the transcript — independent of `persist_session`, `isolation: worktree`, and `memory:` |
 | `session_dir` | pi default | Optional session directory when `persist_session: true`; omitted uses pi's normal session location, and relative paths resolve from the agent cwd |
 | `prompt_mode` | `replace` | `replace`: body is the full system prompt (no AGENTS.md / CLAUDE.md inheritance). `append`: body appended to parent's prompt (agent acts as a "parent twin" — inherits parent's AGENTS.md / CLAUDE.md) |
 | `inherit_context` | `false` | Fork parent conversation into agent |
@@ -398,6 +398,8 @@ Runtime tuning values set via `/agents` → Settings (max concurrency, default m
 **Precedence:** project overrides global on any field present in both. Missing fields fall back to the hardcoded defaults (max concurrency `4`, default max turns unlimited, grace turns `5`, join mode `smart`, defaults enabled).
 
 **Disable defaults** (`disableDefaultAgents`, default `false`): when on, the three built-in agents (general-purpose, Explore, Plan) are not registered — only your project/global custom agents are advertised and spawnable. User-defined agents are unaffected, including ones that override a default by name. The Agent tool's type list updates on the next pi session (the tool schema is registered at startup).
+
+**Output transcript** (`outputTranscript`, default `true`): the project/global default for writing each subagent's `.output` transcript. Set `false` to make transcripts opt-in project-wide — useful when run transcripts shouldn't sit on disk for backup or DLP tooling to pick up. A custom agent's `output_transcript` frontmatter overrides this per agent. Applied live at spawn time. Governs only the transcript, not `persist_session`, worktree commits, or memory files.
 
 **Tool description** (`toolDescriptionMode`, default `"full"`): which Agent tool description the LLM sees. `"full"` is the rich Claude Code-style prompt (~1,400 tokens with the default agents); `"compact"` is ~75% smaller — one-line agent type list, terse usage notes — for small/local models where tool-spec tokens are expensive. Per-option details stay in the parameter descriptions in every mode (the parameter schema is never customizable). Applies on the next pi session.
 

--- a/README.md
+++ b/README.md
@@ -138,7 +138,7 @@ Individual agent results render Claude Code-style in the conversation:
 
 Completed results can be expanded (ctrl+o in pi) to show the full agent output inline.
 
-Both foreground and background agents stream their full conversation to a `.pi/output/agent-<id>.jsonl` transcript file. Background agent completion notifications render as styled boxes:
+By default, foreground and background agents stream their full conversation to a sidechain `.output` transcript file. Set `output_transcript: false` to create no sidechain transcript path or file. This setting does not override `persist_session`; set `persist_session: false` as well when the whole agent conversation must remain in memory. Background agent completion notifications render as styled boxes:
 
 ```
 ✓ Find auth files completed
@@ -219,7 +219,8 @@ All fields are optional — sensible defaults for everything.
 | `model` | inherit parent | Model — `provider/modelId` or fuzzy name (`"haiku"`, `"sonnet"`). Resolved tolerantly (`.`/`-` and a trailing date stamp are interchangeable) and falls back to the same model under another provider if the named one doesn't have it |
 | `thinking` | inherit | off, minimal, low, medium, high, xhigh |
 | `max_turns` | unlimited | Max agentic turns before graceful shutdown. `0` or omit for unlimited |
-| `persist_session` | `false` | Persist this subagent as a normal pi session instead of keeping the session in memory only. The sidechain output transcript is still written either way |
+| `persist_session` | `false` | Persist this subagent as a normal pi session instead of keeping the session in memory only. The sidechain output transcript is still written either way unless `output_transcript: false` |
+| `output_transcript` | `true` | Write the sidechain `.output` transcript. Set `false` to create no sidechain transcript file or path; this does not override `persist_session` |
 | `session_dir` | pi default | Optional session directory when `persist_session: true`; omitted uses pi's normal session location, and relative paths resolve from the agent cwd |
 | `prompt_mode` | `replace` | `replace`: body is the full system prompt (no AGENTS.md / CLAUDE.md inheritance). `append`: body appended to parent's prompt (agent acts as a "parent twin" — inherits parent's AGENTS.md / CLAUDE.md) |
 | `inherit_context` | `false` | Fork parent conversation into agent |

--- a/src/custom-agents.ts
+++ b/src/custom-agents.ts
@@ -71,6 +71,7 @@ function loadFromDir(dir: string, agents: Map<string, AgentConfig>, source: "pro
       thinking: str(fm.thinking) as ThinkingLevel | undefined,
       maxTurns: nonNegativeInt(fm.max_turns),
       persistSession: fm.persist_session != null ? fm.persist_session === true : undefined,
+      outputTranscript: fm.output_transcript != null ? fm.output_transcript !== false : undefined,
       sessionDir: str(fm.session_dir),
       systemPrompt: body.trim(),
       promptMode: fm.prompt_mode === "append" ? "append" : "replace",

--- a/src/index.ts
+++ b/src/index.ts
@@ -541,6 +541,13 @@ export default function (pi: ExtensionAPI) {
   function isFleetViewEnabled(): boolean { return fleetViewEnabled; }
   function setFleetViewEnabled(b: boolean): void { fleetViewEnabled = b; fleet.setEnabled(b); }
 
+  // Project/global default for writing the subagent .output transcript. A custom
+  // agent's `output_transcript` frontmatter overrides this per spawn; when the
+  // frontmatter is silent, this default applies. Read live at spawn time.
+  let outputTranscriptDefault = true;
+  function getOutputTranscriptDefault(): boolean { return outputTranscriptDefault; }
+  function setOutputTranscript(b: boolean): void { outputTranscriptDefault = b; }
+
   // ---- Join mode configuration ----
   let defaultJoinMode: JoinMode = 'smart';
   function getDefaultJoinMode(): JoinMode { return defaultJoinMode; }
@@ -695,6 +702,7 @@ export default function (pi: ExtensionAPI) {
       setToolDescriptionMode: setToolDescriptionMode,
       setFleetView: setFleetViewEnabled,
       setWidgetMode: setWidgetMode,
+      setOutputTranscript: setOutputTranscript,
     },
     (event, payload) => pi.events.emit(event, payload),
   );
@@ -1049,7 +1057,17 @@ Terse command-style prompts produce shallow, generic work.
       const runInBackground = resolvedConfig.runInBackground;
       const isolated = resolvedConfig.isolated;
       const isolation = resolvedConfig.isolation;
-      const outputTranscript = customConfig?.outputTranscript !== false;
+      // Whether this spawn writes its .output transcript. Per-agent
+      // frontmatter (`output_transcript`) wins; otherwise the project/global
+      // default applies. `attachTranscript` below is the SOLE gate — every
+      // downstream consumer keys off record.outputFile being set, so no spawn
+      // path can re-enable the transcript by accident.
+      const outputTranscript = customConfig?.outputTranscript ?? getOutputTranscriptDefault();
+      const attachTranscript = (rec: AgentRecord | undefined, agentId: string): void => {
+        if (!rec || !outputTranscript) return;
+        rec.outputFile = createOutputFilePath(ctx.cwd, agentId, ctx.sessionManager.getSessionId());
+        writeInitialEntry(rec.outputFile, agentId, params.prompt, ctx.cwd);
+      };
 
       const parentModelId = ctx.model?.id;
       const effectiveModelId = model?.id;
@@ -1181,10 +1199,7 @@ Terse command-style prompts produce shallow, generic work.
         if (record && joinMode) {
           record.joinMode = joinMode;
           record.toolCallId = toolCallId;
-          if (outputTranscript) {
-            record.outputFile = createOutputFilePath(ctx.cwd, id, ctx.sessionManager.getSessionId());
-            writeInitialEntry(record.outputFile, id, params.prompt, ctx.cwd);
-          }
+          attachTranscript(record, id);
         }
 
         if (joinMode == null || joinMode === 'async') {
@@ -1302,10 +1317,7 @@ Terse command-style prompts produce shallow, generic work.
           // onSpawned: called synchronously after spawn, before onSessionCreated fires.
           // Set up the output file so streamToOutputFile can pick it up.
           const fgRec = manager.getRecord(fgAgentId);
-          if (fgRec && outputTranscript) {
-            fgRec.outputFile = createOutputFilePath(ctx.cwd, fgAgentId, ctx.sessionManager.getSessionId());
-            writeInitialEntry(fgRec.outputFile, fgAgentId, params.prompt, ctx.cwd);
-          }
+          attachTranscript(fgRec, fgAgentId);
         });
         record = fgResult.record;
       } catch (err) {
@@ -1926,7 +1938,7 @@ skills: <true (inherit all), false (none), or comma-separated skill names to pre
 disallowed_tools: <comma-separated tool names to block, even if otherwise available. Omit for none>
 inherit_context: <true to fork parent conversation into agent so it sees chat history. Default: false>
 run_in_background: <true to run in background by default. Default: false>
-output_transcript: <false to create no sidechain transcript file or path. Independent of persist_session. Default: true>
+output_transcript: <false to write no transcript file or path for this agent. Independent of persist_session. Default: true>
 isolated: <true for no extension/MCP tools, only built-in tools. Default: false>
 memory: <"user" (global), "project" (per-project), or "local" (gitignored per-project) for persistent memory. Omit for none>
 isolation: <"worktree" to run in isolated git worktree. Omit for normal>
@@ -1942,7 +1954,7 @@ Guidelines for choosing settings:
 - Use prompt_mode: replace for fully custom agents with their own personality/instructions
 - Set inherit_context: true if the agent needs to know what was discussed in the parent conversation
 - Set isolated: true if the agent should NOT have access to MCP servers or other extensions
-- Set output_transcript: false to suppress the sidechain transcript; also keep persist_session false when the full conversation must not be written to disk
+- Set output_transcript: false to skip writing this agent's transcript; this alone doesn't keep the run off disk (persist_session, isolation: worktree commits, and memory still write) — set those too if that's the goal
 - Only include frontmatter fields that differ from defaults — omit fields where the default is fine
 
 Write the file using the write tool. Only write the file, nothing else.`;
@@ -2068,6 +2080,7 @@ ${systemPrompt}
       toolDescriptionMode: getToolDescriptionMode(),
       fleetView: isFleetViewEnabled(),
       widgetMode: getWidgetMode(),
+      outputTranscript: getOutputTranscriptDefault(),
     };
   }
 

--- a/src/index.ts
+++ b/src/index.ts
@@ -1049,6 +1049,7 @@ Terse command-style prompts produce shallow, generic work.
       const runInBackground = resolvedConfig.runInBackground;
       const isolated = resolvedConfig.isolated;
       const isolation = resolvedConfig.isolation;
+      const outputTranscript = customConfig?.outputTranscript !== false;
 
       const parentModelId = ctx.model?.id;
       const effectiveModelId = model?.id;
@@ -1180,8 +1181,10 @@ Terse command-style prompts produce shallow, generic work.
         if (record && joinMode) {
           record.joinMode = joinMode;
           record.toolCallId = toolCallId;
-          record.outputFile = createOutputFilePath(ctx.cwd, id, ctx.sessionManager.getSessionId());
-          writeInitialEntry(record.outputFile, id, params.prompt, ctx.cwd);
+          if (outputTranscript) {
+            record.outputFile = createOutputFilePath(ctx.cwd, id, ctx.sessionManager.getSessionId());
+            writeInitialEntry(record.outputFile, id, params.prompt, ctx.cwd);
+          }
         }
 
         if (joinMode == null || joinMode === 'async') {
@@ -1299,7 +1302,7 @@ Terse command-style prompts produce shallow, generic work.
           // onSpawned: called synchronously after spawn, before onSessionCreated fires.
           // Set up the output file so streamToOutputFile can pick it up.
           const fgRec = manager.getRecord(fgAgentId);
-          if (fgRec) {
+          if (fgRec && outputTranscript) {
             fgRec.outputFile = createOutputFilePath(ctx.cwd, fgAgentId, ctx.sessionManager.getSessionId());
             writeInitialEntry(fgRec.outputFile, fgAgentId, params.prompt, ctx.cwd);
           }
@@ -1796,6 +1799,7 @@ Terse command-style prompts produce shallow, generic work.
     if (cfg.disallowedTools?.length) fmFields.push(`disallowed_tools: ${cfg.disallowedTools.join(", ")}`);
     if (cfg.inheritContext) fmFields.push("inherit_context: true");
     if (cfg.runInBackground) fmFields.push("run_in_background: true");
+    if (cfg.outputTranscript === false) fmFields.push("output_transcript: false");
     if (cfg.isolated) fmFields.push("isolated: true");
     if (cfg.memory) fmFields.push(`memory: ${cfg.memory}`);
     if (cfg.isolation) fmFields.push(`isolation: ${cfg.isolation}`);
@@ -1922,6 +1926,7 @@ skills: <true (inherit all), false (none), or comma-separated skill names to pre
 disallowed_tools: <comma-separated tool names to block, even if otherwise available. Omit for none>
 inherit_context: <true to fork parent conversation into agent so it sees chat history. Default: false>
 run_in_background: <true to run in background by default. Default: false>
+output_transcript: <false to create no sidechain transcript file or path. Independent of persist_session. Default: true>
 isolated: <true for no extension/MCP tools, only built-in tools. Default: false>
 memory: <"user" (global), "project" (per-project), or "local" (gitignored per-project) for persistent memory. Omit for none>
 isolation: <"worktree" to run in isolated git worktree. Omit for normal>
@@ -1937,6 +1942,7 @@ Guidelines for choosing settings:
 - Use prompt_mode: replace for fully custom agents with their own personality/instructions
 - Set inherit_context: true if the agent needs to know what was discussed in the parent conversation
 - Set isolated: true if the agent should NOT have access to MCP servers or other extensions
+- Set output_transcript: false to suppress the sidechain transcript; also keep persist_session false when the full conversation must not be written to disk
 - Only include frontmatter fields that differ from defaults — omit fields where the default is fine
 
 Write the file using the write tool. Only write the file, nothing else.`;

--- a/src/settings.ts
+++ b/src/settings.ts
@@ -83,6 +83,17 @@ export interface SubagentsSettings {
    * widget).
    */
   widgetMode?: WidgetMode;
+  /**
+   * Project/global default for writing each subagent's `.output` transcript
+   * (a JSON-lines copy of the run, stored under the OS temp dir).
+   * Defaults to `true`. Set `false` to make transcripts opt-in for the whole
+   * project (e.g. a repo that shouldn't leave run transcripts on disk for backup
+   * or DLP tooling to ingest). A custom agent's `output_transcript` frontmatter
+   * overrides this per agent. This governs only the transcript — it does NOT
+   * affect the persisted pi session (`persist_session`), worktree commits
+   * (`isolation: worktree`), or memory files.
+   */
+  outputTranscript?: boolean;
 }
 
 export type ToolDescriptionMode = "full" | "compact" | "custom";
@@ -99,6 +110,7 @@ export interface SettingsAppliers {
   setToolDescriptionMode: (mode: ToolDescriptionMode) => void;
   setFleetView: (b: boolean) => void;
   setWidgetMode: (mode: WidgetMode) => void;
+  setOutputTranscript: (b: boolean) => void;
 }
 
 /** Emit callback — a subset of `pi.events.emit` to keep helpers testable. */
@@ -162,6 +174,9 @@ function sanitize(raw: unknown): SubagentsSettings {
   if (typeof r.widgetMode === "string" && VALID_WIDGET_MODES.has(r.widgetMode)) {
     out.widgetMode = r.widgetMode as WidgetMode;
   }
+  if (typeof r.outputTranscript === "boolean") {
+    out.outputTranscript = r.outputTranscript;
+  }
   return out;
 }
 
@@ -222,6 +237,7 @@ export function applySettings(s: SubagentsSettings, appliers: SettingsAppliers):
   if (s.toolDescriptionMode) appliers.setToolDescriptionMode(s.toolDescriptionMode);
   if (typeof s.fleetView === "boolean") appliers.setFleetView(s.fleetView);
   if (s.widgetMode) appliers.setWidgetMode(s.widgetMode);
+  if (typeof s.outputTranscript === "boolean") appliers.setOutputTranscript(s.outputTranscript);
 }
 
 /**

--- a/src/types.ts
+++ b/src/types.ts
@@ -43,6 +43,8 @@ export interface AgentConfig {
   maxTurns?: number;
   /** Persist this subagent as a normal pi session instead of keeping it in memory only. */
   persistSession?: boolean;
+  /** Write the sidechain .output transcript. Defaults to true; false suppresses only that transcript. */
+  outputTranscript?: boolean;
   /** Optional session directory used when persistSession is true. Omitted = pi's normal session location. */
   sessionDir?: string;
   systemPrompt: string;

--- a/src/types.ts
+++ b/src/types.ts
@@ -43,7 +43,7 @@ export interface AgentConfig {
   maxTurns?: number;
   /** Persist this subagent as a normal pi session instead of keeping it in memory only. */
   persistSession?: boolean;
-  /** Write the sidechain .output transcript. Defaults to true; false suppresses only that transcript. */
+  /** Write the subagent's .output transcript. Defaults to true; false suppresses only that transcript. */
   outputTranscript?: boolean;
   /** Optional session directory used when persistSession is true. Omitted = pi's normal session location. */
   sessionDir?: string;

--- a/test/custom-agents.test.ts
+++ b/test/custom-agents.test.ts
@@ -107,6 +107,7 @@ model: anthropic/claude-opus-4-6
 thinking: high
 max_turns: 30
 persist_session: true
+output_transcript: false
 session_dir: .seams/pi-sessions/seam-plan-reviewer
 prompt_mode: replace
 inherit_context: true
@@ -127,6 +128,7 @@ You are a security auditor.`);
     expect(agent.thinking).toBe("high");
     expect(agent.maxTurns).toBe(30);
     expect(agent.persistSession).toBe(true);
+    expect(agent.outputTranscript).toBe(false);
     expect(agent.sessionDir).toBe(".seams/pi-sessions/seam-plan-reviewer");
     expect(agent.promptMode).toBe("replace");
     expect(agent.inheritContext).toBe(true);
@@ -153,6 +155,7 @@ Just a prompt.`);
     expect(agent.thinking).toBeUndefined();
     expect(agent.maxTurns).toBeUndefined();
     expect(agent.persistSession).toBeUndefined();
+    expect(agent.outputTranscript).toBeUndefined();
     expect(agent.sessionDir).toBeUndefined();
     expect(agent.promptMode).toBe("replace");
     expect(agent.inheritContext).toBeUndefined();

--- a/test/output-transcript-wiring.test.ts
+++ b/test/output-transcript-wiring.test.ts
@@ -1,0 +1,148 @@
+import { mkdirSync, mkdtempSync, rmSync, writeFileSync } from "node:fs";
+import { tmpdir } from "node:os";
+import { join } from "node:path";
+import { afterEach, beforeEach, describe, expect, it, vi } from "vitest";
+
+vi.mock("../src/agent-runner.js", async () => {
+  const actual = await vi.importActual<typeof import("../src/agent-runner.js")>("../src/agent-runner.js");
+  return { ...actual, runAgent: vi.fn() };
+});
+
+vi.mock("../src/output-file.js", () => ({
+  createOutputFilePath: vi.fn(() => "/tmp/fake-subagent.output"),
+  writeInitialEntry: vi.fn(),
+  streamToOutputFile: vi.fn(() => vi.fn()),
+}));
+
+import { runAgent } from "../src/agent-runner.js";
+import subagentsExtension from "../src/index.js";
+import { createOutputFilePath, streamToOutputFile, writeInitialEntry } from "../src/output-file.js";
+
+function makePi() {
+  const tools = new Map<string, any>();
+  const lifecycle = new Map<string, any>();
+  const events = new Map<string, any>();
+  const pi = {
+    registerMessageRenderer: vi.fn(),
+    registerTool: vi.fn((tool: any) => tools.set(tool.name, tool)),
+    registerCommand: vi.fn(),
+    on: vi.fn((event: string, handler: any) => lifecycle.set(event, handler)),
+    events: {
+      emit: vi.fn(),
+      on: vi.fn((event: string, handler: any) => {
+        events.set(event, handler);
+        return vi.fn();
+      }),
+    },
+    appendEntry: vi.fn(),
+    sendMessage: vi.fn(),
+  } as any;
+  return { pi, tools, lifecycle };
+}
+
+function makeCtx(cwd: string) {
+  return {
+    hasUI: false,
+    ui: { setStatus: vi.fn(), setWidget: vi.fn(), notify: vi.fn() },
+    cwd,
+    model: undefined,
+    modelRegistry: { find: vi.fn(), getAvailable: vi.fn(() => []) },
+    sessionManager: { getSessionId: vi.fn(() => "session-1"), getBranch: vi.fn(() => []) },
+    getSystemPrompt: vi.fn(() => "parent"),
+  } as any;
+}
+
+describe("output_transcript agent wiring", () => {
+  let cwd: string;
+  let agentDir: string;
+  let previousCwd: string;
+  let previousAgentDir: string | undefined;
+  let previousHome: string | undefined;
+
+  beforeEach(() => {
+    cwd = mkdtempSync(join(tmpdir(), "pi-output-transcript-cwd-"));
+    agentDir = mkdtempSync(join(tmpdir(), "pi-output-transcript-agent-"));
+    previousCwd = process.cwd();
+    previousAgentDir = process.env.PI_CODING_AGENT_DIR;
+    previousHome = process.env.HOME;
+    process.env.PI_CODING_AGENT_DIR = agentDir;
+    process.env.HOME = agentDir;
+    mkdirSync(join(cwd, ".pi"), { recursive: true });
+    writeFileSync(join(cwd, ".pi", "subagents.json"), JSON.stringify({ schedulingEnabled: false }));
+    mkdirSync(join(agentDir, "agents"), { recursive: true });
+    process.chdir(cwd);
+    vi.mocked(runAgent).mockImplementation(async (_ctx, _type, _prompt, options) => {
+      await Promise.resolve();
+      const session = { messages: [], subscribe: vi.fn(() => vi.fn()), dispose: vi.fn() } as any;
+      options.onSessionCreated?.(session);
+      return { responseText: "done", session, aborted: false, steered: false };
+    });
+  });
+
+  afterEach(() => {
+    process.chdir(previousCwd);
+    if (previousAgentDir == null) delete process.env.PI_CODING_AGENT_DIR;
+    else process.env.PI_CODING_AGENT_DIR = previousAgentDir;
+    if (previousHome == null) delete process.env.HOME;
+    else process.env.HOME = previousHome;
+    rmSync(cwd, { recursive: true, force: true });
+    rmSync(agentDir, { recursive: true, force: true });
+    vi.clearAllMocks();
+  });
+
+  it("creates no sidechain transcript when a custom agent sets output_transcript false", async () => {
+    writeFileSync(join(agentDir, "agents", "sensitive.md"), `---\ndescription: Sensitive in-memory agent\noutput_transcript: false\n---\n\nKeep data in memory.`);
+    const { pi, tools, lifecycle } = makePi();
+    subagentsExtension(pi);
+
+    await tools.get("Agent").execute(
+      "tool-call",
+      { prompt: "process sensitive data", description: "Process sensitive data", subagent_type: "sensitive" },
+      undefined,
+      undefined,
+      makeCtx(cwd),
+    );
+
+    expect(createOutputFilePath).not.toHaveBeenCalled();
+    expect(writeInitialEntry).not.toHaveBeenCalled();
+    expect(streamToOutputFile).not.toHaveBeenCalled();
+    await lifecycle.get("session_shutdown")?.({}, makeCtx(cwd));
+  });
+
+  it("also suppresses the background sidechain transcript", async () => {
+    writeFileSync(join(agentDir, "agents", "sensitive.md"), `---\ndescription: Sensitive in-memory agent\noutput_transcript: false\nrun_in_background: true\n---\n\nKeep data in memory.`);
+    const { pi, tools, lifecycle } = makePi();
+    subagentsExtension(pi);
+
+    await tools.get("Agent").execute(
+      "tool-call",
+      { prompt: "process sensitive data", description: "Process sensitive data", subagent_type: "sensitive" },
+      undefined,
+      undefined,
+      makeCtx(cwd),
+    );
+
+    expect(createOutputFilePath).not.toHaveBeenCalled();
+    expect(writeInitialEntry).not.toHaveBeenCalled();
+    expect(streamToOutputFile).not.toHaveBeenCalled();
+    await lifecycle.get("session_shutdown")?.({}, makeCtx(cwd));
+  });
+
+  it("keeps transcript creation as the default", async () => {
+    const { pi, tools, lifecycle } = makePi();
+    subagentsExtension(pi);
+
+    await tools.get("Agent").execute(
+      "tool-call",
+      { prompt: "ordinary work", description: "Do ordinary work", subagent_type: "general-purpose" },
+      undefined,
+      undefined,
+      makeCtx(cwd),
+    );
+
+    expect(createOutputFilePath).toHaveBeenCalledOnce();
+    expect(writeInitialEntry).toHaveBeenCalledOnce();
+    expect(streamToOutputFile).toHaveBeenCalledOnce();
+    await lifecycle.get("session_shutdown")?.({}, makeCtx(cwd));
+  });
+});

--- a/test/output-transcript-wiring.test.ts
+++ b/test/output-transcript-wiring.test.ts
@@ -90,7 +90,7 @@ describe("output_transcript agent wiring", () => {
     vi.clearAllMocks();
   });
 
-  it("creates no sidechain transcript when a custom agent sets output_transcript false", async () => {
+  it("creates no transcript when a custom agent sets output_transcript false", async () => {
     writeFileSync(join(agentDir, "agents", "sensitive.md"), `---\ndescription: Sensitive in-memory agent\noutput_transcript: false\n---\n\nKeep data in memory.`);
     const { pi, tools, lifecycle } = makePi();
     subagentsExtension(pi);
@@ -109,7 +109,7 @@ describe("output_transcript agent wiring", () => {
     await lifecycle.get("session_shutdown")?.({}, makeCtx(cwd));
   });
 
-  it("also suppresses the background sidechain transcript", async () => {
+  it("also suppresses the background transcript", async () => {
     writeFileSync(join(agentDir, "agents", "sensitive.md"), `---\ndescription: Sensitive in-memory agent\noutput_transcript: false\nrun_in_background: true\n---\n\nKeep data in memory.`);
     const { pi, tools, lifecycle } = makePi();
     subagentsExtension(pi);
@@ -135,6 +135,46 @@ describe("output_transcript agent wiring", () => {
     await tools.get("Agent").execute(
       "tool-call",
       { prompt: "ordinary work", description: "Do ordinary work", subagent_type: "general-purpose" },
+      undefined,
+      undefined,
+      makeCtx(cwd),
+    );
+
+    expect(createOutputFilePath).toHaveBeenCalledOnce();
+    expect(writeInitialEntry).toHaveBeenCalledOnce();
+    expect(streamToOutputFile).toHaveBeenCalledOnce();
+    await lifecycle.get("session_shutdown")?.({}, makeCtx(cwd));
+  });
+
+  it("suppresses the transcript project-wide when subagents.json sets outputTranscript false", async () => {
+    // A plain default agent (no frontmatter) inherits the project default.
+    writeFileSync(join(cwd, ".pi", "subagents.json"), JSON.stringify({ schedulingEnabled: false, outputTranscript: false }));
+    const { pi, tools, lifecycle } = makePi();
+    subagentsExtension(pi);
+
+    await tools.get("Agent").execute(
+      "tool-call",
+      { prompt: "ordinary work", description: "Do ordinary work", subagent_type: "general-purpose" },
+      undefined,
+      undefined,
+      makeCtx(cwd),
+    );
+
+    expect(createOutputFilePath).not.toHaveBeenCalled();
+    expect(writeInitialEntry).not.toHaveBeenCalled();
+    expect(streamToOutputFile).not.toHaveBeenCalled();
+    await lifecycle.get("session_shutdown")?.({}, makeCtx(cwd));
+  });
+
+  it("lets agent frontmatter output_transcript true override a project outputTranscript false", async () => {
+    writeFileSync(join(cwd, ".pi", "subagents.json"), JSON.stringify({ schedulingEnabled: false, outputTranscript: false }));
+    writeFileSync(join(agentDir, "agents", "audited.md"), `---\ndescription: Always keeps a transcript\noutput_transcript: true\n---\n\nWrite a transcript regardless of the project default.`);
+    const { pi, tools, lifecycle } = makePi();
+    subagentsExtension(pi);
+
+    await tools.get("Agent").execute(
+      "tool-call",
+      { prompt: "audited work", description: "Do audited work", subagent_type: "audited" },
       undefined,
       undefined,
       makeCtx(cwd),

--- a/test/settings.test.ts
+++ b/test/settings.test.ts
@@ -125,6 +125,15 @@ describe("settings persistence", () => {
     expect(loadSettings(projectDir)).toEqual({}); // invalid value dropped
   });
 
+  it("round-trips outputTranscript; drops non-boolean", () => {
+    saveSettings({ outputTranscript: false }, projectDir);
+    expect(loadSettings(projectDir)).toEqual({ outputTranscript: false });
+    saveSettings({ outputTranscript: true }, projectDir);
+    expect(loadSettings(projectDir)).toEqual({ outputTranscript: true });
+    writeProject({ outputTranscript: "no" } as any);
+    expect(loadSettings(projectDir)).toEqual({}); // non-boolean dropped
+  });
+
   it("sanitize drops non-boolean schedulingEnabled silently", async () => {
     writeProject({ schedulingEnabled: "yes" } as any);
     expect(loadSettings(projectDir)).toEqual({});


### PR DESCRIPTION
## Summary
- add `output_transcript: false` custom-agent frontmatter
- skip sidechain path creation, initial writes, and streaming for transcript-disabled foreground and background agents
- preserve transcript creation by default and document independence from `persist_session`

## Why
Some agents may process data that is permitted in memory for immediate operation but must not be copied into a durable sidechain transcript. `persist_session: false` already keeps the Pi session in memory, but the separate `.output` transcript remains unconditional.

## Verification
- `npm test` — 685 passed, 4 skipped
- `npm run typecheck`
- `npm run lint`
- wiring tests assert path creation, initial writes, and stream binding are all suppressed for foreground and background agents, while default behavior remains enabled