### PR TITLE
Support Pi's max thinking level

### DIFF
--- a/README.md
+++ b/README.md
@@ -217,7 +217,7 @@ All fields are optional — sensible defaults for everything.
 | `disallowed_tools` | — | Comma-separated tools to deny even if extensions provide them |
 | `isolation` | — | Set to `worktree` to run in an isolated git worktree |
 | `model` | inherit parent | Model — `provider/modelId` or fuzzy name (`"haiku"`, `"sonnet"`). Resolved tolerantly (`.`/`-` and a trailing date stamp are interchangeable) and falls back to the same model under another provider if the named one doesn't have it |
-| `thinking` | inherit | off, minimal, low, medium, high, xhigh |
+| `thinking` | inherit | off, minimal, low, medium, high, xhigh, max |
 | `max_turns` | unlimited | Max agentic turns before graceful shutdown. `0` or omit for unlimited |
 | `persist_session` | `false` | Persist this subagent as a normal pi session instead of keeping the session in memory only. The sidechain output transcript is still written either way |
 | `session_dir` | pi default | Optional session directory when `persist_session: true`; omitted uses pi's normal session location, and relative paths resolve from the agent cwd |
@@ -227,7 +227,7 @@ All fields are optional — sensible defaults for everything.
 | `isolated` | `false` | Hermetic specialist mode: forces `extensions: false` + `skills: false` + drops `ext:` selectors. Only built-in tools. Distinct from `isolation: worktree` (filesystem) |
 | `enabled` | `true` | Set to `false` to disable an agent (useful for hiding a default agent per-project) |
 
