### PR TITLE
feat: add pi-goal agent mode

### DIFF
--- a/README.md
+++ b/README.md
@@ -21,6 +21,7 @@ https://github.com/user-attachments/assets/8685261b-9338-4fea-8dfe-1c590d5df543
 - **Graceful turn limits** — agents get a "wrap up" warning before hard abort, producing clean partial results instead of cut-off output
 - **Case-insensitive agent types** — `"explore"`, `"Explore"`, `"EXPLORE"` all work. Unknown types fall back to general-purpose with a note
 - **Fuzzy model selection** — specify models by name (`"haiku"`, `"sonnet"`) instead of full IDs, with automatic filtering to only available/configured models
+- **Goal mode** — opt into `@narumitw/pi-goal` so a child keeps working until it completes, blocks, pauses, or hits a limit
 - **Context inheritance** — optionally fork the parent conversation into a sub-agent so it knows what's been discussed
 - **Persistent agent memory** — three scopes (project, local, user) with automatic read-only fallback for agents without write tools
 - **Git worktree isolation** — run agents in isolated repo copies; changes auto-committed to branches on completion
@@ -58,6 +59,21 @@ Agent({
 ```
 
 Foreground agents block until complete and return results inline. Background agents return an ID immediately and notify you on completion.
+
+### Goal mode
+
+Set `goal: true` to run the child through an installed `@narumitw/pi-goal` extension instead of stopping after its first response:
+
+```
+Agent({
+  subagent_type: "general-purpose",
+  prompt: "Implement the change and verify it",
+  description: "Implement verified change",
+  goal: true,
+})
+```
+
+The call waits for a terminal Goal state (`complete`, `blocked`, `paused`, `usage_limited`, or `budget_limited`) before returning and before cleaning up a worktree. Only `complete` is reported as success; other terminal states retain their Goal result and use the normal failed/stopped agent lifecycle. Goal mode fails fast when `pi-goal` is missing or excluded, and cannot be combined with `isolated: true`, `resume`, or `schedule`. `isolation: "worktree"` remains supported.
 
 ### Scheduling
 
@@ -283,6 +299,7 @@ Launch a sub-agent.
 | `thinking` | string | no | Thinking level: off, minimal, low, medium, high, xhigh, max (availability depends on pi version and model) |
 | `max_turns` | number | no | Max agentic turns. Omit for unlimited (default) |
 | `run_in_background` | boolean | no | Run without blocking |
+| `goal` | boolean | no | Run through `pi-goal` until it reaches a terminal state |
 | `resume` | string | no | Agent ID to resume a previous session |
 | `isolated` | boolean | no | No extension/MCP tools |
 | `isolation` | `"worktree"` | no | Run in an isolated git worktree |

--- a/examples/agent-tool-description.md
+++ b/examples/agent-tool-description.md
@@ -26,6 +26,7 @@ If the target is already known, use a direct tool — `read` for a known path, `
 - Use model to specify a different model (as "provider/modelId", or fuzzy e.g. "haiku", "sonnet").
 - Use thinking to control extended thinking level.
 - Use inherit_context if the agent needs the parent conversation history.
+- Use goal: true to run the child through pi-goal until it completes or reaches another terminal state. Goal mode requires pi-goal and cannot be combined with isolated, resume, or schedule.
 - Use isolation: "worktree" to run the agent in an isolated git worktree (safe parallel file modifications). The worktree is automatically cleaned up if the agent makes no changes; otherwise the path and branch are returned in the result.{{scheduleGuideline}}
 
 ## Writing the prompt

--- a/src/agent-manager.ts
+++ b/src/agent-manager.ts
@@ -59,6 +59,7 @@ interface SpawnOptions {
   model?: Model<any>;
   maxTurns?: number;
   isolated?: boolean;
+  goal?: boolean;
   inheritContext?: boolean;
   thinkingLevel?: ThinkingLevel;
   isBackground?: boolean;
@@ -154,6 +155,9 @@ export class AgentManager {
     // call, not minutes later at drain. Throw (not warn): programmatic callers
     // can fix and retry; the RPC layer converts throws into error envelopes.
     assertValidSpawnCwd(options.cwd);
+    if (options.goal && options.isolated) {
+      throw new Error("Cannot combine goal mode with isolated: true because pi-goal is an extension");
+    }
 
     const id = randomUUID().slice(0, 17);
     const abortController = new AbortController();
@@ -173,6 +177,7 @@ export class AgentManager {
       // only filter excludes only explicit `false`, so undefined agents — which
       // have no inline surface — stay visible instead of vanishing.
       isBackground: options.isBackground,
+      goal: options.goal,
       invocation: options.invocation,
     };
     this.agents.set(id, record);
@@ -250,6 +255,7 @@ export class AgentManager {
       model: options.model,
       maxTurns: options.maxTurns,
       isolated: options.isolated,
+      goal: options.goal,
       inheritContext: options.inheritContext,
       thinkingLevel: options.thinkingLevel,
       // Worktree wins for the working dir (the agent must run in the copy —
@@ -448,7 +454,7 @@ export class AgentManager {
     signal?: AbortSignal,
   ): Promise<AgentRecord | undefined> {
     const record = this.agents.get(id);
-    if (!record?.session) return undefined;
+    if (!record?.session || record.goal) return undefined;
 
     record.status = "running";
     record.startedAt = Date.now();

--- a/src/agent-runner.ts
+++ b/src/agent-runner.ts
@@ -2,6 +2,7 @@
  * agent-runner.ts — Core execution engine: creates sessions, runs agents, collects results.
  */
 
+import { randomUUID } from "node:crypto";
 import { readFileSync } from "node:fs";
 import { homedir } from "node:os";
 import { basename, dirname, isAbsolute, join, resolve } from "node:path";
@@ -11,7 +12,9 @@ import {
   type AgentSession,
   type AgentSessionEvent,
   createAgentSession,
+  createEventBus,
   DefaultResourceLoader,
+  type EventBus,
   type ExtensionAPI,
   getAgentDir,
   SessionManager,
@@ -40,6 +43,21 @@ export const SUBAGENT_TOOL_NAMES = {
 
 /** Names of tools registered by this extension that subagents must NOT inherit. */
 const EXCLUDED_TOOL_NAMES: string[] = Object.values(SUBAGENT_TOOL_NAMES);
+const GOAL_TOOL_NAMES = ["goal_complete", "goal_blocked"] as const;
+const GOAL_TERMINAL_STATUSES = new Set([
+  "complete",
+  "blocked",
+  "paused",
+  "usage_limited",
+  "budget_limited",
+]);
+
+type GoalState = {
+  goalId: string;
+  status: string;
+  summary?: string;
+  reason?: string;
+};
 
 /**
  * Canonical name of an extension for `extensions: [...]` allowlist matching.
@@ -265,6 +283,8 @@ export interface RunOptions {
   maxTurns?: number;
   signal?: AbortSignal;
   isolated?: boolean;
+  /** Run the child through @narumitw/pi-goal until it reaches a terminal state. */
+  goal?: boolean;
   inheritContext?: boolean;
   thinkingLevel?: ThinkingLevel;
   /** Override working directory (e.g. for worktree isolation). */
@@ -406,6 +426,112 @@ function resolveConfiguredSessionDir(sessionDir: string | undefined, cwd: string
   return resolve(cwd, sessionDir);
 }
 
+function isGoalExtension(path: string, tools: Map<string, unknown>): boolean {
+  const names = extensionCanonicalNames(path);
+  return names.includes("pi-goal") || (
+    names.includes("goal") && GOAL_TOOL_NAMES.every((name) => tools.has(name))
+  );
+}
+
+function isGoalState(value: unknown): value is GoalState {
+  if (!value || typeof value !== "object") return false;
+  const state = value as Record<string, unknown>;
+  return typeof state.goalId === "string" && typeof state.status === "string";
+}
+
+function formatGoalResult(state: GoalState): string {
+  const detail = state.summary ?? state.reason;
+  return `Goal ${state.status.replaceAll("_", " ")}${detail ? `: ${detail}` : ""}`;
+}
+
+async function runGoal(
+  eventBus: EventBus,
+  objective: string,
+  signal?: AbortSignal,
+): Promise<GoalState> {
+  const requestId = randomUUID();
+  return new Promise((resolveGoal, rejectGoal) => {
+    let goalId: string | undefined;
+    let started = false;
+    let settled = false;
+    let timeout: ReturnType<typeof setTimeout> | undefined;
+    let unsubscribeReply = () => {};
+    let unsubscribeState = () => {};
+    const pendingTerminal = new Map<string, GoalState>();
+
+    const cleanup = () => {
+      if (timeout) clearTimeout(timeout);
+      signal?.removeEventListener("abort", onAbort);
+      unsubscribeReply();
+      unsubscribeState();
+    };
+    const finish = (state: GoalState) => {
+      if (settled) return;
+      settled = true;
+      cleanup();
+      resolveGoal(state);
+    };
+    const fail = (error: Error) => {
+      if (settled) return;
+      settled = true;
+      cleanup();
+      rejectGoal(error);
+    };
+    const onAbort = () => {
+      if (!started) {
+        fail(new Error("Goal-mode agent was aborted before it started"));
+        return;
+      }
+      if (timeout) clearTimeout(timeout);
+      const reason = typeof signal?.reason === "string" ? signal.reason : "agent run aborted";
+      eventBus.emit("pi-goal:rpc:pause", { goalId, reason });
+      timeout = setTimeout(() => {
+        fail(new Error("pi-goal did not acknowledge the goal pause request"));
+      }, 1_000);
+    };
+
+    unsubscribeState = eventBus.on("pi-goal:state", (value) => {
+      if (!isGoalState(value) || !GOAL_TERMINAL_STATUSES.has(value.status)) return;
+      if (goalId === value.goalId) finish(value);
+      else pendingTerminal.set(value.goalId, value);
+    });
+    unsubscribeReply = eventBus.on(`pi-goal:rpc:start:reply:${requestId}`, (value) => {
+      if (!value || typeof value !== "object") return;
+      const reply = value as {
+        success?: unknown;
+        error?: unknown;
+        data?: { goalId?: unknown; status?: unknown };
+      };
+      if (reply.success !== true) {
+        fail(new Error(typeof reply.error === "string" ? reply.error : "pi-goal rejected the objective"));
+        return;
+      }
+      if (typeof reply.data?.goalId !== "string" || typeof reply.data.status !== "string") {
+        fail(new Error("pi-goal returned an invalid start reply"));
+        return;
+      }
+      goalId = reply.data.goalId;
+      if (timeout) clearTimeout(timeout);
+      const pending = pendingTerminal.get(goalId);
+      if (pending) finish(pending);
+      else if (GOAL_TERMINAL_STATUSES.has(reply.data.status)) {
+        finish({ goalId, status: reply.data.status });
+      }
+    });
+    timeout = setTimeout(() => {
+      fail(new Error("pi-goal is loaded but does not support goal-mode RPC; update @narumitw/pi-goal"));
+    }, 1_000);
+
+    if (signal?.aborted) {
+      onAbort();
+      return;
+    }
+    signal?.addEventListener("abort", onAbort, { once: true });
+    started = true;
+    eventBus.emit("pi-goal:rpc:start", { requestId, objective });
+  });
+}
+
 export async function runAgent(
   ctx: ExtensionContext,
   type: SubagentType,
@@ -414,6 +540,10 @@ export async function runAgent(
 ): Promise<RunResult> {
   const config = getConfig(type);
   const agentConfig = getAgentConfig(type);
+
+  if (options.goal && options.isolated) {
+    throw new Error("Cannot combine goal mode with isolated: true because pi-goal is an extension");
+  }
 
   // Resolve working directory: worktree override > parent cwd
   const effectiveCwd = options.cwd ?? ctx.cwd;
@@ -541,8 +671,10 @@ export async function runAgent(
           };
         };
 
+  const eventBus = options.goal ? createEventBus() : undefined;
   const loader = new DefaultResourceLoader({
     cwd: configCwd,
+    eventBus,
     agentDir,
     noExtensions,
     additionalExtensionPaths,
@@ -555,6 +687,15 @@ export async function runAgent(
     appendSystemPromptOverride: () => [],
   });
   await loader.reload();
+
+  if (
+    options.goal &&
+    !loader.getExtensions().extensions.some((extension) =>
+      isGoalExtension(extension.path, extension.tools)
+    )
+  ) {
+    throw new Error("Goal mode requires @narumitw/pi-goal to be loaded by this agent");
+  }
 
   // Plain entries in `tools:` are expected to be built-in names (extension tools
   // go through `ext:`), so an unknown name there is unambiguously a typo. Previously
@@ -649,7 +790,8 @@ export async function runAgent(
     const optInActive = extNames.size > 0;
     for (const extension of loader.getExtensions().extensions) {
       const canons = extensionCanonicalNames(extension.path);
-      if (optInActive && !canons.some((c) => extNames.has(c))) continue;
+      const requiredForGoal = options.goal && isGoalExtension(extension.path, extension.tools);
+      if (optInActive && !requiredForGoal && !canons.some((c) => extNames.has(c))) continue;
       // First alias that carries a narrowing set — a user won't narrow one
       // extension under two different names, so first-match is correct.
       const narrowed = canons.map((c) => narrowing.get(c)).find(Boolean);
@@ -674,6 +816,9 @@ export async function runAgent(
     // (`ext:` opt-in flip), so any extension tool in `extensionToolNames` is allowed.
     return !noExtensions;
   });
+  if (options.goal && !GOAL_TOOL_NAMES.every((name) => allowedTools.includes(name))) {
+    throw new Error("Goal mode requires goal_complete and goal_blocked in the active tool allowlist");
+  }
 
   const settingsManager = SettingsManager.create(configCwd, agentDir);
   const configuredSessionDir = resolveConfiguredSessionDir(agentConfig?.sessionDir, effectiveCwd);
@@ -726,6 +871,11 @@ export async function runAgent(
 
   options.onSessionCreated?.(session);
 
+  const goalAbortController = options.goal ? new AbortController() : undefined;
+  const abortGoalFromParent = () => goalAbortController?.abort("agent run aborted");
+  if (options.signal?.aborted) abortGoalFromParent();
+  else options.signal?.addEventListener("abort", abortGoalFromParent, { once: true });
+
   // Track turns for graceful max_turns enforcement
   let turnCount = 0;
   const maxTurns = normalizeMaxTurns(options.maxTurns ?? agentConfig?.maxTurns ?? defaultMaxTurns);
@@ -744,6 +894,7 @@ export async function runAgent(
         } else if (softLimitReached && turnCount >= maxTurns + graceTurns) {
           aborted = true;
           session.abort();
+          goalAbortController?.abort("turn limit reached");
         }
       }
     }
@@ -788,16 +939,32 @@ export async function runAgent(
   // Boundary for the history fallback: only assistant text produced from here
   // on counts as this run's output (a fresh session, so usually 0).
   const startLen = session.messages.length;
+  let goalState: GoalState | undefined;
   try {
-    await session.prompt(effectivePrompt);
+    if (options.goal) {
+      if (!eventBus) throw new Error("Goal mode event bus was not initialized");
+      goalState = await runGoal(eventBus, effectivePrompt, goalAbortController?.signal);
+    } else {
+      await session.prompt(effectivePrompt);
+    }
   } finally {
-    unsubTurns();
-    collector.unsubscribe();
-    cleanupAbort();
+    try {
+      if (options.goal) await session.waitForIdle();
+    } finally {
+      options.signal?.removeEventListener("abort", abortGoalFromParent);
+      unsubTurns();
+      collector.unsubscribe();
+      cleanupAbort();
+    }
   }
 
-  const responseText = collector.getText().trim() || getLastAssistantText(session, startLen);
-  return { responseText, session, aborted, steered: softLimitReached, failure: finalTurnError(session, startLen) };
+  const responseText = goalState
+    ? formatGoalResult(goalState)
+    : collector.getText().trim() || getLastAssistantText(session, startLen);
+  const failure = goalState && goalState.status !== "complete"
+    ? responseText
+    : finalTurnError(session, startLen);
+  return { responseText, session, aborted, steered: softLimitReached, failure };
 }
 
 /**

--- a/src/index.ts
+++ b/src/index.ts
@@ -139,7 +139,8 @@ const THINKING_LEVELS = ["off", "minimal", "low", "medium", "high", "xhigh", "ma
  */
 function partialOutputSuffix(record: AgentRecord): string {
   const partial = record.result?.trim();
-  return partial ? `\n\nPartial output before the failure:\n${partial}` : "";
+  if (!partial || partial === record.error?.trim()) return "";
+  return `\n\nPartial output before the failure:\n${partial}`;
 }
 
 /** Human-readable status label for agent completion. */
@@ -778,6 +779,7 @@ Notes:
 - Parallel work: one message, multiple Agent calls, run_in_background: true on each. You are notified when background agents finish — never poll or sleep.
 - The result is not shown to the user — summarize it for them. Verify an agent's claimed code changes before reporting work done.
 - resume continues a previous agent by ID; steer_subagent messages a running one.
+- goal: true runs the child through pi-goal until it completes or stops.
 - isolation: "worktree" runs the agent in an isolated git worktree; changes land on a branch.`;
 
   const fullAgentToolDescription = `Launch a new agent to handle complex, multi-step tasks autonomously. Each agent type has specific capabilities and tools available to it.
@@ -808,6 +810,7 @@ If the target is already known, use a direct tool — \`read\` for a known path,
 - Use model to specify a different model (as "provider/modelId", or fuzzy e.g. "haiku", "sonnet").
 - Use thinking to control extended thinking level.
 - Use inherit_context if the agent needs the parent conversation history.
+- Use goal: true to run the child through pi-goal until it completes or reaches another terminal state. Goal mode requires pi-goal and cannot be combined with isolated, resume, or schedule.
 - Use isolation: "worktree" to run the agent in an isolated git worktree (safe parallel file modifications). The worktree is automatically cleaned up if the agent makes no changes; otherwise the path and branch are returned in the result.${scheduleGuideline}
 
 ## Writing the prompt
@@ -911,6 +914,11 @@ Terse command-style prompts produce shallow, generic work.
       run_in_background: Type.Optional(
         Type.Boolean({
           description: "Set to true to run in background. Returns agent ID immediately. You will be notified on completion.",
+        }),
+      ),
+      goal: Type.Optional(
+        Type.Boolean({
+          description: "Run through pi-goal until complete, blocked, paused, usage-limited, or budget-limited.",
         }),
       ),
       resume: Type.Optional(
@@ -1091,6 +1099,7 @@ Terse command-style prompts produce shallow, generic work.
       const runInBackground = resolvedConfig.runInBackground;
       const isolated = resolvedConfig.isolated;
       const isolation = resolvedConfig.isolation;
+      const goal = params.goal ?? false;
       // Whether this spawn writes its .output transcript. Per-agent
       // frontmatter (`output_transcript`) wins; otherwise the project/global
       // default applies. `attachTranscript` below is the SOLE gate — every
@@ -1131,6 +1140,16 @@ Terse command-style prompts produce shallow, generic work.
         modelName,
         tags: agentTags.length > 0 ? agentTags : undefined,
       };
+
+      if (goal && isolated) {
+        return textResult("Cannot combine `goal: true` with `isolated: true` — goal mode requires the pi-goal extension.");
+      }
+      if (goal && params.resume) {
+        return textResult("Cannot combine `goal: true` with `resume` — goal mode starts a fresh goal.");
+      }
+      if (goal && params.schedule) {
+        return textResult("Cannot combine `goal: true` with `schedule`.");
+      }
 
       // ---- Schedule: register a job, don't spawn now ----
       if (params.schedule) {
@@ -1179,6 +1198,9 @@ Terse command-style prompts produce shallow, generic work.
         if (!existing) {
           return textResult(`Agent not found: "${params.resume}". It may have been cleaned up.`);
         }
+        if (existing.goal) {
+          return textResult(`Cannot resume goal-mode agent "${params.resume}"; start a fresh goal-mode agent instead.`);
+        }
         if (!existing.session) {
           return textResult(`Agent "${params.resume}" has no active session to resume.`);
         }
@@ -1220,6 +1242,7 @@ Terse command-style prompts produce shallow, generic work.
             model,
             maxTurns: effectiveMaxTurns,
             isolated,
+            goal,
             inheritContext,
             thinkingLevel: thinking,
             isBackground: true,
@@ -1346,6 +1369,7 @@ Terse command-style prompts produce shallow, generic work.
           model,
           maxTurns: effectiveMaxTurns,
           isolated,
+          goal,
           inheritContext,
           thinkingLevel: thinking,
           isolation,

--- a/src/types.ts
+++ b/src/types.ts
@@ -97,6 +97,8 @@ export interface AgentRecord {
   resultConsumed?: boolean;
   /** Steering messages queued before the session was ready. */
   pendingSteers?: string[];
+  /** True when the initial run is owned by pi-goal and cannot use ordinary resume. */
+  goal?: boolean;
   /** Worktree info if the agent is running in an isolated worktree. */
   worktree?: { path: string; branch: string; baseSha: string; workPath: string };
   /** Worktree cleanup result after agent completion. */

--- a/test/agent-manager.test.ts
+++ b/test/agent-manager.test.ts
@@ -14,7 +14,7 @@ vi.mock("../src/worktree.js", () => ({
   pruneWorktrees: vi.fn(),
 }));
 
-import { runAgent } from "../src/agent-runner.js";
+import { resumeAgent, runAgent } from "../src/agent-runner.js";
 
 const mockPi = {} as any;
 const mockCtx = { cwd: "/tmp" } as any;
@@ -159,6 +159,47 @@ describe("AgentManager — spawnAndWait onSpawned + foreground output file wirin
     }, (fgId) => { spawnedId = fgId; });
 
     expect(spawnedId).toBe(id);
+  });
+
+  it("passes goal mode through to runAgent", async () => {
+    manager = new AgentManager();
+    resolvedRun();
+
+    await manager.spawnAndWait(mockPi, mockCtx, "general-purpose", "test", {
+      description: "test",
+      goal: true,
+    });
+
+    expect(runAgent).toHaveBeenCalledWith(
+      mockCtx,
+      "general-purpose",
+      "test",
+      expect.objectContaining({ goal: true }),
+    );
+  });
+
+  it("does not resume a session created in goal mode", async () => {
+    manager = new AgentManager();
+    resolvedRun();
+
+    const { record } = await manager.spawnAndWait(mockPi, mockCtx, "general-purpose", "test", {
+      description: "test",
+      goal: true,
+    });
+
+    await expect(manager.resume(record.id, "continue")).resolves.toBeUndefined();
+    expect(resumeAgent).not.toHaveBeenCalled();
+  });
+
+  it("rejects isolated goal mode before creating a record", () => {
+    manager = new AgentManager();
+
+    expect(() => manager.spawn(mockPi, mockCtx, "general-purpose", "test", {
+      description: "test",
+      goal: true,
+      isolated: true,
+    })).toThrow(/isolated: true/);
+    expect(manager.listAgents()).toEqual([]);
   });
 
   it("onComplete fires on the error path with resultConsumed=true", async () => {
@@ -578,6 +619,36 @@ describe("AgentManager — SpawnOptions.cwd passthrough (#96)", () => {
       expect.objectContaining({ cwd: "/wt/copy/packages/api", configCwd: "/tmp" }),
     );
     expect(cleanupWorktree).toHaveBeenCalledWith("/", expect.anything(), "test");
+  });
+
+  it("does not clean a goal-mode worktree until the goal run promise settles", async () => {
+    const { createWorktree, cleanupWorktree } = await import("../src/worktree.js");
+    vi.mocked(createWorktree).mockReturnValueOnce({
+      path: "/wt/copy", branch: "pi-agent-x", baseSha: "abc", workPath: "/wt/copy",
+    });
+    vi.mocked(cleanupWorktree).mockClear();
+    let finishRun!: (value: any) => void;
+    vi.mocked(runAgent).mockImplementationOnce(() => new Promise((resolve) => {
+      finishRun = resolve;
+    }));
+
+    manager = new AgentManager();
+    const id = manager.spawn(mockPi, mockCtx, "general-purpose", "test", {
+      description: "test",
+      goal: true,
+      isolation: "worktree",
+    });
+    await Promise.resolve();
+
+    expect(cleanupWorktree).not.toHaveBeenCalled();
+    finishRun({
+      responseText: "Goal complete: done",
+      session: mockSession(),
+      aborted: false,
+      steered: false,
+    });
+    await manager.getRecord(id)!.promise;
+    expect(cleanupWorktree).toHaveBeenCalledOnce();
   });
 
   it("plain worktree (no cwd) keeps the historical root working dir even when workPath differs", async () => {

--- a/test/agent-runner-e2e.test.ts
+++ b/test/agent-runner-e2e.test.ts
@@ -40,6 +40,7 @@ import { registerFauxProvider } from "./helpers/pi-ai.js";
 vi.setConfig({ testTimeout: 30_000 });
 
 const FIXTURE = resolve(fileURLToPath(new URL("./fixtures/e2e-probe-ext.mjs", import.meta.url)));
+const GOAL_FIXTURE = resolve(fileURLToPath(new URL("./fixtures/goal.js", import.meta.url)));
 /** The fixture registers exactly this tool. */
 const EXT_TOOL = "e2e_probe";
 const BUILTINS = ["read", "bash", "edit", "write", "grep", "find", "ls"];
@@ -157,5 +158,43 @@ describe("agent-runner end-to-end (real pi-mono session + real extension)", () =
     expect(active).toContain(EXT_TOOL); // selected → surfaces despite the flip
     expect(active).toContain("read");
     expect(active).not.toContain("bash"); // builtinToolNames: ["read"] only
+  });
+
+  it("goal mode completes over a private event bus with the real loader and session", async () => {
+    registerAgents(new Map([["e2e", {
+      name: "e2e",
+      description: "e2e",
+      builtinToolNames: BUILTINS,
+      extensions: [GOAL_FIXTURE],
+      skills: false,
+      systemPrompt: "You are e2e.",
+      promptMode: "replace",
+      inheritContext: false,
+      runInBackground: false,
+      isolated: false,
+    } as AgentConfig]]));
+    const model = faux.getModel();
+    const modelRegistry: any = {
+      find: () => model,
+      getAll: () => [model],
+      getAvailable: () => [model],
+      hasConfiguredAuth: () => true,
+      isUsingOAuth: () => false,
+      getApiKeyAndHeaders: async () => ({ apiKey: "faux", headers: {} }),
+      registerProvider: () => {},
+      unregisterProvider: () => {},
+    };
+
+    const result = await runAgent(
+      { cwd, getSystemPrompt: () => "PARENT", model, modelRegistry } as any,
+      "e2e",
+      "complete through Goal",
+      { pi: makePi(), model, goal: true },
+    );
+    try {
+      expect(result.responseText).toBe("Goal complete: real loader verified");
+    } finally {
+      await result.session.dispose();
+    }
   });
 });

--- a/test/agent-runner.test.ts
+++ b/test/agent-runner.test.ts
@@ -5,32 +5,56 @@ import { afterEach, beforeEach, describe, expect, it, vi } from "vitest";
 
 const {
   createAgentSession,
+  createEventBus,
   defaultResourceLoaderCtor,
+  eventBusRef,
   loaderExtensionsRef,
   getAgentDir,
   sessionManagerInMemory,
   sessionManagerCreate,
   settingsManagerCreate,
   settingsManagerGetSessionDir,
-} = vi.hoisted(() => ({
-  createAgentSession: vi.fn(),
-  defaultResourceLoaderCtor: vi.fn(),
-  loaderExtensionsRef: {
-    current: { extensions: [], errors: [], runtime: {} } as {
-      extensions: Array<{ path: string; tools: Map<string, unknown> }>;
-      errors: Array<{ path: string; error: string }>;
-      runtime: Record<string, unknown>;
+} = vi.hoisted(() => {
+  const eventBusRef = { current: undefined as any };
+  return {
+    createAgentSession: vi.fn(),
+    createEventBus: vi.fn(() => {
+      const handlers = new Map<string, Set<(data: unknown) => void>>();
+      const bus = {
+        emit: vi.fn((channel: string, data: unknown) => {
+          for (const handler of handlers.get(channel) ?? []) handler(data);
+        }),
+        on: vi.fn((channel: string, handler: (data: unknown) => void) => {
+          const listeners = handlers.get(channel) ?? new Set();
+          listeners.add(handler);
+          handlers.set(channel, listeners);
+          return () => listeners.delete(handler);
+        }),
+        clear: vi.fn(() => handlers.clear()),
+      };
+      eventBusRef.current = bus;
+      return bus;
+    }),
+    defaultResourceLoaderCtor: vi.fn(),
+    eventBusRef,
+    loaderExtensionsRef: {
+      current: { extensions: [], errors: [], runtime: {} } as {
+        extensions: Array<{ path: string; tools: Map<string, unknown> }>;
+        errors: Array<{ path: string; error: string }>;
+        runtime: Record<string, unknown>;
+      },
     },
-  },
-  getAgentDir: vi.fn(() => "/mock/agent-dir"),
-  sessionManagerInMemory: vi.fn(() => ({ kind: "memory-session-manager" })),
-  sessionManagerCreate: vi.fn(() => ({ kind: "persistent-session-manager" })),
-  settingsManagerGetSessionDir: vi.fn(() => undefined as string | undefined),
-  settingsManagerCreate: vi.fn(() => ({ kind: "settings-manager", getSessionDir: settingsManagerGetSessionDir })),
-}));
+    getAgentDir: vi.fn(() => "/mock/agent-dir"),
+    sessionManagerInMemory: vi.fn(() => ({ kind: "memory-session-manager" })),
+    sessionManagerCreate: vi.fn(() => ({ kind: "persistent-session-manager" })),
+    settingsManagerGetSessionDir: vi.fn(() => undefined as string | undefined),
+    settingsManagerCreate: vi.fn(() => ({ kind: "settings-manager", getSessionDir: settingsManagerGetSessionDir })),
+  };
+});
 
 vi.mock("@earendil-works/pi-coding-agent", () => ({
   createAgentSession,
+  createEventBus,
   // Mock loader simulates pi-mono: reload() applies additionalExtensionPaths
   // (an unknown path becomes an error row, mirroring a failed load) and then
   // runs extensionsOverride over the result.
@@ -132,6 +156,7 @@ function createSession(finalText: string) {
       });
     }),
     abort: vi.fn(),
+    waitForIdle: vi.fn(async () => {}),
     steer: vi.fn(),
     getActiveToolNames: vi.fn(() => ["read"]),
     setActiveToolsByName: vi.fn(),
@@ -153,6 +178,8 @@ const pi = {} as any;
 
 beforeEach(() => {
   createAgentSession.mockReset();
+  createEventBus.mockClear();
+  eventBusRef.current = undefined;
   defaultResourceLoaderCtor.mockClear();
   getAgentDir.mockClear();
   sessionManagerInMemory.mockClear();
@@ -700,6 +727,218 @@ function lastToolsPassed(): string[] {
 function lastLoaderOpts(): Record<string, unknown> {
   return defaultResourceLoaderCtor.mock.calls[0][0];
 }
+
+function setupGoalAgent(overrides: Record<string, unknown> = {}) {
+  vi.mocked(getConfig).mockReturnValueOnce(makeConfig({ extensions: true, ...overrides }));
+  vi.mocked(getAgentConfig).mockReturnValueOnce(makeAgentConfig({ extensions: true, ...overrides }));
+  vi.mocked(getToolNamesForType).mockReturnValueOnce(BUILTINS_7);
+  withExtensions({
+    "/ext/goal.ts": ["goal_complete", "goal_blocked"],
+    "/ext/other.ts": ["other_tool"],
+  });
+}
+
+function bindGoalRpc(
+  session: ReturnType<typeof createSession>["session"],
+  terminal: { status: string; summary?: string; reason?: string },
+  terminalBeforeReply = false,
+) {
+  session.bindExtensions.mockImplementation(async () => {
+    const bus = eventBusRef.current;
+    bus.on("pi-goal:rpc:start", (request: any) => {
+      const state = { goalId: "goal-1", ...terminal };
+      if (terminalBeforeReply) bus.emit("pi-goal:state", state);
+      bus.emit(`pi-goal:rpc:start:reply:${request.requestId}`, {
+        success: true,
+        data: { goalId: "goal-1", status: terminalBeforeReply ? terminal.status : "active" },
+      });
+      if (!terminalBeforeReply) queueMicrotask(() => bus.emit("pi-goal:state", state));
+    });
+  });
+}
+
+function bindPauseBeforeReplyRpc(session: ReturnType<typeof createSession>["session"]) {
+  session.bindExtensions.mockImplementation(async () => {
+    const bus = eventBusRef.current;
+    let startRequest: any;
+    bus.on("pi-goal:rpc:start", (request: any) => {
+      startRequest = request;
+    });
+    bus.on("pi-goal:rpc:pause", (request: any) => {
+      bus.emit("pi-goal:state", {
+        goalId: "goal-1",
+        status: "paused",
+        reason: request.reason,
+      });
+      bus.emit(`pi-goal:rpc:start:reply:${startRequest.requestId}`, {
+        success: true,
+        data: { goalId: "goal-1", status: "paused" },
+      });
+    });
+  });
+}
+
+function bindActiveGoalRpc(session: ReturnType<typeof createSession>["session"]) {
+  session.bindExtensions.mockImplementation(async () => {
+    const bus = eventBusRef.current;
+    bus.on("pi-goal:rpc:start", (request: any) => {
+      bus.emit(`pi-goal:rpc:start:reply:${request.requestId}`, {
+        success: true,
+        data: { goalId: "goal-1", status: "active" },
+      });
+    });
+    bus.on("pi-goal:rpc:pause", (request: any) => {
+      bus.emit("pi-goal:state", {
+        goalId: request.goalId ?? "goal-1",
+        status: "paused",
+        reason: request.reason,
+      });
+    });
+  });
+}
+
+describe("agent-runner goal mode", () => {
+  it("starts pi-goal over the private event bus and waits for session idle before returning", async () => {
+    setupGoalAgent();
+    const { session } = createSession("ignored");
+    bindGoalRpc(session, { status: "complete", summary: "verified result" });
+    createAgentSession.mockResolvedValue({ session });
+
+    const result = await runAgent(ctx, "Explore", "implement it", { pi, goal: true });
+
+    expect(result.responseText).toBe("Goal complete: verified result");
+    expect(session.prompt).not.toHaveBeenCalled();
+    expect(session.waitForIdle).toHaveBeenCalledOnce();
+    expect(lastLoaderOpts().eventBus).toBe(eventBusRef.current);
+    expect(eventBusRef.current.emit).toHaveBeenCalledWith(
+      "pi-goal:rpc:start",
+      expect.objectContaining({ objective: "implement it", requestId: expect.any(String) }),
+    );
+  });
+
+  it("does not miss an immediate blocked state emitted before the start reply", async () => {
+    setupGoalAgent();
+    const { session } = createSession("ignored");
+    bindGoalRpc(session, { status: "blocked", reason: "dependency missing" }, true);
+    createAgentSession.mockResolvedValue({ session });
+
+    const result = await runAgent(ctx, "Explore", "implement it", { pi, goal: true });
+
+    expect(result.responseText).toBe("Goal blocked: dependency missing");
+    expect(result.failure).toBe("Goal blocked: dependency missing");
+    expect(session.waitForIdle).toHaveBeenCalledOnce();
+  });
+
+  it("pauses a goal during startup after a parent abort", async () => {
+    setupGoalAgent();
+    const { session } = createSession("ignored");
+    bindPauseBeforeReplyRpc(session);
+    createAgentSession.mockResolvedValue({ session });
+    const controller = new AbortController();
+
+    const run = runAgent(ctx, "Explore", "go", { pi, goal: true, signal: controller.signal });
+    await vi.waitFor(() => {
+      expect(eventBusRef.current.emit).toHaveBeenCalledWith(
+        "pi-goal:rpc:start",
+        expect.anything(),
+      );
+    });
+    controller.abort();
+    const result = await run;
+
+    expect(session.abort).toHaveBeenCalledOnce();
+    expect(eventBusRef.current.emit).toHaveBeenCalledWith(
+      "pi-goal:rpc:pause",
+      { goalId: undefined, reason: "agent run aborted" },
+    );
+    expect(session.waitForIdle).toHaveBeenCalled();
+    expect(result.responseText).toBe("Goal paused: agent run aborted");
+    expect(result.failure).toBe(result.responseText);
+  });
+
+  it("pauses a goal over RPC when the hard turn limit aborts", async () => {
+    setupGoalAgent();
+    const { session, listeners } = createSession("ignored");
+    bindActiveGoalRpc(session);
+    createAgentSession.mockResolvedValue({ session });
+
+    const run = runAgent(ctx, "Explore", "go", { pi, goal: true, maxTurns: 1 });
+    await vi.waitFor(() => {
+      expect(eventBusRef.current.emit).toHaveBeenCalledWith(
+        "pi-goal:rpc:start",
+        expect.anything(),
+      );
+    });
+    for (let turn = 0; turn < 6; turn++) {
+      for (const listener of listeners) listener({ type: "turn_end" });
+    }
+    const result = await run;
+
+    expect(session.steer).toHaveBeenCalledOnce();
+    expect(session.abort).toHaveBeenCalledOnce();
+    expect(eventBusRef.current.emit).toHaveBeenCalledWith(
+      "pi-goal:rpc:pause",
+      { goalId: "goal-1", reason: "turn limit reached" },
+    );
+    expect(result.aborted).toBe(true);
+    expect(result.responseText).toBe("Goal paused: turn limit reached");
+    expect(result.failure).toBe(result.responseText);
+  });
+
+  it("fails fast when isolated mode disables extensions", async () => {
+    await expect(runAgent(ctx, "Explore", "go", { pi, goal: true, isolated: true }))
+      .rejects.toThrow(/isolated: true/);
+    expect(defaultResourceLoaderCtor).not.toHaveBeenCalled();
+  });
+
+  it("does not start a goal when its signal was already aborted", async () => {
+    setupGoalAgent();
+    const { session } = createSession("ignored");
+    createAgentSession.mockResolvedValue({ session });
+    const controller = new AbortController();
+    controller.abort();
+
+    await expect(runAgent(ctx, "Explore", "go", { pi, goal: true, signal: controller.signal }))
+      .rejects.toThrow(/aborted before it started/);
+    expect(eventBusRef.current.emit).not.toHaveBeenCalledWith(
+      "pi-goal:rpc:start",
+      expect.anything(),
+    );
+  });
+
+  it("fails fast when pi-goal is missing or excluded", async () => {
+    vi.mocked(getConfig).mockReturnValueOnce(makeConfig({ extensions: true }));
+    vi.mocked(getAgentConfig).mockReturnValueOnce(makeAgentConfig({ extensions: true }));
+    await expect(runAgent(ctx, "Explore", "go", { pi, goal: true }))
+      .rejects.toThrow(/requires @narumitw\/pi-goal/);
+
+    setupGoalAgent({ excludeExtensions: ["goal"] });
+    await expect(runAgent(ctx, "Explore", "go", { pi, goal: true }))
+      .rejects.toThrow(/requires @narumitw\/pi-goal/);
+  });
+
+  it("adds pi-goal tools despite an unrelated ext: opt-in selector", async () => {
+    setupGoalAgent({ extSelectors: ["ext:other"] });
+    const { session } = createSession("ignored");
+    bindGoalRpc(session, { status: "paused", reason: "turn limit" });
+    createAgentSession.mockResolvedValue({ session });
+
+    await runAgent(ctx, "Explore", "go", { pi, goal: true });
+
+    expect(lastToolsPassed()).toEqual(expect.arrayContaining([
+      "goal_complete",
+      "goal_blocked",
+      "other_tool",
+    ]));
+  });
+
+  it("rejects a denylist that removes a required pi-goal tool", async () => {
+    setupGoalAgent({ disallowedTools: ["goal_complete"] });
+
+    await expect(runAgent(ctx, "Explore", "go", { pi, goal: true }))
+      .rejects.toThrow(/requires goal_complete and goal_blocked/);
+  });
+});
 
 describe("agent-runner session persistence", () => {
   it("uses an in-memory session by default", async () => {

--- a/test/fixtures/goal.js
+++ b/test/fixtures/goal.js
@@ -1,0 +1,30 @@
+import { Type } from "@sinclair/typebox";
+
+export default function (pi) {
+  for (const name of ["goal_complete", "goal_blocked"]) {
+    pi.registerTool({
+      name,
+      label: name,
+      description: "Goal-mode protocol fixture.",
+      parameters: Type.Object({}),
+      async execute() {
+        return { content: [{ type: "text", text: name }] };
+      },
+    });
+  }
+
+  pi.events.on("pi-goal:rpc:start", ({ requestId }) => {
+    const goalId = "e2e-goal";
+    pi.events.emit(`pi-goal:rpc:start:reply:${requestId}`, {
+      success: true,
+      data: { goalId, status: "active" },
+    });
+    queueMicrotask(() => {
+      pi.events.emit("pi-goal:state", {
+        goalId,
+        status: "complete",
+        summary: "real loader verified",
+      });
+    });
+  });
+}

--- a/test/goal-mode-wiring.test.ts
+++ b/test/goal-mode-wiring.test.ts
@@ -1,0 +1,195 @@
+import { afterEach, describe, expect, it, vi } from "vitest";
+
+vi.mock("../src/agent-runner.js", async () => {
+  const actual = await vi.importActual<typeof import("../src/agent-runner.js")>("../src/agent-runner.js");
+  return { ...actual, runAgent: vi.fn() };
+});
+
+import { runAgent } from "../src/agent-runner.js";
+import subagentsExtension from "../src/index.js";
+
+function makeHarness() {
+  const tools = new Map<string, any>();
+  const lifecycle = new Map<string, any>();
+  const pi = {
+    registerMessageRenderer: vi.fn(),
+    registerTool: vi.fn((tool: any) => tools.set(tool.name, tool)),
+    registerCommand: vi.fn(),
+    on: vi.fn((event: string, handler: any) => lifecycle.set(event, handler)),
+    events: { emit: vi.fn(), on: vi.fn(() => vi.fn()) },
+    appendEntry: vi.fn(),
+    sendMessage: vi.fn(),
+  } as any;
+  subagentsExtension(pi);
+  return { pi, tools, lifecycle };
+}
+
+function ctx() {
+  return {
+    hasUI: false,
+    ui: { setStatus: vi.fn(), setWidget: vi.fn(), notify: vi.fn() },
+    cwd: process.cwd(),
+    model: undefined,
+    modelRegistry: { find: vi.fn(), getAvailable: vi.fn(() => []) },
+    sessionManager: { getSessionId: vi.fn(() => "s1"), getBranch: vi.fn(() => []) },
+    getSystemPrompt: vi.fn(() => "parent"),
+  } as any;
+}
+
+const responseText = (result: any) => result.content[0].text as string;
+
+async function shutdown(harness: ReturnType<typeof makeHarness>) {
+  await harness.lifecycle.get("session_shutdown")?.({}, ctx());
+}
+
+describe("Agent tool goal mode wiring", () => {
+  let harness: ReturnType<typeof makeHarness> | undefined;
+
+  afterEach(async () => {
+    vi.mocked(runAgent).mockReset();
+    if (harness) await shutdown(harness);
+    harness = undefined;
+  });
+
+  it("publishes goal in the schema and passes it through foreground runs", async () => {
+    harness = makeHarness();
+    vi.mocked(runAgent).mockResolvedValue({
+      responseText: "Goal complete: verified",
+      session: { dispose: vi.fn() } as any,
+      aborted: false,
+      steered: false,
+    });
+    const agent = harness.tools.get("Agent");
+
+    expect(agent.parameters.properties.goal).toBeDefined();
+    const result = await agent.execute(
+      "tc-goal-fg",
+      { prompt: "go", description: "verified work", subagent_type: "general-purpose", goal: true },
+      undefined,
+      undefined,
+      ctx(),
+    );
+
+    expect(runAgent).toHaveBeenCalledWith(
+      expect.anything(),
+      "general-purpose",
+      "go",
+      expect.objectContaining({ goal: true }),
+    );
+    expect(responseText(result)).toContain("Goal complete: verified");
+  });
+
+  it("reports a non-complete foreground goal as a failure without duplicating its result", async () => {
+    harness = makeHarness();
+    vi.mocked(runAgent).mockResolvedValue({
+      responseText: "Goal blocked: dependency missing",
+      session: { dispose: vi.fn() } as any,
+      aborted: false,
+      steered: false,
+      failure: "Goal blocked: dependency missing",
+    });
+
+    const result = await harness.tools.get("Agent").execute(
+      "tc-goal-blocked",
+      { prompt: "go", description: "blocked work", subagent_type: "general-purpose", goal: true },
+      undefined,
+      undefined,
+      ctx(),
+    );
+
+    expect(responseText(result)).toContain("Agent failed: Goal blocked: dependency missing");
+    expect(responseText(result)).not.toContain("Partial output before the failure");
+  });
+
+  it("passes goal mode through background runs", async () => {
+    harness = makeHarness();
+    vi.mocked(runAgent).mockResolvedValue({
+      responseText: "Goal blocked: dependency missing",
+      session: { dispose: vi.fn() } as any,
+      aborted: false,
+      steered: false,
+      failure: "Goal blocked: dependency missing",
+    });
+    const result = await harness.tools.get("Agent").execute(
+      "tc-goal-bg",
+      {
+        prompt: "go",
+        description: "blocked work",
+        subagent_type: "general-purpose",
+        goal: true,
+        run_in_background: true,
+      },
+      undefined,
+      undefined,
+      ctx(),
+    );
+
+    expect(responseText(result)).toMatch(/Agent ID:/);
+    await new Promise((resolve) => setImmediate(resolve));
+    expect(runAgent).toHaveBeenCalledWith(
+      expect.anything(),
+      "general-purpose",
+      "go",
+      expect.objectContaining({ goal: true }),
+    );
+    expect(harness.pi.events.emit).toHaveBeenCalledWith(
+      "subagents:failed",
+      expect.objectContaining({ status: "error" }),
+    );
+  });
+
+  it("rejects a later ordinary resume of a goal-mode record", async () => {
+    harness = makeHarness();
+    vi.mocked(runAgent).mockResolvedValue({
+      responseText: "Goal complete: verified",
+      session: { dispose: vi.fn() } as any,
+      aborted: false,
+      steered: false,
+    });
+    const agent = harness.tools.get("Agent");
+    const started = await agent.execute(
+      "tc-goal-start",
+      {
+        prompt: "go",
+        description: "goal work",
+        subagent_type: "general-purpose",
+        goal: true,
+        run_in_background: true,
+      },
+      undefined,
+      undefined,
+      ctx(),
+    );
+    const id = responseText(started).match(/Agent ID: ([\w-]+)/)?.[1];
+    expect(id).toBeDefined();
+    await new Promise((resolve) => setImmediate(resolve));
+
+    const resumed = await agent.execute(
+      "tc-goal-resume",
+      { prompt: "continue", description: "resume", subagent_type: "general-purpose", resume: id },
+      undefined,
+      undefined,
+      ctx(),
+    );
+
+    expect(responseText(resumed)).toMatch(/Cannot resume goal-mode agent/);
+  });
+
+  it.each([
+    [{ goal: true, isolated: true }, /isolated: true/],
+    [{ goal: true, resume: "agent-1" }, /resume/],
+    [{ goal: true, schedule: "+1h" }, /schedule/],
+  ])("rejects unsupported combinations before spawning", async (extra, message) => {
+    harness = makeHarness();
+    const result = await harness.tools.get("Agent").execute(
+      "tc-goal-invalid",
+      { prompt: "go", description: "invalid goal", subagent_type: "general-purpose", ...extra },
+      undefined,
+      undefined,
+      ctx(),
+    );
+
+    expect(responseText(result)).toMatch(message);
+    expect(runAgent).not.toHaveBeenCalled();
+  });
+});

--- a/test/tool-description-mode.test.ts
+++ b/test/tool-description-mode.test.ts
@@ -119,6 +119,7 @@ describe("toolDescriptionMode", () => {
     // If you change one of these behaviors, update BOTH descriptions.
     for (const contract of [
       "run_in_background",
+      "goal: true",
       "resume",
       "steer_subagent",
       'isolation: "worktree"',


### PR DESCRIPTION
Closes #161.

Companion provider PR: narumiruna/pi-extensions#298

## Summary

- add first-class `Agent({ goal: true })` schema, manager, runner, and documentation support
- give Goal-mode children a private session event bus, start pi-goal after extension binding, and wait for an authoritative terminal state plus session idle before cleanup
- pause goals safely on parent abort or hard turn limits, including cancellation before the start reply
- preserve worktree/background behavior while failing fast for missing/excluded pi-goal, removed Goal tools, `isolated: true`, `resume`, and `schedule`
- report only `complete` as success; blocked/paused/limited outcomes retain their Goal result through the failed/stopped lifecycle

## Verification

- `npm run lint`
- `npm run typecheck`
- `npm run build`
- hermetic full suite: **752 passed, 5 skipped**
- E2E suite: **44 passed, 5 skipped**
- real-loader Goal protocol E2E: passed
- cross-repository smoke with the actual pi-goal source, real Pi loader/session, and `goal_complete`: passed
