### PR TITLE
fix: make result waits abortable

### DIFF
--- a/README.md
+++ b/README.md
@@ -298,6 +298,8 @@ Check status and retrieve results from a background agent.
 | `wait` | boolean | no | Wait for completion |
 | `verbose` | boolean | no | Include full conversation log |
 
+Cancelling a `wait: true` call (for example, with `Esc`) stops only the wait. The background agent keeps running, and its completion notification still arrives normally.
+
 ### `steer_subagent`
 
 Send a steering message to a running agent. The message interrupts after the current tool execution.

--- a/src/index.ts
+++ b/src/index.ts
@@ -58,6 +58,39 @@ function textResult(msg: string, details?: AgentDetails) {
   return { content: [{ type: "text" as const, text: msg }], details: details as any };
 }
 
+/** Await a promise until it settles or the caller cancels, without aborting the underlying work. */
+function abortable<T>(promise: Promise<T>, signal?: AbortSignal): Promise<T> {
+  if (!signal) return promise;
+  if (signal.aborted) return Promise.reject(signal.reason);
+
+  return new Promise<T>((resolve, reject) => {
+    let settled = false;
+    const cleanup = () => signal.removeEventListener("abort", onAbort);
+    const onAbort = () => {
+      if (settled) return;
+      settled = true;
+      cleanup();
+      reject(signal.reason);
+    };
+
+    signal.addEventListener("abort", onAbort, { once: true });
+    promise.then(
+      (value) => {
+        if (settled) return;
+        settled = true;
+        cleanup();
+        resolve(value);
+      },
+      (error: unknown) => {
+        if (settled) return;
+        settled = true;
+        cleanup();
+        reject(error);
+      },
+    );
+  });
+}
+
 export function renderRunningAgentStatus(
   frame: string,
   statsText: string,
@@ -297,6 +330,9 @@ export default function (pi: ExtensionAPI) {
   // before they reach pi.sendMessage (fire-and-forget).
   const pendingNudges = new Map<string, ReturnType<typeof setTimeout>>();
   const NUDGE_HOLD_MS = 200;
+  // A queued result wait must observe completion before its held notification
+  // can fire, so successful waits can still suppress that redundant nudge.
+  const QUEUE_WAIT_POLL_MS = Math.floor(NUDGE_HOLD_MS / 4);
 
   function scheduleNudge(key: string, send: () => void, delay = NUDGE_HOLD_MS) {
     cancelNudge(key);
@@ -1423,25 +1459,25 @@ Terse command-style prompts produce shallow, generic work.
         }),
       ),
     }),