-Frontmatter is authoritative. If an agent file sets `model`, `thinking`, `max_turns`, `inherit_context`, `run_in_background`, `isolated`, or `isolation`, those values are locked for that agent. `Agent` tool parameters only fill fields the agent config leaves unspecified.
+Frontmatter is authoritative. If an agent file sets `model`, `thinking`, `max_turns`, `inherit_context`, `run_in_background`, `isolated`, or `isolation`, those values are locked for that agent. `Agent` tool parameters only fill fields the agent config leaves unspecified. Thinking-level availability depends on the host Pi version and selected model.
 
 **Forgiving `model:` resolution.** A `model:` pin is matched against pi's model registry tolerantly, so cosmetic id variations don't silently drop the agent back to the parent's model: `.` and `-` are treated as equivalent in version numbers (`claude-haiku-4.5` ≡ `claude-haiku-4-5`), a trailing `-YYYYMMDD` date stamp is optional (`anthropic/claude-haiku-4-5-20251001` matches an undated registry id and vice-versa), and a `provider/modelId` whose named provider doesn't carry that model retries the bare id against every provider. Precedence is **exact → fuzzy under the named provider → same model under any provider → unavailable**, so an exact match always wins and dated snapshots aren't conflated. If nothing resolves, the pin can't run and the agent inherits the parent model — `/agents → Agent types` flags this case as `(unavailable, fallback: inherit)` and shows the resolved target `(→ provider/id)` when resolution lands on a different provider or version than configured. (This is distinct from [Model Scope](#model-scope) enforcement, which matches the `enabledModels` allowlist by *exact* entry.)
 
@@ -278,7 +278,7 @@ Launch a sub-agent.
 | `description` | string | yes | Short 3-5 word summary (shown in UI) |
 | `subagent_type` | string | yes | Agent type (built-in or custom) |
 | `model` | string | no | Model — `provider/modelId` or fuzzy name (`"haiku"`, `"sonnet"`). Resolved tolerantly (`.`/`-` and a trailing date stamp interchangeable) with provider fallback |
-| `thinking` | string | no | Thinking level: off, minimal, low, medium, high, xhigh |
+| `thinking` | string | no | Thinking level: off, minimal, low, medium, high, xhigh, max |
 | `max_turns` | number | no | Max agentic turns. Omit for unlimited (default) |
 | `run_in_background` | boolean | no | Run without blocking |
 | `resume` | string | no | Agent ID to resume a previous session |

--- a/src/index.ts
+++ b/src/index.ts
@@ -29,7 +29,7 @@ import { SubagentScheduler } from "./schedule.js";
 import { resolveStorePath, ScheduleStore } from "./schedule-store.js";
 import { applyAndEmitLoaded, type SubagentsSettings, saveAndEmitChanged, type ToolDescriptionMode } from "./settings.js";
 import { getStatusNote } from "./status-note.js";
-import { type AgentConfig, type AgentInvocation, type AgentRecord, type JoinMode, type NotificationDetails, type SubagentType, type WidgetMode } from "./types.js";
+import { type AgentConfig, type AgentInvocation, type AgentRecord, type JoinMode, type NotificationDetails, type SubagentType, THINKING_LEVELS, THINKING_LEVELS_DESCRIPTION, type WidgetMode } from "./types.js";
 import {
   type AgentActivity,
   type AgentDetails,
@@ -857,7 +857,7 @@ Terse command-style prompts produce shallow, generic work.
       ),
       thinking: Type.Optional(
         Type.String({
-          description: "Thinking level: off, minimal, low, medium, high, xhigh. Overrides agent default.",
+          description: `Thinking level: ${THINKING_LEVELS_DESCRIPTION}. Overrides agent default. Availability depends on the host Pi version and model.`,
         }),
       ),
       max_turns: Type.Optional(
@@ -1914,7 +1914,7 @@ The file format is a markdown file with YAML frontmatter and a system prompt bod
 description: <one-line description shown in UI>
 tools: <comma-separated built-in tools: read, bash, edit, write, grep, find, ls. Use "none" for no tools. Omit for all tools>
 model: <optional model as "provider/modelId", e.g. "anthropic/claude-haiku-4-5". Omit to inherit parent model>
-thinking: <optional thinking level: off, minimal, low, medium, high, xhigh. Omit to inherit>
+thinking: <optional thinking level: ${THINKING_LEVELS_DESCRIPTION}. Omit to inherit; availability depends on the host Pi version and model>
 max_turns: <optional max agentic turns. 0 or omit for unlimited (default)>
 prompt_mode: <"replace" (body IS the full system prompt) or "append" (body is appended to default prompt). Default: replace>
 extensions: <true (inherit all MCP/extension tools), false (none), or comma-separated names. Default: true>
@@ -2006,15 +2006,7 @@ Write the file using the write tool. Only write the file, nothing else.`;
     }
 
     // 5. Thinking
-    const thinkingChoice = await ctx.ui.select("Thinking level", [
-      "inherit",
-      "off",
-      "minimal",
-      "low",
-      "medium",
-      "high",
-      "xhigh",
-    ]);
+    const thinkingChoice = await ctx.ui.select("Thinking level", ["inherit", ...THINKING_LEVELS]);
     if (!thinkingChoice) return;
 
     let thinkingLine = "";

--- a/src/types.ts
+++ b/src/types.ts
@@ -8,6 +8,10 @@ import type { LifetimeUsage } from "./usage.js";
 
 export type { ThinkingLevel };
 
+/** User-selectable levels; the host Pi/model validates availability at session creation. */
+export const THINKING_LEVELS = ["off", "minimal", "low", "medium", "high", "xhigh", "max"] as const;
+export const THINKING_LEVELS_DESCRIPTION = THINKING_LEVELS.join(", ");
+
 /** Agent type: any string name (built-in defaults or user-defined). */
 export type SubagentType = string;
 

--- a/test/custom-agents.test.ts
+++ b/test/custom-agents.test.ts
@@ -338,6 +338,17 @@ Plain tools.`);
     expect(agent.extSelectors).toBeUndefined();
   });
 
+  it("loads the max thinking level", () => {
+    writeAgent("maxthink", `---
+thinking: max
+---
+
+Maximum thinking.`);
+
+    const result = loadCustomAgents(tmpDir);
+    expect(result.get("maxthink")!.thinking).toBe("max");
+  });
+
   it("passes through thinking level as-is (no validation)", () => {
     writeAgent("anythink", `---
 thinking: turbo

--- a/test/tool-description-mode.test.ts
+++ b/test/tool-description-mode.test.ts
@@ -92,6 +92,12 @@ describe("toolDescriptionMode", () => {
     expect(desc).toContain("very thorough");
   });
 
+  it("advertises max as a supported thinking level", () => {
+    const tools = setup();
+    const thinking = tools.get("Agent").parameters.properties.thinking;
+    expect(thinking.description).toContain("max");
+  });
+
   it("compact mode swaps in the short description with one-line type list", () => {
     const tools = setup({ toolDescriptionMode: "compact" });
     const desc: string = tools.get("Agent").description;


### PR DESCRIPTION
## Summary

- centralize the user-selectable thinking-level list
- expose Pi's `max` level in Agent guidance and both agent creation flows
- document host Pi and model compatibility requirements
- add regression coverage for tool guidance and custom-agent frontmatter

## Verification

- `npm run lint`
- `npm run typecheck`
- `npm run test` — 694 passed, 4 skipped
- `npm run build`
- typecheck against the published Pi 0.80.1 peer boundary

Closes #147

🤖 Generated with [Pi](https://pi.dev)
