### PR TITLE
fix(ui): safely render conversation display text

### DIFF
--- a/package-lock.json
+++ b/package-lock.json
@@ -11,6 +11,7 @@
       "dependencies": {
         "@sinclair/typebox": "^0.34.49",
         "croner": "^10.0.1",
+        "istextorbinary": "^9.5.0",
         "nanoid": "^5.0.0"
       },
       "devDependencies": {
@@ -1227,7 +1228,7 @@
         "typebox": "1.1.38"
       },
       "bin": {
-        "pi-ai": "dist/cli.js"
+        "pi-ai": "./dist/cli.js"
       },
       "engines": {
         "node": ">=22.19.0"
@@ -1349,6 +1350,9 @@
       "cpu": [
         "arm64"
       ],
+      "libc": [
+        "glibc"
+      ],
       "license": "MIT",
       "optional": true,
       "os": [
@@ -1365,6 +1369,9 @@
       "integrity": "sha512-AGuJdgKsmJdm4Pych7kv3sqe591ERRaAHW3xjLooiFzn8J+PxUyof++7YZrB5Y5tpnTO+K18Og3taj2NpluCRQ==",
       "cpu": [
         "arm64"
+      ],
+      "libc": [
+        "musl"
       ],
       "license": "MIT",
       "optional": true,
@@ -1383,6 +1390,9 @@
       "cpu": [
         "riscv64"
       ],
+      "libc": [
+        "glibc"
+      ],
       "license": "MIT",
       "optional": true,
       "os": [
@@ -1400,6 +1410,9 @@
       "cpu": [
         "x64"
       ],
+      "libc": [
+        "glibc"
+      ],
       "license": "MIT",
       "optional": true,
       "os": [
@@ -1416,6 +1429,9 @@
       "integrity": "sha512-/DHn+1DrfL6oRaPPWXaOKvonFFrni666fxd+zFqiQEfvBH0tsHVWjq9iqBk0oDp0qaPA72lIMy5BptxISBEhZQ==",
       "cpu": [
         "x64"
+      ],
+      "libc": [
+        "musl"
       ],
       "license": "MIT",
       "optional": true,
@@ -3510,6 +3526,21 @@
         "node": "*"
       }
     },
+    "node_modules/binaryextensions": {
+      "version": "6.11.0",
+      "resolved": "https://registry.npmjs.org/binaryextensions/-/binaryextensions-6.11.0.tgz",
+      "integrity": "sha512-sXnYK/Ij80TO3lcqZVV2YgfKN5QjUWIRk/XSm2J/4bd/lPko3lvk0O4ZppH6m+6hB2/GTu+ptNwVFe1xh+QLQw==",
+      "license": "Artistic-2.0",
+      "dependencies": {
+        "editions": "^6.21.0"
+      },
+      "engines": {
+        "node": ">=4"
+      },
+      "funding": {
+        "url": "https://bevry.me/fund"
+      }
+    },
     "node_modules/bowser": {
       "version": "2.14.1",
       "resolved": "https://registry.npmjs.org/bowser/-/bowser-2.14.1.tgz",
@@ -3606,6 +3637,22 @@
       "peer": true,
       "dependencies": {
         "safe-buffer": "^5.0.1"
+      }
+    },
+    "node_modules/editions": {
+      "version": "6.22.0",
+      "resolved": "https://registry.npmjs.org/editions/-/editions-6.22.0.tgz",
+      "integrity": "sha512-UgGlf8IW75je7HZjNDpJdCv4cGJWIi6yumFdZ0R7A8/CIhQiWUjyGLCxdHpd8bmyD1gnkfUNK0oeOXqUS2cpfQ==",
+      "license": "Artistic-2.0",
+      "dependencies": {
+        "version-range": "^4.15.0"
+      },
+      "engines": {
+        "ecmascript": ">= es5",
+        "node": ">=4"
+      },
+      "funding": {
+        "url": "https://bevry.me/fund"
       }
     },
     "node_modules/es-module-lexer": {
@@ -3848,6 +3895,23 @@
       },
       "engines": {
         "node": ">= 14"
+      }
+    },
+    "node_modules/istextorbinary": {
+      "version": "9.5.0",
+      "resolved": "https://registry.npmjs.org/istextorbinary/-/istextorbinary-9.5.0.tgz",
+      "integrity": "sha512-5mbUj3SiZXCuRf9fT3ibzbSSEWiy63gFfksmGfdOzujPjW3k+z8WvIBxcJHBoQNlaZaiyB25deviif2+osLmLw==",
+      "license": "Artistic-2.0",
+      "dependencies": {
+        "binaryextensions": "^6.11.0",
+        "editions": "^6.21.0",
+        "textextensions": "^6.11.0"
+      },
+      "engines": {
+        "node": ">=4"
+      },
+      "funding": {
+        "url": "https://bevry.me/fund"
       }
     },
     "node_modules/json-bigint": {
@@ -4532,6 +4596,21 @@
       "license": "MIT",
       "peer": true
     },
+    "node_modules/textextensions": {
+      "version": "6.11.0",
+      "resolved": "https://registry.npmjs.org/textextensions/-/textextensions-6.11.0.tgz",
+      "integrity": "sha512-tXJwSr9355kFJI3lbCkPpUH5cP8/M0GGy2xLO34aZCjMXBaK3SoPnZwr/oWmo1FdCnELcs4npdCIOFtq9W3ruQ==",
+      "license": "Artistic-2.0",
+      "dependencies": {
+        "editions": "^6.21.0"
+      },
+      "engines": {
+        "node": ">=4"
+      },
+      "funding": {
+        "url": "https://bevry.me/fund"
+      }
+    },
     "node_modules/tinybench": {
       "version": "2.9.0",
       "resolved": "https://registry.npmjs.org/tinybench/-/tinybench-2.9.0.tgz",
@@ -4615,6 +4694,18 @@
       "resolved": "https://registry.npmjs.org/undici-types/-/undici-types-7.24.6.tgz",
       "integrity": "sha512-WRNW+sJgj5OBN4/0JpHFqtqzhpbnV0GuB+OozA9gCL7a993SmU+1JBZCzLNxYsbMfIeDL+lTsphD5jN5N+n0zg==",
       "license": "MIT"
+    },
+    "node_modules/version-range": {
+      "version": "4.15.0",
+      "resolved": "https://registry.npmjs.org/version-range/-/version-range-4.15.0.tgz",
+      "integrity": "sha512-Ck0EJbAGxHwprkzFO966t4/5QkRuzh+/I1RxhLgUKKwEn+Cd8NwM60mE3AqBZg5gYODoXW0EFsQvbZjRlvdqbg==",
+      "license": "Artistic-2.0",
+      "engines": {
+        "node": ">=4"
+      },
+      "funding": {
+        "url": "https://bevry.me/fund"
+      }
     },
     "node_modules/vite": {
       "version": "8.0.14",

--- a/package.json
+++ b/package.json
@@ -28,6 +28,7 @@
   "dependencies": {
     "@sinclair/typebox": "^0.34.49",
     "croner": "^10.0.1",
+    "istextorbinary": "^9.5.0",
     "nanoid": "^5.0.0"
   },
   "scripts": {

--- a/src/index.ts
+++ b/src/index.ts
@@ -51,6 +51,7 @@ import {
   type UICtx,
 } from "./ui/agent-widget.js";
 import { FleetList, type FleetUICtx } from "./ui/fleet-list.js";
+import { prepareConversationDisplay } from "./ui/prepare-conversation-display.js";
 import { showSchedulesMenu } from "./ui/schedule-menu.js";
 import { addUsage, getLifetimeTotal, getSessionContextPercent, type LifetimeUsage } from "./usage.js";
 
@@ -59,6 +60,13 @@ import { addUsage, getLifetimeTotal, getSessionContextPercent, type LifetimeUsag
 /** Tool execute return value for a text response. */
 function textResult(msg: string, details?: AgentDetails) {
   return { content: [{ type: "text" as const, text: msg }], details: details as any };
+}
+
+export function prepareInvocationTagLines(rawTags: string[]): string[] {
+  return rawTags.flatMap((tag) => {
+    const prepared = prepareConversationDisplay(tag);
+    return [...(prepared.warning ? [prepared.warning] : []), ...prepared.lines];
+  });
 }
 
 export function renderRunningAgentStatus(
@@ -1153,7 +1161,8 @@ Terse command-style prompts produce shallow, generic work.
       };
       // Tool-result render shows the mode label too; viewer's header already does.
       const modeLabel = getPromptModeLabel(subagentType);
-      const { tags: invocationTags } = buildInvocationTags(agentInvocation);
+      const { tags: rawInvocationTags } = buildInvocationTags(agentInvocation);
+      const invocationTags = prepareInvocationTagLines(rawInvocationTags);
       const agentTags = modeLabel ? [modeLabel, ...invocationTags] : invocationTags;
       const detailBase = {
         displayName,

--- a/src/istextorbinary.d.ts
+++ b/src/istextorbinary.d.ts
@@ -1,0 +1,3 @@
+declare module "istextorbinary" {
+  export function isBinary(filename?: string | null, buffer?: Buffer | null): boolean | null;
+}

--- a/src/ui/agent-widget.ts
+++ b/src/ui/agent-widget.ts
@@ -178,8 +178,9 @@ export function buildInvocationTags(
 /** Truncate text to a single line, max `len` chars. */
 function truncateLine(text: string, len = 60): string {
   const line = text.split("\n").find(l => l.trim())?.trim() ?? "";
-  if (line.length <= len) return line;
-  return line.slice(0, len) + "…";
+  const codePoints = Array.from(line);
+  if (codePoints.length <= len) return line;
+  return codePoints.slice(0, len).join("") + "…";
 }
 
 /** Build a human-readable activity string from currently-running tools or response text. */

--- a/src/ui/conversation-viewer.ts
+++ b/src/ui/conversation-viewer.ts
@@ -12,10 +12,11 @@ import type { AgentRecord } from "../types.js";
 import { getLifetimeTotal, getSessionContextPercent } from "../usage.js";
 import type { Theme } from "./agent-widget.js";
 import { type AgentActivity, buildInvocationTags, describeActivity, fgPreservingNestedStyles, formatDuration, formatSessionTokens, getDisplayName, getPromptModeLabel } from "./agent-widget.js";
+import { prepareConversationDisplay } from "./prepare-conversation-display.js";
 import { createViewerKeys, type ViewerKeybindings, type ViewerKeys } from "./viewer-keys.js";
 
-/** Base lines consumed by chrome: top border + header + header sep + footer sep + footer + bottom border. */
-const CHROME_LINES_BASE = 6;
+/** Fixed chrome: top border + header separator + footer separator + footer + bottom border. */
+const CHROME_LINES_FIXED = 5;
 const MIN_VIEWPORT = 3;
 /** Height ceiling shared by the overlay's `maxHeight` and the viewer's internal viewport cap. */
 export const VIEWPORT_HEIGHT_PCT = 70;
@@ -135,39 +136,19 @@ export class ConversationViewer implements Component {
     const hrBot = th.fg("border", `╰${"─".repeat(width - 2)}╯`);
     const hrMid = row(th.fg("dim", "─".repeat(innerW)));
 
+    const maxRows = this.maxRows();
+    const minimumChrome = CHROME_LINES_FIXED + 1 + (this.composer ? 1 : 0);
+    if (maxRows < minimumChrome) return [];
+    const headerLines = this.headerLines(maxRows);
+
     // Header
     lines.push(hrTop);
-    const name = getDisplayName(this.record.type);
-    const modeLabel = getPromptModeLabel(this.record.type);
-    const modeTag = modeLabel ? ` ${th.fg("dim", `(${modeLabel})`)}` : "";
-    const statusIcon = this.record.status === "running"
-      ? th.fg("accent", "●")
-      : this.record.status === "completed"
-        ? th.fg("success", "✓")
-        : this.record.status === "error"
-          ? th.fg("error", "✗")
-          : th.fg("dim", "○");
-    const duration = formatDuration(this.record.startedAt, this.record.completedAt);
-
-    const headerParts: string[] = [duration];
-    const toolUses = this.activity?.toolUses ?? this.record.toolUses;
-    if (toolUses > 0) headerParts.unshift(`${toolUses} tool${toolUses === 1 ? "" : "s"}`);
-    const tokens = getLifetimeTotal(this.activity?.lifetimeUsage);
-    if (tokens > 0) {
-      const percent = getSessionContextPercent(this.activity?.session);
-      headerParts.push(formatSessionTokens(tokens, percent, th, this.record.compactionCount));
-    }
-
-    lines.push(row(
-      `${statusIcon} ${th.bold(name)}${modeTag}  ${th.fg("muted", this.record.description)} ${th.fg("dim", "·")} ${fgPreservingNestedStyles(th, "dim", headerParts.join(" · "))}`,
-    ));
-    const invocationLine = this.invocationLine();
-    if (invocationLine) lines.push(row(invocationLine));
+    for (const headerLine of headerLines) lines.push(row(headerLine));
     lines.push(hrMid);
 
     // Content area — rebuild every render (live data, no cache needed)
     const contentLines = this.buildContentLines(innerW);
-    const viewportHeight = this.viewportHeight();
+    const viewportHeight = this.viewportHeight(headerLines.length, maxRows);
     const maxScroll = Math.max(0, contentLines.length - viewportHeight);
 
     if (this.autoScroll) {
@@ -261,23 +242,73 @@ export class ConversationViewer implements Component {
 
   // ---- Private ----
 
-  private viewportHeight(): number {
-    // Cap mirrors the overlay's maxHeight — otherwise the viewer would render
-    // more lines than the overlay shows and clip the footer.
-    const maxRows = Math.floor((this.tui.terminal.rows * VIEWPORT_HEIGHT_PCT) / 100);
-    return Math.max(MIN_VIEWPORT, maxRows - this.chromeLines());
+  private maxRows(): number {
+    return Math.floor((this.tui.terminal.rows * VIEWPORT_HEIGHT_PCT) / 100);
   }
 
-  private chromeLines(): number {
-    // The composer adds one row above the footer hint while it's open.
-    return CHROME_LINES_BASE + (this.invocationLine() ? 1 : 0) + (this.composer ? 1 : 0);
+  private viewportHeight(headerRows = this.headerLines(this.maxRows()).length, maxRows = this.maxRows()): number {
+    return Math.max(0, maxRows - this.chromeLines(headerRows));
   }
 
-  private invocationLine(): string | undefined {
+  private chromeLines(headerRows: number): number {
+    return CHROME_LINES_FIXED + headerRows + (this.composer ? 1 : 0);
+  }
+
+  private headerLines(maxRows: number): string[] {
+    const th = this.theme;
+    const name = prepareConversationDisplay(getDisplayName(this.record.type));
+    const description = prepareConversationDisplay(this.record.description);
+    const modeLabel = getPromptModeLabel(this.record.type);
+    const modeTag = modeLabel ? ` ${th.fg("dim", `(${modeLabel})`)}` : "";
+    const statusIcon = this.record.status === "running" ? th.fg("accent", "●")
+      : this.record.status === "completed" ? th.fg("success", "✓")
+        : this.record.status === "error" ? th.fg("error", "✗") : th.fg("dim", "○");
+    const parts: string[] = [formatDuration(this.record.startedAt, this.record.completedAt)];
+    const toolUses = this.activity?.toolUses ?? this.record.toolUses;
+    if (toolUses > 0) parts.unshift(`${toolUses} tool${toolUses === 1 ? "" : "s"}`);
+    const tokens = getLifetimeTotal(this.activity?.lifetimeUsage);
+    if (tokens > 0) parts.push(formatSessionTokens(tokens, getSessionContextPercent(this.activity?.session), th, this.record.compactionCount));
+
+    const lines: string[] = [];
+    if (name.warning) lines.push(th.fg("muted", name.warning));
+    const inlineDescription = description.warning ? "" : description.lines[0] ?? "";
+    const primaryLine = `${statusIcon} ${th.bold(name.lines[0] ?? "")}${modeTag}  ${th.fg("muted", inlineDescription)} ${th.fg("dim", "·")} ${fgPreservingNestedStyles(th, "dim", parts.join(" · "))}`;
+    lines.push(primaryLine);
+    for (const line of name.lines.slice(1)) lines.push(`  ${th.bold(line)}`);
+    if (description.warning) {
+      lines.push(th.fg("muted", description.warning));
+      for (const line of description.lines) lines.push(`  ${th.fg("muted", line)}`);
+    } else {
+      for (const line of description.lines.slice(1)) lines.push(`  ${th.fg("muted", line)}`);
+    }
+
     const { modelName, tags } = buildInvocationTags(this.record.invocation);
-    const parts = modelName ? [modelName, ...tags] : tags;
-    if (parts.length === 0) return undefined;
-    return this.theme.fg("dim", `  ↳ ${parts.join(" · ")}`);
+    const invocationParts = [modelName, ...tags]
+      .filter((part): part is string => part !== undefined)
+      .map(part => prepareConversationDisplay(part));
+    const canRenderInline = invocationParts.every(part => !part.warning && part.lines.length === 1);
+    if (canRenderInline && invocationParts.length > 0) {
+      lines.push(th.fg("dim", `  ↳ ${invocationParts.map(part => part.text).join(" · ")}`));
+    } else {
+      let firstInvocationRow = true;
+      for (const part of invocationParts) {
+        if (part.warning) lines.push(th.fg("muted", part.warning));
+        for (const line of part.lines) {
+          lines.push(th.fg("dim", `  ${firstInvocationRow ? "↳" : " "} ${line}`));
+          firstInvocationRow = false;
+        }
+      }
+    }
+
+    const roomyMinimumViewport = maxRows >= CHROME_LINES_FIXED + (this.composer ? 1 : 0) + 1 + MIN_VIEWPORT
+      ? MIN_VIEWPORT
+      : 1;
+    const headerBudget = Math.max(1, maxRows - CHROME_LINES_FIXED - (this.composer ? 1 : 0) - roomyMinimumViewport);
+    if (lines.length <= headerBudget) return lines;
+
+    const supplemental = lines.filter((line) => line !== primaryLine);
+    if (headerBudget === 1) return [primaryLine];
+    return [primaryLine, ...supplemental.slice(0, headerBudget - 2), th.fg("dim", "…")];
   }
 
   private buildContentLines(width: number): string[] {
@@ -286,6 +317,16 @@ export class ConversationViewer implements Component {
     const th = this.theme;
     const messages = this.session.messages;
     const lines: string[] = [];
+    const appendPrepared = (rawText: string, options: { maxCodePoints?: number; frame?: (line: string) => string } = {}) => {
+      const prepared = prepareConversationDisplay(rawText, options.maxCodePoints);
+      if (prepared.warning) lines.push(th.fg("muted", prepared.warning));
+      for (const preparedLine of prepared.lines) {
+        for (const wrapped of wrapTextWithAnsi(preparedLine, width)) {
+          lines.push(truncateToWidth(options.frame ? options.frame(wrapped) : wrapped, width));
+        }
+      }
+      return prepared;
+    };
 
     if (messages.length === 0) {
       lines.push(th.fg("dim", "(waiting for first message...)"));
@@ -301,9 +342,7 @@ export class ConversationViewer implements Component {
         if (!text.trim()) continue;
         if (needsSeparator) lines.push(th.fg("dim", "───"));
         lines.push(th.fg("accent", "[User]"));
-        for (const line of wrapTextWithAnsi(text.trim(), width)) {
-          lines.push(line);
-        }
+        appendPrepared(text.trim());
       } else if (msg.role === "assistant") {
         const textParts: string[] = [];
         const toolCalls: string[] = [];
@@ -315,35 +354,19 @@ export class ConversationViewer implements Component {
         }
         if (needsSeparator) lines.push(th.fg("dim", "───"));
         lines.push(th.bold("[Assistant]"));
-        if (textParts.length > 0) {
-          for (const line of wrapTextWithAnsi(textParts.join("\n").trim(), width)) {
-            lines.push(line);
-          }
-        }
-        for (const name of toolCalls) {
-          lines.push(truncateToWidth(th.fg("muted", `  [Tool: ${name}]`), width));
-        }
+        if (textParts.length > 0) appendPrepared(textParts.join("\n").trim());
+        for (const name of toolCalls) appendPrepared(String(name), { frame: (line) => th.fg("muted", `  [Tool: ${line}]`) });
       } else if (msg.role === "toolResult") {
-        const text = extractText(msg.content);
-        const truncated = text.length > 500 ? text.slice(0, 500) + "... (truncated)" : text;
-        if (!truncated.trim()) continue;
+        const rawText = extractText(msg.content);
+        if (!rawText.trim()) continue;
         if (needsSeparator) lines.push(th.fg("dim", "───"));
         lines.push(th.fg("dim", "[Result]"));
-        for (const line of wrapTextWithAnsi(truncated.trim(), width)) {
-          lines.push(th.fg("dim", line));
-        }
+        appendPrepared(rawText.trim(), { maxCodePoints: 500, frame: (line) => th.fg("dim", line) });
       } else if ((msg as any).role === "bashExecution") {
         const bash = msg as any;
         if (needsSeparator) lines.push(th.fg("dim", "───"));
-        lines.push(truncateToWidth(th.fg("muted", `  $ ${bash.command}`), width));
-        if (bash.output?.trim()) {
-          const out = bash.output.length > 500
-            ? bash.output.slice(0, 500) + "... (truncated)"
-            : bash.output;
-          for (const line of wrapTextWithAnsi(out.trim(), width)) {
-            lines.push(th.fg("dim", line));
-          }
-        }
+        appendPrepared(String(bash.command), { frame: (line) => th.fg("muted", `  $ ${line}`) });
+        if (bash.output?.trim()) appendPrepared(String(bash.output).trim(), { maxCodePoints: 500, frame: (line) => th.fg("dim", line) });
       } else {
         continue;
       }
@@ -352,9 +375,10 @@ export class ConversationViewer implements Component {
 
     // Streaming indicator for running agents
     if (this.record.status === "running" && this.activity) {
-      const act = describeActivity(this.activity.activeTools, this.activity.responseText);
       lines.push("");
-      lines.push(truncateToWidth(th.fg("accent", "▍ ") + th.fg("dim", act), width));
+      appendPrepared(describeActivity(this.activity.activeTools, this.activity.responseText), {
+        frame: (line) => th.fg("accent", "▍ ") + th.fg("dim", line),
+      });
     }
 
     return lines.map(l => truncateToWidth(l, width));

--- a/src/ui/prepare-conversation-display.ts
+++ b/src/ui/prepare-conversation-display.ts
@@ -1,0 +1,52 @@
+import { isBinary } from "istextorbinary";
+
+const UNSAFE_CODE_POINT = /[\p{Cc}\p{Cf}\p{Cs}\p{Co}\p{Cn}]/u;
+const SHAPING_FORMAT_CONTROLS = new Set([0x200c, 0x200d]);
+
+export interface PreparedConversationDisplay {
+  text: string;
+  lines: string[];
+  warning?: string;
+  binary: boolean;
+}
+
+function escapeUnsafeTerminalText(text: string): string {
+  let escaped = "";
+
+  for (const character of text) {
+    const codePoint = character.codePointAt(0);
+    if (codePoint === undefined) continue;
+
+    if (character === "\n" || character === "\t") {
+      escaped += character;
+    } else if (
+      codePoint === 0xfffd
+      || (codePoint >= 0xfff9 && codePoint <= 0xfffb)
+      || (UNSAFE_CODE_POINT.test(character) && !SHAPING_FORMAT_CONTROLS.has(codePoint))
+    ) {
+      escaped += `\\u{${codePoint.toString(16).toUpperCase()}}`;
+    } else {
+      escaped += character;
+    }
+  }
+
+  return escaped;
+}
+
+export function prepareConversationDisplay(rawText: string, maxCodePoints?: number): PreparedConversationDisplay {
+  const codePoints = Array.from(rawText);
+  const displayText = maxCodePoints !== undefined && codePoints.length > maxCodePoints
+    ? `${codePoints.slice(0, maxCodePoints).join("")}... (truncated)`
+    : rawText;
+  if (isBinary(null, Buffer.from(displayText, "utf8"))) {
+    return { text: "[binary content]", lines: ["[binary content]"], binary: true };
+  }
+
+  const text = escapeUnsafeTerminalText(displayText);
+  return {
+    text,
+    lines: text.split("\n"),
+    warning: text === displayText ? undefined : "[unsafe terminal content escaped]",
+    binary: false,
+  };
+}

--- a/test/agent-widget.test.ts
+++ b/test/agent-widget.test.ts
@@ -1,7 +1,14 @@
 import { describe, expect, it } from "vitest";
-import { renderRunningAgentStatus } from "../src/index.js";
+import { prepareInvocationTagLines, renderRunningAgentStatus } from "../src/index.js";
 import type { WidgetMode } from "../src/types.js";
-import { type AgentActivity, AgentWidget, fgPreservingNestedStyles, formatSessionTokens } from "../src/ui/agent-widget.js";
+import {
+  type AgentActivity,
+  AgentWidget,
+  buildInvocationTags,
+  describeActivity,
+  fgPreservingNestedStyles,
+  formatSessionTokens,
+} from "../src/ui/agent-widget.js";
 
 describe("formatSessionTokens", () => {
   const theme = { fg: (c: string, s: string) => `<${c}>${s}</${c}>`, bold: (s: string) => s };
@@ -39,6 +46,39 @@ describe("formatSessionTokens", () => {
     expect(fgPreservingNestedStyles(ansiTheme, "accent", tokenText)).toBe(
       "\u001b[35m1.2k token (\u001b[33m70%\u001b[39m\u001b[35m)\u001b[39m",
     );
+  });
+});
+
+describe("describeActivity", () => {
+  it("truncates response activity by Unicode code points without splitting an emoji", () => {
+    const activity = describeActivity(new Map(), `${"a".repeat(59)}😀z`);
+
+    expect(activity).toBe(`${"a".repeat(59)}😀…`);
+    expect(activity).not.toContain("[binary content]");
+  });
+});
+
+describe("buildInvocationTags", () => {
+  it("keeps invocation metadata raw until a display boundary", () => {
+    expect(buildInvocationTags({
+      modelName: "Model\u001b[H\nVariant",
+      thinking: "high\u001b[2J\nforged" as any,
+      isolated: true,
+    })).toEqual({
+      modelName: "Model\u001b[H\nVariant",
+      tags: ["thinking: high\u001b[2J\nforged", "isolated"],
+    });
+  });
+});
+
+describe("prepareInvocationTagLines", () => {
+  it("gates raw invocation tags at the custom tool-result display boundary", () => {
+    expect(prepareInvocationTagLines(["thinking: high\u001b[2J\nforged", "isolated"])).toEqual([
+      "[unsafe terminal content escaped]",
+      "thinking: high\\u{1B}[2J",
+      "forged",
+      "isolated",
+    ]);
   });
 });
 

--- a/test/conversation-viewer.test.ts
+++ b/test/conversation-viewer.test.ts
@@ -1,5 +1,7 @@
+import { stripVTControlCharacters } from "node:util";
 import { beforeEach, describe, expect, it, vi } from "vitest";
-import type { AgentRecord } from "../src/types.js";
+import { registerAgents } from "../src/agent-types.js";
+import type { AgentConfig, AgentRecord } from "../src/types.js";
 
 // ── Mock wrapTextWithAnsi ──────────────────────────────────────────────
 // We need to control what wrapTextWithAnsi returns to simulate the
@@ -76,6 +78,307 @@ beforeEach(() => {
 });
 
 describe("ConversationViewer", () => {
+  describe("safe conversation rendering", () => {
+    function renderedText(messages: unknown[], activity?: any, record: Partial<AgentRecord> = {}): string[] {
+      const viewer = new ConversationViewer(
+        mockTui(), mockSession(messages), mockRecord(record), activity, ansiTheme(), vi.fn(),
+      );
+      const lines = viewer.render(80).map((line) => stripVTControlCharacters(line));
+      expect(lines.every((line) => !line.includes("\n"))).toBe(true);
+      expect(lines.every((line) => visibleWidth(line) <= 80)).toBe(true);
+      return lines;
+    }
+
+    function expectWarningBeforeEscape(lines: string[], escaped: string): void {
+      const warningRow = lines.findIndex((line) => line.includes("[unsafe terminal content escaped]"));
+      const escapedRow = lines.findIndex((line) => line.includes(escaped));
+      expect(warningRow).toBeGreaterThanOrEqual(0);
+      expect(escapedRow).toBe(warningRow + 1);
+    }
+
+    it("classifies a sparse replacement character exactly as istextorbinary does", () => {
+      const lines = renderedText([{
+        role: "toolResult",
+        toolCallId: "tool-sparse-replacement",
+        toolName: "read",
+        content: [{ type: "text", text: "safe�after" }],
+        isError: false,
+        timestamp: Date.now(),
+      }]);
+
+      expect(lines.filter((line) => line.includes("[binary content]"))).toHaveLength(1);
+      expect(lines.join("\n")).not.toContain("\\u{FFFD}");
+    });
+
+    it("classifies binary content over the final limited display text", () => {
+      const payload = `\u009D${"�".repeat(60)}${"a".repeat(439)}${"b".repeat(5_000)}`;
+      const lines = renderedText([{
+        role: "toolResult",
+        toolCallId: "tool-limited-binary",
+        toolName: "read",
+        content: [{ type: "text", text: payload }],
+        isError: false,
+        timestamp: Date.now(),
+      }]);
+
+      expect(lines.filter((line) => line.includes("[binary content]"))).toHaveLength(1);
+      expect(lines.join("\n")).not.toContain("\\u{FFFD}");
+    });
+
+    it("replaces recording-like dense replacement text without exposing its contents", () => {
+      const payload = "RIFF�\u{9D}�\u{81}随机�\u{A4}�audio�\u{90}�tail";
+      const lines = renderedText([{
+        role: "toolResult",
+        toolCallId: "tool-1",
+        toolName: "read",
+        content: [{ type: "text", text: payload }],
+        isError: false,
+        timestamp: Date.now(),
+      }]);
+      const contentRows = lines.filter((line) => line.includes("binary content") || line.includes("RIFF") || line.includes("audio"));
+
+      expect(contentRows).toHaveLength(1);
+      expect(contentRows[0]?.replace(/^│\s*|\s*│$/g, "").trim()).toBe("[binary content]");
+      expect(lines.join("\n")).not.toContain("RIFF");
+      expect(lines.join("\n")).not.toContain("audio");
+    });
+
+    it("keeps NUL-bearing content classified as binary", () => {
+      const lines = renderedText([{
+        role: "toolResult",
+        toolCallId: "tool-nul",
+        toolName: "read",
+        content: [{ type: "text", text: "safe\u0000after" }],
+        isError: false,
+        timestamp: Date.now(),
+      }]);
+
+      expect(lines.filter((line) => line.includes("[binary content]"))).toHaveLength(1);
+      expect(lines.join("\n")).not.toContain("safe");
+    });
+
+    it.each([
+      ["ESC", "safe\u001b[2Jafter", "safe\\u{1B}[2Jafter"],
+      ["C1", "safe\u0085after", "safe\\u{85}after"],
+      ["bidi", "safe\u202Eafter", "safe\\u{202E}after"],
+      ["private use", "safe\uE000after", "safe\\u{E000}after"],
+    ])("secondarily escapes %s text that istextorbinary classifies as text", (_kind, raw, escaped) => {
+      const lines = renderedText([{
+        role: "toolResult",
+        toolCallId: "tool-unsafe",
+        toolName: "read",
+        content: [{ type: "text", text: raw }],
+        isError: false,
+        timestamp: Date.now(),
+      }]);
+
+      expectWarningBeforeEscape(lines, escaped);
+      expect(lines.join("\n")).not.toContain(raw);
+      expect(lines.join("\n")).not.toContain("[binary content]");
+    });
+
+    it("passes ordinary text including tabs through without a warning", () => {
+      const wrappedTexts: string[] = [];
+      wrapOverride = (text) => {
+        wrappedTexts.push(text);
+        return [text];
+      };
+      const lines = renderedText([
+        { role: "user", content: "Hello,\t世界 👩‍💻" },
+        { role: "assistant", content: [{ type: "text", text: "Ordinary response" }] },
+      ]);
+
+      expect(wrappedTexts).toContain("Hello,\t世界 👩‍💻");
+      expect(wrappedTexts).toContain("Ordinary response");
+      expect(lines.join("\n")).not.toContain("[unsafe terminal content escaped]");
+    });
+
+    it("renders safe multiline tool names, bash commands, and activity as separate rows without warnings", () => {
+      const messageLines = renderedText([
+        { role: "assistant", content: [{ type: "toolCall", name: "tool\nname" }] },
+        { role: "bashExecution", command: "printf first\nprintf second", output: "" },
+      ]);
+      expect(messageLines.join("\n")).not.toContain("[unsafe terminal content escaped]");
+      expect(messageLines.some((line) => line.includes("[Tool: tool]"))).toBe(true);
+      expect(messageLines.some((line) => line.includes("[Tool: name]"))).toBe(true);
+      expect(messageLines.some((line) => line.includes("$ printf first"))).toBe(true);
+      expect(messageLines.some((line) => line.includes("$ printf second"))).toBe(true);
+
+      const activityLines = renderedText([{ role: "user", content: "prompt" }], {
+        activeTools: new Map([["call-1", "custom first\ncustom second"]]), toolUses: 1, responseText: "", turnCount: 0,
+        lifetimeUsage: {},
+      });
+      expect(activityLines.join("\n")).not.toContain("[unsafe terminal content escaped]");
+      expect(activityLines.some((line) => line.includes("custom first"))).toBe(true);
+      expect(activityLines.some((line) => line.includes("custom second"))).toBe(true);
+    });
+
+    it("warns before unsafe multiline tool names, bash commands, and activity and renders safe rows", () => {
+      const messageLines = renderedText([
+        { role: "assistant", content: [{ type: "toolCall", name: "tool\u001b[2J\nname" }] },
+        { role: "bashExecution", command: "printf '\u001b[2J'\nprintf safe", output: "" },
+      ]);
+      expectWarningBeforeEscape(messageLines, "[Tool: tool\\u{1B}[2J]");
+      expect(messageLines.some((line) => line.includes("[Tool: name]"))).toBe(true);
+      const warningRows = messageLines
+        .map((line, index) => line.includes("[unsafe terminal content escaped]") ? index : -1)
+        .filter((index) => index >= 0);
+      expect(warningRows).toHaveLength(2);
+      expect(messageLines[warningRows[1] + 1]).toContain("$ printf '\\u{1B}[2J'");
+      expect(messageLines.some((line) => line.includes("$ printf safe"))).toBe(true);
+
+      const activityLines = renderedText([{ role: "user", content: "prompt" }], {
+        activeTools: new Map(), toolUses: 0, responseText: "stream\u001b[2J\nsafe", turnCount: 0,
+        lifetimeUsage: {},
+      });
+      expectWarningBeforeEscape(activityLines, "stream\\u{1B}[2J");
+      expect(activityLines.some((line) => line.includes("safe"))).toBe(true);
+
+      expect(messageLines.join("\n") + activityLines.join("\n")).not.toMatch(/[\u001b\u0007]/);
+    });
+
+    it("renders unsafe multiline invocation tags as structural warning and escaped rows", () => {
+      const lines = renderedText([], undefined, {
+        invocation: {
+          thinking: "high\u001b[2J\nforged" as NonNullable<AgentRecord["invocation"]>["thinking"],
+        },
+      });
+      const warningRow = lines.findIndex((line) => line.includes("[unsafe terminal content escaped]"));
+
+      expect(warningRow).toBeGreaterThanOrEqual(0);
+      expect(lines[warningRow + 1]).toContain("thinking: high\\u{1B}[2J");
+      expect(lines[warningRow + 2]).toContain("forged");
+      expect(lines.join("\n")).not.toContain("\u001b[2J");
+      expect(lines.every((line) => !line.includes("\n"))).toBe(true);
+    });
+
+    it("gates external display name, description, and invocation model in header-adjacent rows", () => {
+      const config: AgentConfig = {
+        name: "unsafe-header",
+        displayName: "Display\u001b[2J\nName",
+        description: "Description\u001b[31m\nDetail",
+        extensions: false,
+        skills: false,
+        systemPrompt: "",
+        promptMode: "replace",
+      };
+      registerAgents(new Map([[config.name, config]]));
+      const lines = renderedText([], undefined, {
+        type: config.name,
+        description: config.description,
+        invocation: { modelName: "Model\u001b[H\nVariant" },
+      });
+      const rendered = lines.join("\n");
+
+      expect(lines.filter((line) => line.includes("[unsafe terminal content escaped]"))).toHaveLength(3);
+      expect(rendered).toContain("Display\\u{1B}[2J");
+      expect(rendered).toContain("Description\\u{1B}[31m");
+      expect(rendered).toContain("Model\\u{1B}[H");
+      expect(rendered).not.toContain("\u001b[2J");
+      expect(rendered).not.toContain("\u001b[31m");
+      expect(rendered).not.toContain("\u001b[H");
+    });
+
+    it.each([40, 12])("bounds multiline header chrome to the 70%% overlay height at %i rows", (rows) => {
+      const config: AgentConfig = {
+        name: `overflow-header-${rows}`,
+        displayName: ["Primary display", ...Array.from({ length: 12 }, (_, i) => `Name ${i}\u001b[2J`)].join("\n"),
+        description: Array.from({ length: 12 }, (_, i) => `Description ${i}\u001b[31m`).join("\n"),
+        extensions: false,
+        skills: false,
+        systemPrompt: "",
+        promptMode: "replace",
+      };
+      registerAgents(new Map([[config.name, config]]));
+      const tui = mockTui(rows, 80);
+      const viewer = new ConversationViewer(
+        tui,
+        mockSession([{ role: "user", content: "meaningful content" }]),
+        mockRecord({
+          type: config.name,
+          description: config.description,
+          invocation: {
+            modelName: Array.from({ length: 12 }, (_, i) => `Model ${i}\u001b[H`).join("\n"),
+          },
+        }),
+        undefined,
+        ansiTheme(),
+        vi.fn(),
+      );
+
+      const rendered = viewer.render(80);
+      const plain = rendered.map((line) => stripVTControlCharacters(line));
+      expect(rendered.length).toBeLessThanOrEqual(Math.floor((rows * 70) / 100));
+      expect(plain[0]).toContain("╭");
+      expect(plain.at(-1)).toContain("╰");
+      expect(plain.at(-2)).toContain("Esc close");
+      expect(plain.join("\n")).toContain("Primary display");
+      expect(plain.join("\n")).toContain("meaningful content");
+      expect(plain.join("\n")).toContain("…");
+      expect(plain.every((line) => !line.includes("\n"))).toBe(true);
+      assertAllLinesFit(rendered, 80);
+    });
+
+    it("escapes unsafe active tool names before they reach the terminal", () => {
+      const lines = renderedText([{ role: "user", content: "prompt" }], {
+        activeTools: new Map([["call-1", "tool\u001b[2Jname"]]),
+        toolUses: 1, responseText: "", turnCount: 0, lifetimeUsage: {},
+      });
+
+      expectWarningBeforeEscape(lines, "tool\\u{1B}[2Jname…");
+      expect(lines.join("\n")).not.toContain("\u001b[2J");
+    });
+
+    it("applies the 500-code-point limit before the terminal safety gate", () => {
+      const preparedTexts: string[] = [];
+      wrapOverride = (text) => {
+        preparedTexts.push(text);
+        return [text];
+      };
+      const lines = renderedText([
+        { role: "toolResult", content: [{ type: "text", text: `${"a".repeat(500)}\0hidden` }] },
+        { role: "toolResult", content: [{ type: "text", text: `${"b".repeat(499)}\u001b[2J` }] },
+      ]);
+
+      expect(preparedTexts[0]).toBe(`${"a".repeat(500)}... (truncated)`);
+      expect(preparedTexts[0]).not.toContain("[binary content]");
+      expect(preparedTexts[0]).not.toContain("[unsafe terminal content escaped]");
+      expect(preparedTexts.some((text) => text.includes("\\u{1B}... (truncated)"))).toBe(true);
+      expect(lines.some((line) => line.includes("[unsafe terminal content escaped]"))).toBe(true);
+    });
+
+    it("truncates raw tool output by code point before escaping", () => {
+      const preparedTexts: string[] = [];
+      wrapOverride = (text) => {
+        preparedTexts.push(text);
+        return [text];
+      };
+      const astralAtBoundary = `${"a".repeat(499)}👩\u001b[2J`;
+      const unsafeAtBoundary = `${"b".repeat(499)}\u001b[2J`;
+      renderedText([
+        { role: "toolResult", content: [{ type: "text", text: astralAtBoundary }] },
+        { role: "toolResult", content: [{ type: "text", text: unsafeAtBoundary }] },
+      ]);
+      const prepared = preparedTexts.join("\n");
+
+      expect(prepared).toContain(`👩... (truncated)`);
+      expect(prepared).not.toContain("�");
+      expect(prepared).toContain("\\u{1B}... (truncated)");
+      expect(prepared).not.toMatch(/\\u\{1B(?:$|\.\.\.)/m);
+    });
+
+    it("escapes unsafe user and assistant text without exposing raw controls", () => {
+      const userRendered = renderedText([{ role: "user", content: "user\u001b[2J" }]).join("\n");
+      const assistantRendered = renderedText([{
+        role: "assistant", content: [{ type: "text", text: "assistant\u001b[2J" }],
+      }]).join("\n");
+
+      expect(userRendered).toContain("user\\u{1B}[2J");
+      expect(assistantRendered).toContain("assistant\\u{1B}[2J");
+      expect(userRendered + assistantRendered).not.toContain("\u001b[2J");
+    });
+  });
+
   describe("render width safety", () => {
     const widths = [40, 80, 120, 216];
 
@@ -476,6 +779,24 @@ describe("ConversationViewer", () => {
       );
       expect(viewer.render(W).join("\n")).not.toContain("Enter steer");
       expect(() => viewer.handleInput("\r")).not.toThrow();
+    });
+
+    it("keeps composer chrome within the small-terminal height cap", () => {
+      const rows = 10;
+      const cap = Math.floor(rows * 0.7);
+      const tui = mockTui(rows, W);
+      const viewer = new ConversationViewer(
+        tui, mockSession(), mockRecord({ status: "running" }),
+        undefined, ansiTheme(), vi.fn(), undefined, undefined, vi.fn(),
+      );
+      viewer.handleInput("\r");
+
+      const rendered = viewer.render(W).map((line) => stripVTControlCharacters(line));
+      expect(rendered.length).toBeLessThanOrEqual(cap);
+      if (rendered.length > 0) {
+        expect(rendered.some((line) => line.includes("Enter send · Esc cancel"))).toBe(true);
+        expect(rendered[rendered.length - 1]).toMatch(/^╰─+╯$/);
+      }
     });
 
     it("composer rows never exceed width", () => {


### PR DESCRIPTION
## Summary

- add a late, display-only safety gate for externally derived `ConversationViewer` text
- replace binary-like display bodies with `[binary content]` and visibly escape terminal-unsafe code points without mutating session messages
- route message bodies, tool data, streaming activity, header metadata, model names, and invocation tags through the same gate
- preserve exact-width rows while bounding multiline header/composer rendering to the overlay height
- apply display limits by Unicode code point before classification and escaping

## Scope

This is intentionally a separate follow-up to #153 rather than an amendment to that PR. It builds on the exact-width rendering fix already merged there, but the display-safety changes span the viewer, activity and invocation-tag rendering, dependency metadata, and regression coverage.

No agent behavior, `AgentSession.messages`, model context, persistence, resume/fork behavior, or `get_subagent_result` output is changed.

## Verification

- `npm run lint`
- `npm run typecheck`
- `npm run test` — 40 passed, 1 skipped; 754 tests passed, 5 skipped
- `npm run build`
- `git diff --check upstream/master...HEAD`
