### PR TITLE
fix(ui): keep conversation rows exact-width

### DIFF
--- a/src/ui/conversation-viewer.ts
+++ b/src/ui/conversation-viewer.ts
@@ -130,7 +130,7 @@ export class ConversationViewer implements Component {
       return s + " ".repeat(Math.max(0, len - vis));
     };
     const row = (content: string) =>
-      th.fg("border", "│") + " " + truncateToWidth(pad(content, innerW), innerW) + " " + th.fg("border", "│");
+      th.fg("border", "│") + " " + truncateToWidth(pad(content, innerW), innerW, "...", true) + " " + th.fg("border", "│");
     const hrTop = th.fg("border", `╭${"─".repeat(width - 2)}╮`);
     const hrBot = th.fg("border", `╰${"─".repeat(width - 2)}╯`);
     const hrMid = row(th.fg("dim", "─".repeat(innerW)));

--- a/test/conversation-viewer.test.ts
+++ b/test/conversation-viewer.test.ts
@@ -101,6 +101,27 @@ describe("ConversationViewer", () => {
       }
     });
 
+    it("keeps bordered rows exact-width at a double-width truncation boundary", () => {
+      const width = 40;
+      for (let prefixLength = 0; prefixLength < width; prefixLength++) {
+        const viewer = new ConversationViewer(
+          mockTui(30, width),
+          mockSession([]),
+          mockRecord({ description: `${"a".repeat(prefixLength)}界more` }),
+          undefined,
+          ansiTheme(),
+          vi.fn(),
+        );
+
+        for (const line of viewer.render(width)) {
+          expect(
+            visibleWidth(line),
+            `prefix ${prefixLength} produced an under-width bordered row: ${JSON.stringify(line)}`,
+          ).toBe(width);
+        }
+      }
+    });
+
     it("no line exceeds width when text is longer than viewport", () => {
       const longLine = "A".repeat(500);
       const messages = [


### PR DESCRIPTION
## Summary

- preserve the requested visible width when truncating bordered conversation-viewer rows
- add a regression test covering double-width characters at every truncation boundary

Without `preserveWidth`, truncating a row at some CJK boundaries can leave it one column short, causing the right border to shift left.

## Tests

- `npm run lint`
- `npm run typecheck`
- `npm run test` — 39 files passed, 722 tests passed, 4 skipped
- `npm run build`
