### PR TITLE
fix(ui): unify FleetView selection markers with codebase ●/○ language

### DIFF
--- a/src/ui/fleet-list.ts
+++ b/src/ui/fleet-list.ts
@@ -2,7 +2,7 @@
  * fleet-list.ts — Claude Code-style "FleetView" list rendered below the editor.
  *
  * Shows `main` + each running/queued subagent as a navigable list. Pressing ↓ (or
- * ←) at an empty prompt activates the list; ↑/↓ move the selection (filled ⏺ marker),
+ * ←) at an empty prompt activates the list; ↑/↓ move the selection (filled ● marker),
  * Enter opens the selected agent's live conversation overlay, Esc returns to the prompt.
  * A viewer stays open when its agent finishes; finished agents linger briefly in the list.
  *
@@ -367,7 +367,7 @@ export class FleetList {
   }
 
   private bullet(rosterIndex: number, sel: number, theme: Theme): string {
-    return rosterIndex === sel ? theme.fg("accent", "⏺") : theme.fg("dim", "◯");
+    return rosterIndex === sel ? theme.fg("accent", "●") : theme.fg("dim", "○");
   }
 
   private renderAgentRow(rosterIndex: number, sel: number, record: AgentRecord, width: number, theme: Theme): string {

--- a/test/fleet-list.test.ts
+++ b/test/fleet-list.test.ts
@@ -164,11 +164,11 @@ describe("FleetList navigation", () => {
     ]);
     h.press(DOWN);          // activate → selection on main (idx 0)
     h.press(DOWN_RELEASE);  // release half of the SAME tap — must be a no-op
-    expect(h.render().find(l => l.includes("main"))).toContain("⏺");
+    expect(h.render().find(l => l.includes("main"))).toContain("●");
     h.press(DOWN);          // a real second tap → first agent
     h.press(DOWN_RELEASE);
-    expect(h.render().find(l => l.includes("one"))).toContain("⏺");
-    expect(h.render().find(l => l.includes("two"))).toContain("◯");
+    expect(h.render().find(l => l.includes("one"))).toContain("●");
+    expect(h.render().find(l => l.includes("two"))).toContain("○");
   });
 
   it("moves selection down/up and clamps at the ends", () => {
@@ -179,11 +179,11 @@ describe("FleetList navigation", () => {
     const h = harness(agents);
     h.press(DOWN); // activate → index 0 (main)
     h.press(DOWN); // → 1 (a1)
-    expect(h.render().find(l => l.includes("one"))).toContain("⏺");
+    expect(h.render().find(l => l.includes("one"))).toContain("●");
     h.press(DOWN); // → 2 (a2)
     h.press(DOWN); // clamp at 2
-    expect(h.render().find(l => l.includes("two"))).toContain("⏺");
-    expect(h.render().find(l => l.includes("one"))).toContain("◯");
+    expect(h.render().find(l => l.includes("two"))).toContain("●");
+    expect(h.render().find(l => l.includes("one"))).toContain("○");
   });
 
   it("↑ above 'main' deactivates (returns to the prompt)", () => {
@@ -297,9 +297,9 @@ describe("FleetList rendering", () => {
     const lines = h.render(120);
     // hint + blank + main + one agent
     expect(lines[0]).toContain("← for agents");
-    expect(lines.find(l => l.includes("main"))).toContain("⏺"); // main selected by default
+    expect(lines.find(l => l.includes("main"))).toContain("●"); // main selected by default
     const agentLine = lines.find(l => l.includes("Sleep then report 1"))!;
-    expect(agentLine).toContain("◯");
+    expect(agentLine).toContain("○");
     expect(agentLine).toContain(getDisplayName("general-purpose"));
     expect(agentLine).toContain("↓ 13.1k tokens");
     expect(agentLine).toMatch(/\d+s · ↓/); // "<seconds>s · ↓ ..." (timing-agnostic)
@@ -355,7 +355,7 @@ describe("FleetList rendering", () => {
     // step down to the last agent (8 agents → roster index 8)
     for (let i = 0; i < 8; i++) h.press(DOWN);
     const lines = h.render(120);
-    expect(lines.find(l => l.includes("report 7"))).toContain("⏺");
+    expect(lines.find(l => l.includes("report 7"))).toContain("●");
     expect(lines.some(l => l.includes("↑"))).toBe(true); // hidden-above indicator
   });
 });
@@ -385,8 +385,8 @@ describe("FleetList overlay lifecycle", () => {
     agents.splice(0, 1);
     await h.closeOverlay();
     // Selection follows a2 ("two") to its new position, not whatever is at idx 2 now.
-    expect(h.render().find(l => l.includes("two"))).toContain("⏺");
-    expect(h.render().find(l => l.includes("three"))).toContain("◯");
+    expect(h.render().find(l => l.includes("two"))).toContain("●");
+    expect(h.render().find(l => l.includes("three"))).toContain("○");
   });
 
   it("wires the viewer's steer composer to manager.steer with the agent id", () => {


### PR DESCRIPTION
Closes: #122

## Summary

FleetView's selection markers are outliers in the extension's own visual language. Everywhere else, state is shown with a plain filled/hollow circle pair; only FleetView reaches for exotic glyphs:

| Location | filled | hollow |
|----------|--------|--------|
| `conversation-viewer.ts` | `●` running | `○` idle |
| `agent-widget.ts` | `●` active | `○` inactive |
| `index.ts` agent list | `•` project | `◦` global |
| **`fleet-list.ts` (this)** | `⏺` (U+23FA) | `◯` (U+25EF) |

`⏺` (BLACK CIRCLE FOR RECORD) and `◯` (LARGE CIRCLE) are niche, render inconsistently across terminal fonts, and `◯` is visibly oversized next to text. This PR aligns FleetView with the rest of the codebase: `●` selected (accent) / `○` unselected (dim).

These are base geometric shapes (U+25CF/U+25CB) with the broadest terminal-font coverage. Selection is already carried by the accent-vs-dim color, so a compound glyph like `◉` (U+25C9 FISHEYE — outer ring + inner dot that muddies at small terminal sizes) adds noise over plain `●`.

**The change is one line** (plus a doc comment and test expectations):

```diff
- return rosterIndex === sel ? theme.fg("accent", "⏺") : theme.fg("dim", "◯");
+ return rosterIndex === sel ? theme.fg("accent", "●") : theme.fg("dim", "○");
```

## Relationship to #122

#122 identified the same glyph problem but proposed `◉`/`○` — introducing a *third* circle set instead of converging on the existing one — and bundled ~300 lines beyond the fix: a 220-line companion extension with its own `/subagents-ui` command and a 79-line shell script that `sed -i`s the installed package under `node_modules` (breaks on every update, and its spinner patterns don't match the current source). The companion machinery is personal customization that belongs in user dotfiles, not the extension. This PR keeps only the core idea and points it at the codebase's established glyph pair.

## Testing

`npm run lint`, `npm run typecheck`, `npm run test` all pass (731 tests).

## Checklist

- [x] `npm run lint` / `typecheck` / `test` pass
- [x] Single-line behavioral change; no API changes
- [x] No breaking changes