-    execute: async (_toolCallId, params, _signal, _onUpdate, _ctx) => {
+    execute: async (_toolCallId, params, signal, _onUpdate, _ctx) => {
       const record = manager.getRecord(params.agent_id);
       if (!record) {
         return textResult(`Agent not found: "${params.agent_id}". It may have been cleaned up.`);
       }
 
-      // Wait for completion if requested.
-      // Pre-mark resultConsumed BEFORE awaiting: onComplete fires inside .then()
-      // (attached earlier at spawn time) and always runs before this await resumes.
-      // Setting the flag here prevents a redundant follow-up notification.
+      // Wait for completion if requested. Cancellation stops only this tool
+      // call; the background agent keeps running and remains unconsumed so its
+      // completion notification can still be delivered.
       // Queued agents have no promise yet (it's created when the queue starts
       // them), so poll until they leave the queue, then await like a running one.
       if (params.wait && (record.status === "running" || record.status === "queued")) {
-        record.resultConsumed = true;
-        cancelNudge(params.agent_id);
         while (record.status === "queued") {
-          await new Promise((r) => setTimeout(r, 250));
+          await abortable(
+            new Promise<void>((resolve) => setTimeout(resolve, QUEUE_WAIT_POLL_MS)),
+            signal,
+          );
         }
-        if (record.promise) await record.promise;
+        if (record.promise) await abortable(record.promise, signal);
       }
 
       const displayName = getDisplayName(record.type);

--- a/test/wait-queued.test.ts
+++ b/test/wait-queued.test.ts
@@ -1,5 +1,5 @@
 /**
- * wait-queued.test.ts — get_subagent_result(wait: true) on a QUEUED agent.
+ * wait-queued.test.ts — get_subagent_result(wait: true) lifecycle behavior.
  *
  * Queued records have no promise yet (it's created when the queue starts
  * them), so the old `status === "running" && record.promise` condition
@@ -120,6 +120,109 @@ describe("get_subagent_result wait:true on a queued agent", () => {
     expect(textOf(result)).toContain("THE-RESULT-PAYLOAD");
     expect(textOf(result)).not.toContain("still running");
 
+    await new Promise((r) => setTimeout(r, 350));
+    expect(JSON.stringify(pi.sendMessage.mock.calls)).not.toContain(queuedId);
+
     await lifecycle.get("session_shutdown")?.();
   }, 20_000);
+
+  it("aborts a running result wait without aborting or consuming the child", async () => {
+    const { pi, tools, lifecycle } = makePi();
+    subagentsExtension(pi);
+
+    let resolveRun: (() => void) | undefined;
+    let childSignal: AbortSignal | undefined;
+    vi.mocked(runAgent).mockImplementation(
+      (_ctx, _type, _prompt, options) =>
+        new Promise((resolve) => {
+          childSignal = options.signal;
+          resolveRun = () => resolve({
+            responseText: "THE-RESULT-PAYLOAD",
+            session: { dispose: vi.fn() } as any,
+            aborted: false,
+            steered: false,
+          });
+        }),
+    );
+
+    const { id } = await spawnBackground(tools);
+    const controller = new AbortController();
+    const removeListener = vi.spyOn(controller.signal, "removeEventListener");
+    const waitOutcome = tools
+      .get("get_subagent_result")
+      .execute("tc-wait-abort", { agent_id: id, wait: true }, controller.signal, undefined, ctx())
+      .then(
+        () => "resolved",
+        (error: unknown) => error instanceof Error ? error.name : String(error),
+      );
+
+    controller.abort();
+    const outcome = await Promise.race([
+      waitOutcome,
+      new Promise<string>((resolve) => setTimeout(() => resolve("timed-out"), 100)),
+    ]);
+    const childWasAborted = childSignal?.aborted;
+
+    resolveRun?.();
+    await flush();
+    await waitOutcome;
+    await new Promise((r) => setTimeout(r, 350));
+
+    const completedResult = await tools
+      .get("get_subagent_result")
+      .execute("tc-result", { agent_id: id }, undefined, undefined, ctx());
+
+    await lifecycle.get("session_shutdown")?.();
+
+    expect(outcome).toBe("AbortError");
+    expect(childWasAborted).toBe(false);
+    expect(removeListener).toHaveBeenCalledTimes(1);
+    expect(pi.sendMessage).toHaveBeenCalledTimes(1);
+    expect(textOf(completedResult)).toContain("THE-RESULT-PAYLOAD");
+  });
+
+  it("aborts a queued result wait before the agent starts", async () => {
+    const { pi, tools, lifecycle } = makePi();
+    subagentsExtension(pi);
+
+    const resolvers = deferredRuns();
+    let queuedId: string | undefined;
+    for (let i = 0; i < 10 && !queuedId; i++) {
+      const { id, queued } = await spawnBackground(tools);
+      if (queued) queuedId = id;
+    }
+    expect(queuedId, "expected to hit the concurrency limit within 10 spawns").toBeDefined();
+
+    const controller = new AbortController();
+    const waitOutcome = tools
+      .get("get_subagent_result")
+      .execute("tc-queued-abort", { agent_id: queuedId, wait: true }, controller.signal, undefined, ctx())
+      .then(
+        () => "resolved",
+        (error: unknown) => error instanceof Error ? error.name : String(error),
+      );
+
+    controller.abort();
+    const outcome = await Promise.race([
+      waitOutcome,
+      new Promise<string>((resolve) => setTimeout(() => resolve("timed-out"), 100)),
+    ]);
+
+    let completedResult: any;
+    for (let i = 0; i < 40 && !completedResult; i++) {
+      while (resolvers.length > 0) resolvers.shift()!();
+      await flush();
+      const result = await tools
+        .get("get_subagent_result")
+        .execute("tc-queued-result", { agent_id: queuedId }, undefined, undefined, ctx());
+      if (textOf(result).includes("THE-RESULT-PAYLOAD")) completedResult = result;
+      await new Promise((r) => setTimeout(r, 25));
+    }
+
+    await waitOutcome;
+    await lifecycle.get("session_shutdown")?.();
+
+    expect(outcome).toBe("AbortError");
+    expect(textOf(completedResult)).toContain("THE-RESULT-PAYLOAD");
+  });
 });


### PR DESCRIPTION
Closes #158.

## Summary

- race `get_subagent_result(wait: true)` against the tool-call `AbortSignal` without forwarding cancellation to the background child
- leave an aborted wait unconsumed so the child can finish and deliver its normal completion notification
- make queued waits abortable while preserving successful-wait notification deduplication
- document the `Esc` behavior and cover running, queued, notification, child-survival, and listener-cleanup behavior through the registered tool

## Verification

- `npm run lint`
- `npm run typecheck`
- `npm run build`
- `npm run test` (733 passed, 5 skipped)
- `git diff --check`