### PR TITLE
feat: support caller-supplied session names

### DIFF
--- a/README.md
+++ b/README.md
@@ -53,11 +53,12 @@ Agent({
   subagent_type: "Explore",
   prompt: "Find all files that handle authentication",
   description: "Find auth files",
+  name: "Authentication search",
   run_in_background: true,
 })
 ```
 
-Foreground agents block until complete and return results inline. Background agents return an ID immediately and notify you on completion.
+Foreground agents block until complete and return results inline. Background agents return an ID immediately and notify you on completion. Optional `name` labels the subagent session for easier identification; the normal short agent-ID suffix is still appended automatically (for example, `Authentication search#a1b2c3d4`).
 
 ### Scheduling
 
@@ -68,6 +69,7 @@ Agent({
   subagent_type: "Explore",
   prompt: "Look at recent commits and summarize what changed since last week",
   description: "Weekly commit review",
+  name: "Weekly repository review",
   schedule: "0 0 9 * * 1",   // 9am every Monday (6-field cron)
 })
 ```
@@ -278,6 +280,7 @@ Launch a sub-agent.
 |-----------|------|----------|-------------|
 | `prompt` | string | yes | The task for the agent |
 | `description` | string | yes | Short 3-5 word summary (shown in UI) |
+| `name` | string | no | Human-readable session name; the short agent-ID suffix is added automatically |
 | `subagent_type` | string | yes | Agent type (built-in or custom) |
 | `model` | string | no | Model — `provider/modelId` or fuzzy name (`"haiku"`, `"sonnet"`). Resolved tolerantly (`.`/`-` and a trailing date stamp interchangeable) with provider fallback |
 | `thinking` | string | no | Thinking level: off, minimal, low, medium, high, xhigh, max (availability depends on pi version and model) |

--- a/src/agent-manager.ts
+++ b/src/agent-manager.ts
@@ -56,6 +56,8 @@ interface SpawnArgs {
 
 interface SpawnOptions {
   description: string;
+  /** Caller-supplied session name; falls back to the agent config/type when omitted. */
+  sessionName?: string;
   model?: Model<any>;
   maxTurns?: number;
   isolated?: boolean;
@@ -247,6 +249,7 @@ export class AgentManager {
     const promise = runAgent(ctx, type, prompt, {
       pi,
       agentId: id,
+      sessionName: options.sessionName,
       model: options.model,
       maxTurns: options.maxTurns,
       isolated: options.isolated,

--- a/src/agent-runner.ts
+++ b/src/agent-runner.ts
@@ -261,6 +261,8 @@ export interface RunOptions {
   pi: ExtensionAPI;
   /** Manager-assigned id; suffixes session name to disambiguate parallel spawns (e.g. `Explore#a1b2c3d4`). */
   agentId?: string;
+  /** Caller-supplied session name; takes precedence over the agent config/type. */
+  sessionName?: string;
   model?: Model<any>;
   maxTurns?: number;
   signal?: AbortSignal;
@@ -706,7 +708,10 @@ export async function runAgent(
 
   const { session } = await createAgentSession(sessionOpts);
 
-  const baseSessionName = agentConfig?.name ?? type;
+  const suppliedSessionName = typeof options.sessionName === "string" && options.sessionName.trim()
+    ? options.sessionName.trim()
+    : undefined;
+  const baseSessionName = suppliedSessionName ?? agentConfig?.name ?? type;
   session.setSessionName(
     options.agentId ? `${baseSessionName}#${options.agentId.slice(0, 8)}` : baseSessionName,
   );

--- a/src/index.ts
+++ b/src/index.ts
@@ -888,6 +888,11 @@ Terse command-style prompts produce shallow, generic work.
       description: Type.String({
         description: "A short (3-5 word) description of the task (shown in UI).",
       }),
+      name: Type.Optional(
+        Type.String({
+          description: "Optional human-readable session name. The short agent ID suffix is added automatically.",
+        }),
+      ),
       subagent_type: Type.String({
         description: `The type of specialized agent to use. Available types: ${getAvailableTypes().join(", ")}. Custom agents from .pi/agents/*.md (project) or ${getAgentDir()}/agents/*.md (global) are also available.`,
       }),
@@ -1153,6 +1158,7 @@ Terse command-style prompts produce shallow, generic work.
           const job = scheduler.addJob({
             name: params.description as string,
             description: params.description as string,
+            sessionName: params.name as string | undefined,
             schedule: params.schedule as string,
             subagent_type: subagentType,
             prompt: params.prompt as string,
@@ -1217,6 +1223,7 @@ Terse command-style prompts produce shallow, generic work.
         try {
           id = manager.spawn(pi, ctx, subagentType, params.prompt, {
             description: params.description,
+            sessionName: params.name,
             model,
             maxTurns: effectiveMaxTurns,
             isolated,
@@ -1343,6 +1350,7 @@ Terse command-style prompts produce shallow, generic work.
       try {
         const fgResult = await manager.spawnAndWait(pi, ctx, subagentType, params.prompt, {
           description: params.description,
+          sessionName: params.name,
           model,
           maxTurns: effectiveMaxTurns,
           isolated,

--- a/src/schedule.ts
+++ b/src/schedule.ts
@@ -35,6 +35,7 @@ export type ScheduleChangeEvent =
 export interface NewJobInput {
   name: string;
   description: string;
+  sessionName?: string;
   schedule: string;
   subagent_type: SubagentType;
   prompt: string;
@@ -96,6 +97,7 @@ export class SubagentScheduler {
       id: nanoid(10),
       name: input.name,
       description: input.description,
+      sessionName: input.sessionName,
       schedule: detected.normalized,
       scheduleType: detected.type,
       intervalMs: detected.intervalMs,
@@ -240,6 +242,7 @@ export class SubagentScheduler {
     try {
       agentId = manager.spawn(pi, ctx, job.subagent_type, job.prompt, {
         description: job.description,
+        sessionName: job.sessionName,
         isBackground: true,
         bypassQueue: true,
         model: resolvedModel,

--- a/src/types.ts
+++ b/src/types.ts
@@ -182,6 +182,8 @@ export interface ScheduledSubagent {
   intervalMs?: number;
 
   // spawn params (subset of Agent tool params; no inherit_context, no resume)
+  /** Optional caller-supplied session name. */
+  sessionName?: string;
   subagent_type: SubagentType;
   prompt: string;
   model?: string;

--- a/test/agent-manager.test.ts
+++ b/test/agent-manager.test.ts
@@ -647,6 +647,24 @@ describe("AgentManager — SpawnOptions.cwd passthrough (#96)", () => {
   });
 });
 
+describe("AgentManager — session name passthrough", () => {
+  let manager: AgentManager;
+  afterEach(() => manager?.dispose());
+
+  it("passes SpawnOptions.sessionName to runAgent", async () => {
+    vi.mocked(runAgent).mockClear();
+    resolvedRun();
+    manager = new AgentManager();
+    const id = manager.spawn(mockPi, mockCtx, "general-purpose", "test", {
+      description: "test",
+      sessionName: "CH-005 verify",
+    });
+    await manager.getRecord(id)!.promise;
+
+    expect(vi.mocked(runAgent).mock.lastCall![3].sessionName).toBe("CH-005 verify");
+  });
+});
+
 describe("AgentManager — abort() state machine", () => {
   let manager: AgentManager;
   afterEach(() => manager?.dispose());

--- a/test/agent-runner.test.ts
+++ b/test/agent-runner.test.ts
@@ -282,6 +282,32 @@ describe("agent-runner final output capture", () => {
 
     expect(session.setSessionName).toHaveBeenCalledWith("Explore#a1b2c3d4");
   });
+
+  it("trims and prefers a caller-supplied session name while preserving the short agentId suffix", async () => {
+    const { session } = createSession("NAMED");
+    createAgentSession.mockResolvedValue({ session });
+
+    await runAgent(ctx, "Explore", "go", {
+      pi,
+      agentId: "a1b2c3d4e5f6",
+      sessionName: "  CH-005 plan  ",
+    });
+
+    expect(session.setSessionName).toHaveBeenCalledWith("CH-005 plan#a1b2c3d4");
+  });
+
+  it("falls back to the configured name when a caller supplies only whitespace", async () => {
+    const { session } = createSession("NAMED");
+    createAgentSession.mockResolvedValue({ session });
+
+    await runAgent(ctx, "Explore", "go", {
+      pi,
+      agentId: "a1b2c3d4e5f6",
+      sessionName: "   ",
+    });
+
+    expect(session.setSessionName).toHaveBeenCalledWith("Explore#a1b2c3d4");
+  });
 });
 
 // #144 — a failed FINAL assistant turn (stopReason "error") must surface as

--- a/test/schedule-store.test.ts
+++ b/test/schedule-store.test.ts
@@ -57,6 +57,14 @@ describe("ScheduleStore", () => {
     expect(fresh.list()).toEqual([job]);
   });
 
+  it("round-trips a caller-supplied session name", () => {
+    const file = join(tmp, "s.json");
+    const store = new ScheduleStore(file);
+    store.add(makeJob({ sessionName: "GH-123 scheduled review" }));
+
+    expect(new ScheduleStore(file).list()[0].sessionName).toBe("GH-123 scheduled review");
+  });
+
   it("update returns merged record and persists the patch", () => {
     const store = new ScheduleStore(join(tmp, "s.json"));
     const job = makeJob({ name: "before" });

--- a/test/schedule.test.ts
+++ b/test/schedule.test.ts
@@ -294,6 +294,21 @@ describe("SubagentScheduler — fire path", () => {
     expect(optsArg.isBackground).toBe(true);
   });
 
+  it("preserves a caller-supplied session name when a scheduled job fires", () => {
+    const job = scheduler.addJob({
+      name: "named-job",
+      description: "x",
+      sessionName: "GH-123 scheduled review",
+      schedule: "1s",
+      subagent_type: "general-purpose",
+      prompt: "x",
+    });
+
+    expect(scheduler.list().find(j => j.id === job.id)?.sessionName).toBe("GH-123 scheduled review");
+    vi.advanceTimersByTime(1_000);
+    expect(manager.spawn.mock.calls[0][4].sessionName).toBe("GH-123 scheduled review");
+  });
+
   it("disabled jobs do not fire", () => {
     const job = scheduler.addJob({
       name: "off", description: "x", schedule: "1s",

--- a/test/session-name-wiring.test.ts
+++ b/test/session-name-wiring.test.ts
@@ -1,0 +1,139 @@
+import { mkdirSync, mkdtempSync, readFileSync, rmSync, writeFileSync } from "node:fs";
+import { tmpdir } from "node:os";
+import { join } from "node:path";
+import { afterEach, beforeEach, describe, expect, it, vi } from "vitest";
+
+vi.mock("../src/agent-runner.js", async () => {
+  const actual = await vi.importActual<typeof import("../src/agent-runner.js")>("../src/agent-runner.js");
+  return { ...actual, runAgent: vi.fn() };
+});
+
+import { runAgent } from "../src/agent-runner.js";
+import subagentsExtension from "../src/index.js";
+
+function makePi() {
+  const tools = new Map<string, any>();
+  const lifecycle = new Map<string, any>();
+  const pi = {
+    registerMessageRenderer: vi.fn(),
+    registerTool: vi.fn((tool: any) => tools.set(tool.name, tool)),
+    registerCommand: vi.fn(),
+    on: vi.fn((event: string, handler: any) => lifecycle.set(event, handler)),
+    events: { emit: vi.fn(), on: vi.fn(() => vi.fn()) },
+    appendEntry: vi.fn(),
+    sendMessage: vi.fn(),
+  } as any;
+  return { pi, tools, lifecycle };
+}
+
+function makeCtx(cwd: string) {
+  return {
+    hasUI: false,
+    ui: { setStatus: vi.fn(), setWidget: vi.fn(), notify: vi.fn() },
+    cwd,
+    model: undefined,
+    modelRegistry: { find: vi.fn(), getAvailable: vi.fn(() => []) },
+    sessionManager: { getSessionId: vi.fn(() => "session-1"), getBranch: vi.fn(() => []) },
+    getSystemPrompt: vi.fn(() => "parent"),
+  } as any;
+}
+
+describe("Agent session name top-level wiring", () => {
+  let cwd: string;
+  let agentDir: string;
+  let previousCwd: string;
+  let previousAgentDir: string | undefined;
+  let previousHome: string | undefined;
+
+  beforeEach(() => {
+    cwd = mkdtempSync(join(tmpdir(), "pi-session-name-cwd-"));
+    agentDir = mkdtempSync(join(tmpdir(), "pi-session-name-agent-"));
+    previousCwd = process.cwd();
+    previousAgentDir = process.env.PI_CODING_AGENT_DIR;
+    previousHome = process.env.HOME;
+    process.env.PI_CODING_AGENT_DIR = agentDir;
+    process.env.HOME = agentDir;
+    mkdirSync(join(cwd, ".pi"), { recursive: true });
+    process.chdir(cwd);
+    vi.mocked(runAgent).mockResolvedValue({
+      responseText: "done",
+      session: { dispose: vi.fn() } as any,
+      aborted: false,
+      steered: false,
+    });
+  });
+
+  afterEach(() => {
+    process.chdir(previousCwd);
+    if (previousAgentDir == null) delete process.env.PI_CODING_AGENT_DIR;
+    else process.env.PI_CODING_AGENT_DIR = previousAgentDir;
+    if (previousHome == null) delete process.env.HOME;
+    else process.env.HOME = previousHome;
+    rmSync(cwd, { recursive: true, force: true });
+    rmSync(agentDir, { recursive: true, force: true });
+    vi.clearAllMocks();
+  });
+
+  it("advertises name and passes it through foreground and background Agent calls", async () => {
+    writeFileSync(
+      join(cwd, ".pi", "subagents.json"),
+      JSON.stringify({ schedulingEnabled: false, outputTranscript: false, defaultJoinMode: "async" }),
+    );
+    const { pi, tools, lifecycle } = makePi();
+    const ctx = makeCtx(cwd);
+    subagentsExtension(pi);
+    const agent = tools.get("Agent");
+
+    expect(agent.parameters.properties.name.description).toContain("human-readable session name");
+
+    await agent.execute(
+      "foreground-call",
+      { prompt: "foreground", description: "Run foreground", name: "Foreground review", subagent_type: "general-purpose" },
+      undefined,
+      undefined,
+      ctx,
+    );
+    expect(vi.mocked(runAgent).mock.calls[0][3].sessionName).toBe("Foreground review");
+
+    await agent.execute(
+      "background-call",
+      { prompt: "background", description: "Run background", name: "Background review", subagent_type: "general-purpose", run_in_background: true },
+      undefined,
+      undefined,
+      ctx,
+    );
+    expect(vi.mocked(runAgent).mock.calls[1][3].sessionName).toBe("Background review");
+
+    await lifecycle.get("session_shutdown")?.({}, ctx);
+  });
+
+  it("stores name when a top-level Agent call creates a scheduled job", async () => {
+    writeFileSync(join(cwd, ".pi", "subagents.json"), JSON.stringify({ outputTranscript: false }));
+    const { pi, tools, lifecycle } = makePi();
+    const ctx = makeCtx(cwd);
+    subagentsExtension(pi);
+    await lifecycle.get("session_start")?.({}, ctx);
+
+    await tools.get("Agent").execute(
+      "scheduled-call",
+      {
+        prompt: "scheduled",
+        description: "Run scheduled",
+        name: "Scheduled review",
+        subagent_type: "general-purpose",
+        schedule: "1h",
+      },
+      undefined,
+      undefined,
+      ctx,
+    );
+
+    const stored = JSON.parse(
+      readFileSync(join(cwd, ".pi", "subagent-schedules", "session-1.json"), "utf-8"),
+    );
+    expect(stored.jobs[0].sessionName).toBe("Scheduled review");
+    expect(runAgent).not.toHaveBeenCalled();
+
+    await lifecycle.get("session_shutdown")?.({}, ctx);
+  });
+});


### PR DESCRIPTION
## Summary

- add an optional `name` parameter to the `Agent` tool
- use it for foreground and background subagent sessions while preserving the short agent-ID suffix
- persist it with scheduled jobs and apply it when those jobs fire
- trim caller input and fall back to the configured agent name/type when it is empty

## Motivation

Descriptions are intentionally short task summaries, but callers may need stable, human-readable session labels for persisted subagent runs. A separate name lets orchestrators label sessions without changing the task description shown in the UI.

## Testing

- `npm run lint`
- `npm run typecheck`
- `npm run test` (738 passed, 5 skipped)
- `npm run build`
