### PR TITLE
fix(ui): hide inactive FleetView roster

### DIFF
--- a/src/ui/fleet-list.ts
+++ b/src/ui/fleet-list.ts
@@ -337,15 +337,14 @@ export class FleetList {
   // ---- Rendering ----
 
   private renderBar(width: number, theme: Theme): string[] {
+    if (!this.active || this.viewerClose || !this.editorHasFocus()) return [];
     const agents = this.roster().slice(1) as AgentEntry[];
     if (agents.length === 0) return [];
     // Clamp locally so a render between a roster shrink and the next update()
     // (e.g. on terminal resize) never loses the selection marker.
     const sel = Math.min(this.selectedIndex, agents.length);
 
-    const hint = this.active
-      ? "↑↓ select · enter view · esc back"
-      : "esc to interrupt · ← for agents · ↓ to manage";
+    const hint = "↑↓ select · enter view · esc back";
     const lines: string[] = [];
     lines.push(truncateToWidth("  " + theme.fg("dim", hint), width));
     lines.push("");

--- a/src/ui/fleet-list.ts
+++ b/src/ui/fleet-list.ts
@@ -46,6 +46,7 @@ export type FleetUICtx = {
 type MainEntry = { kind: "main" };
 type AgentEntry = { kind: "agent"; record: AgentRecord };
 type FleetEntry = MainEntry | AgentEntry;
+type FleetTUI = { focusedComponent?: unknown; requestRender(force?: boolean): void };
 
 /** `11s` — integer seconds, no decimal/suffix (matches Claude Code, unlike formatMs). */
 export function formatFleetElapsed(ms: number): string {
@@ -76,8 +77,9 @@ function rightAlign(left: string, right: string, width: number): string {
 
 export class FleetList {
   private ui: FleetUICtx | undefined;
-  private tui: any | undefined;
+  private tui: FleetTUI | undefined;
   private inputUnsub: (() => void) | undefined;
+  private pendingOpen: ReturnType<typeof setImmediate> | undefined;
   private widgetRegistered = false;
   private timer: ReturnType<typeof setInterval> | undefined;
 
@@ -89,6 +91,7 @@ export class FleetList {
   /** Set while a conversation overlay is open; calling it closes the overlay. */
   private viewerClose: (() => void) | undefined;
   private viewingAgentId: string | undefined;
+  private restoreActiveAfterViewer = false;
 
   constructor(
     private manager: AgentManager,
@@ -100,13 +103,17 @@ export class FleetList {
   setEnabled(enabled: boolean): void {
     if (enabled === this.enabled) return;
     this.enabled = enabled;
-    if (!enabled) this.active = false;
+    if (!enabled) {
+      this.active = false;
+      this.cancelPendingOpen();
+    }
     this.update();
   }
 
   /** Capture the UI context and (re)register the global input handler. */
   setUICtx(ui: FleetUICtx): void {
     if (ui === this.ui) return;
+    this.cancelPendingOpen();
     this.inputUnsub?.();
     this.ui = ui;
     this.widgetRegistered = false;
@@ -128,6 +135,7 @@ export class FleetList {
   }
 
   dispose(): void {
+    this.cancelPendingOpen();
     if (this.timer) { clearInterval(this.timer); this.timer = undefined; }
     this.inputUnsub?.();
     this.inputUnsub = undefined;
@@ -293,30 +301,48 @@ export class FleetList {
     }
     const session = record.session;
     const activity = this.agentActivity.get(record.id);
+    const ui = this.ui;
+    this.cancelPendingOpen();
+    this.restoreActiveAfterViewer = this.active;
     this.viewingAgentId = record.id;
+    this.deactivate();
+    this.tui?.requestRender(true);
 
-    void this.ui.custom<undefined>(
-      (tui, theme, keybindings, done) => {
-        this.viewerClose = () => done(undefined);
-        return new ConversationViewer(
-          tui,
-          session,
-          record,
-          activity,
-          theme,
-          done,
-          () => {
-            if (this.manager.abort(record.id)) this.ui?.notify(`Stopped "${record.description}".`, "info");
-          },
-          keybindings,
-          (message: string) => this.manager.steer(record.id, message),
-        );
-      },
-      {
-        overlay: true,
-        overlayOptions: { anchor: "center", width: "90%", maxHeight: `${VIEWPORT_HEIGHT_PCT}%` },
-      },
-    ).then(() => this.clearViewer(), () => this.clearViewer());
+    this.pendingOpen = setImmediate(() => {
+      this.pendingOpen = undefined;
+      if (this.ui !== ui || this.viewerClose || this.viewingAgentId !== record.id) return;
+
+      void ui.custom<undefined>(
+        (tui, theme, keybindings, done) => {
+          this.viewerClose = () => done(undefined);
+          return new ConversationViewer(
+            tui,
+            session,
+            record,
+            activity,
+            theme,
+            done,
+            () => {
+              if (this.manager.abort(record.id)) this.ui?.notify(`Stopped "${record.description}".`, "info");
+            },
+            keybindings,
+            (message: string) => this.manager.steer(record.id, message),
+          );
+        },
+        {
+          overlay: true,
+          overlayOptions: { anchor: "center", width: "90%", maxHeight: `${VIEWPORT_HEIGHT_PCT}%` },
+        },
+      ).then(() => this.clearViewer(), () => this.clearViewer());
+    });
+  }
+
+  private cancelPendingOpen(): void {
+    if (!this.pendingOpen) return;
+    clearImmediate(this.pendingOpen);
+    this.pendingOpen = undefined;
+    this.viewingAgentId = undefined;
+    this.restoreActiveAfterViewer = false;
   }
 
   /** Reset overlay state and return to the list (on close, auto-close, or error). */
@@ -331,6 +357,8 @@ export class FleetList {
     }
     this.viewerClose = undefined;
     this.viewingAgentId = undefined;
+    this.active = this.restoreActiveAfterViewer;
+    this.restoreActiveAfterViewer = false;
     this.update();
   }
 

--- a/test/fleet-list.test.ts
+++ b/test/fleet-list.test.ts
@@ -57,6 +57,10 @@ interface Harness {
   setEditorText: (t: string) => void;
   /** Whether an overlay has been opened. */
   overlayOpened: () => boolean;
+  /** Lifecycle transitions recorded by the fake TUI/UI. */
+  transitions: () => string[];
+  /** Whether the replacement UI's custom overlay was opened. */
+  replaceUICtx: () => () => boolean;
   /** Whether the most recently opened overlay's `done` was invoked (closed). */
   overlayClosed: () => boolean;
   /** Simulate the viewer closing itself (Esc → done); flushes the close microtask. */
@@ -73,7 +77,11 @@ function harness(agents: AgentRecord[]): Harness {
   let closed = false;
   let overlayDone: ((r: undefined) => void) | undefined;
   let overlayComponent: { handleInput(data: string): void } | undefined;
-  const fakeTui = { requestRender: () => {}, terminal: { columns: 120, rows: 40 } };
+  const lifecycle: string[] = [];
+  const fakeTui = {
+    requestRender: (force?: boolean) => lifecycle.push(`request-render:${force === true}`),
+    terminal: { columns: 120, rows: 40 },
+  };
 
   const ui: FleetUICtx = {
     setWidget: (_key, content) => { widgetFactory = content as any; },
@@ -81,6 +89,7 @@ function harness(agents: AgentRecord[]): Harness {
     getEditorText: () => editorText,
     notify: () => {},
     custom: ((factory: any) => {
+      lifecycle.push("overlay-open");
       opened = true;
       return new Promise<undefined>((resolve) => {
         const done = (r: undefined) => { closed = true; overlayDone = undefined; resolve(r); };
@@ -106,6 +115,20 @@ function harness(agents: AgentRecord[]): Harness {
     render: (width = 120) => (widgetFactory ? widgetFactory(fakeTui, theme).render(width) : []),
     setEditorText: (t) => { editorText = t; },
     overlayOpened: () => opened,
+    transitions: () => lifecycle,
+    replaceUICtx: () => {
+      let replacementOpened = false;
+      const replacementUi: FleetUICtx = {
+        ...ui,
+        onTerminalInput: () => () => {},
+        custom: (() => {
+          replacementOpened = true;
+          return new Promise<undefined>(() => {});
+        }) as FleetUICtx["custom"],
+      };
+      fleet.setUICtx(replacementUi);
+      return () => replacementOpened;
+    },
     overlayClosed: () => closed,
     closeOverlay: async () => { overlayDone?.(undefined); await Promise.resolve(); },
     widgetTui: fakeTui,
@@ -396,6 +419,56 @@ describe("FleetList overlay lifecycle", () => {
     expect(h.render()).toEqual([]);
   });
 
+  it("renders the base UI before opening the selected viewer", async () => {
+    const h = harness([makeRecord({ id: "live" })]);
+    h.press(DOWN); // activate (main)
+    h.render(); // hand FleetList the TUI so force-render requests are observable
+    h.press(DOWN); // select the agent
+    h.transitions().length = 0;
+
+    h.press(ENTER);
+    expect(h.overlayOpened()).toBe(false); // opening must be deferred
+
+    await new Promise<void>(resolve => setImmediate(resolve));
+    expect(h.transitions().indexOf("request-render:true")).toBeGreaterThanOrEqual(0);
+    expect(h.transitions().indexOf("request-render:true")).toBeLessThan(h.transitions().indexOf("overlay-open"));
+    expect(h.overlayOpened()).toBe(true);
+  });
+
+  it("cancels a pending viewer on dispose", async () => {
+    const h = harness([makeRecord({ id: "live" })]);
+    h.press(DOWN); // activate (main)
+    h.press(DOWN); // select the agent
+    h.press(ENTER);
+    h.fleet.dispose();
+
+    await new Promise<void>(resolve => setImmediate(resolve));
+    expect(h.overlayOpened()).toBe(false);
+  });
+
+  it("cancels a pending viewer when FleetView is disabled", async () => {
+    const h = harness([makeRecord({ id: "live" })]);
+    h.press(DOWN); // activate (main)
+    h.press(DOWN); // select the agent
+    h.press(ENTER);
+    h.fleet.setEnabled(false);
+
+    await new Promise<void>(resolve => setImmediate(resolve));
+    expect(h.overlayOpened()).toBe(false);
+  });
+
+  it("cancels a pending viewer when the UI context is replaced", async () => {
+    const h = harness([makeRecord({ id: "live" })]);
+    h.press(DOWN); // activate (main)
+    h.press(DOWN); // select the agent
+    h.press(ENTER);
+    const replacementOpened = h.replaceUICtx();
+
+    await new Promise<void>(resolve => setImmediate(resolve));
+    expect(h.overlayOpened()).toBe(false);
+    expect(replacementOpened()).toBe(false);
+  });
+
   it("keeps the cursor on the viewed agent after closing, even if the list reordered", async () => {
     const fakeSession = { subscribe: () => () => {}, messages: [] };
     const agents = [
@@ -407,7 +480,8 @@ describe("FleetList overlay lifecycle", () => {
     h.press(DOWN); // activate (main, idx 0)
     h.press(DOWN); // a1 (idx 1)
     h.press(DOWN); // a2 (idx 2)
-    h.press(ENTER); // open a2
+    h.press(ENTER); // schedule a2
+    await new Promise<void>(resolve => setImmediate(resolve));
     // a1 finishes and drops out while viewing → a2 shifts from idx 2 to idx 1.
     agents.splice(0, 1);
     await h.closeOverlay();
@@ -416,12 +490,13 @@ describe("FleetList overlay lifecycle", () => {
     expect(h.render().find(l => l.includes("three"))).toContain("○");
   });
 
-  it("wires the viewer's steer composer to manager.steer with the agent id", () => {
+  it("wires the viewer's steer composer to manager.steer with the agent id", async () => {
     const agents = [makeRecord({ id: "live", description: "the one" })];
     const h = harness(agents);
     h.press(DOWN);  // activate (main)
     h.press(DOWN);  // → the agent
-    h.press(ENTER); // open the conversation viewer
+    h.press(ENTER); // schedule the conversation viewer
+    await new Promise<void>(resolve => setImmediate(resolve));
 
     const viewer = h.overlayComponent();
     expect(viewer).toBeDefined();
@@ -437,7 +512,8 @@ describe("FleetList overlay lifecycle", () => {
     const h = harness(agents);
     h.press(DOWN); // active (main)
     h.press(DOWN); // → the agent
-    h.press(ENTER); // opens overlay
+    h.press(ENTER); // schedules overlay
+    await new Promise<void>(resolve => setImmediate(resolve));
     expect(h.overlayOpened()).toBe(true);
     // The agent finishes, well past the linger window...
     agents[0] = makeRecord({ id: "live", description: "the one", status: "completed", completedAt: Date.now() - 60_000 });

--- a/test/fleet-list.test.ts
+++ b/test/fleet-list.test.ts
@@ -148,6 +148,17 @@ describe("FleetList navigation", () => {
     expect(output).not.toContain("nested-child");
   });
 
+  it("keeps the roster hidden until selection is active", () => {
+    const h = harness([makeRecord()]);
+    expect(h.render()).toEqual([]);
+
+    h.press(DOWN);
+    expect(h.render().some(l => l.includes("enter view"))).toBe(true);
+
+    h.press(ESC);
+    expect(h.render()).toEqual([]);
+  });
+
   it("activates on ↓ at an empty prompt, consuming the key", () => {
     const h = harness([makeRecord()]);
     const res = h.press(DOWN);
@@ -165,6 +176,7 @@ describe("FleetList navigation", () => {
     const h = harness([makeRecord()]);
     h.setEditorText("hello");
     expect(h.press(DOWN)).toBeUndefined();
+    expect(h.render()).toEqual([]);
   });
 
   it("ignores key-release events so one tap moves exactly one row", () => {
@@ -200,22 +212,21 @@ describe("FleetList navigation", () => {
     const h = harness([makeRecord()]);
     h.press(DOWN); // activate, index 0
     expect(h.press(UP)).toEqual({ consume: true });
-    // back to inactive hint
-    expect(h.render().some(l => l.includes("← for agents"))).toBe(true);
+    expect(h.render()).toEqual([]);
   });
 
   it("Esc deactivates", () => {
     const h = harness([makeRecord()]);
     h.press(DOWN);
     expect(h.press(ESC)).toEqual({ consume: true });
-    expect(h.render().some(l => l.includes("← for agents"))).toBe(true);
+    expect(h.render()).toEqual([]);
   });
 
   it("passes non-nav keys through and cancels navigation", () => {
     const h = harness([makeRecord()]);
     h.press(DOWN);
     expect(h.press(RIGHT)).toBeUndefined();
-    expect(h.render().some(l => l.includes("← for agents"))).toBe(true);
+    expect(h.render()).toEqual([]);
   });
 
   it("ignores all input while disabled and hides the widget", () => {
@@ -281,11 +292,11 @@ describe("FleetList vs other focused components (#123)", () => {
     focusInHarness(h, realEditor());
     expect(h.press(DOWN)).toEqual({ consume: true }); // activate at the prompt
     focusInHarness(h, { kind: "selector" });          // a dialog takes focus
+    expect(h.render()).toEqual([]);
     expect(h.press(DOWN)).toBeUndefined();
     expect(h.press(ENTER)).toBeUndefined();
     expect(h.press(ESC)).toBeUndefined();
-    // and the list dropped back to its inactive hint
-    expect(h.render().some(l => l.includes("← for agents"))).toBe(true);
+    expect(h.render()).toEqual([]);
   });
 
   it("still activates when the prompt editor has focus", () => {
@@ -304,9 +315,10 @@ describe("FleetList vs other focused components (#123)", () => {
 describe("FleetList rendering", () => {
   it("renders main + agent rows with markers, type, description and right-aligned stats", () => {
     const h = harness([makeRecord({ description: "Sleep then report 1" })]);
+    h.press(DOWN);
     const lines = h.render(120);
     // hint + blank + main + one agent
-    expect(lines[0]).toContain("← for agents");
+    expect(lines[0]).toContain("enter view");
     expect(lines.find(l => l.includes("main"))).toContain("●"); // main selected by default
     const agentLine = lines.find(l => l.includes("Sleep then report 1"))!;
     expect(agentLine).toContain("○");
@@ -320,7 +332,9 @@ describe("FleetList rendering", () => {
       makeRecord({ id: "new", description: "newest", startedAt: 2000 }),
       makeRecord({ id: "old", description: "oldest", startedAt: 1000 }),
     ];
-    const lines = harness(agents).render();
+    const h = harness(agents);
+    h.press(DOWN);
+    const lines = h.render();
     const oldIdx = lines.findIndex(l => l.includes("oldest"));
     const newIdx = lines.findIndex(l => l.includes("newest"));
     expect(oldIdx).toBeGreaterThanOrEqual(0);
@@ -332,7 +346,9 @@ describe("FleetList rendering", () => {
       makeRecord({ id: "live", description: "running one" }),
       makeRecord({ id: "pending", description: "queued one", status: "queued", session: undefined }),
     ];
-    const lines = harness(agents).render();
+    const h = harness(agents);
+    h.press(DOWN);
+    const lines = h.render();
     expect(lines.some(l => l.includes("running one"))).toBe(true);
     expect(lines.some(l => l.includes("queued one"))).toBe(false);
   });
@@ -341,6 +357,7 @@ describe("FleetList rendering", () => {
     const agents = Array.from({ length: 8 }, (_, i) =>
       makeRecord({ id: `a${i}`, description: `report ${i}` }));
     const h = harness(agents);
+    h.press(DOWN);
     const lines = h.render(120);
     // 8 agents, cap 5 visible → "↓ 3 more"
     expect(lines.some(l => l.includes("↓ 3 more"))).toBe(true);
@@ -376,7 +393,7 @@ describe("FleetList overlay lifecycle", () => {
     h.press(DOWN); // active, index 0 (main)
     h.press(ENTER);
     expect(h.overlayOpened()).toBe(false); // never opened an overlay
-    expect(h.render().some(l => l.includes("← for agents"))).toBe(true);
+    expect(h.render()).toEqual([]);
   });
 
   it("keeps the cursor on the viewed agent after closing, even if the list reordered", async () => {
@@ -415,7 +432,7 @@ describe("FleetList overlay lifecycle", () => {
     expect(h.manager.steer).toHaveBeenCalledWith("live", "go left");
   });
 
-  it("does NOT auto-close when the viewed agent finishes (final output stays readable)", () => {
+  it("does NOT auto-close when the viewed agent finishes (final output stays readable)", async () => {
     const agents = [makeRecord({ id: "live", description: "the one" })];
     const h = harness(agents);
     h.press(DOWN); // active (main)
@@ -425,14 +442,22 @@ describe("FleetList overlay lifecycle", () => {
     // The agent finishes, well past the linger window...
     agents[0] = makeRecord({ id: "live", description: "the one", status: "completed", completedAt: Date.now() - 60_000 });
     h.fleet.onAgentFinished("live");
-    expect(h.overlayClosed()).toBe(false);                          // viewer stays open
-    expect(h.render().some(l => l.includes("the one"))).toBe(true); // and stays listed while viewed
+    expect(h.overlayClosed()).toBe(false); // viewer stays open
+    expect(h.render()).toEqual([]);        // roster stays hidden while it cannot be selected
+
+    await h.closeOverlay();
+    expect(h.render()).toEqual([]);
   });
 
   it("lingers a finished agent in the list, then drops it after the window", () => {
     const recent = makeRecord({ id: "r", description: "recent done", status: "completed", completedAt: Date.now() });
-    expect(harness([recent]).render().some(l => l.includes("recent done"))).toBe(true);
+    const recentHarness = harness([recent]);
+    recentHarness.press(DOWN);
+    expect(recentHarness.render().some(l => l.includes("recent done"))).toBe(true);
+
     const old = makeRecord({ id: "o", description: "old done", status: "completed", completedAt: Date.now() - 60_000 });
-    expect(harness([old]).render().some(l => l.includes("old done"))).toBe(false);
+    const oldHarness = harness([old]);
+    oldHarness.press(DOWN);
+    expect(oldHarness.render().some(l => l.includes("old done"))).toBe(false);
   });
 });

--- a/test/fleet-list.test.ts
+++ b/test/fleet-list.test.ts
@@ -166,6 +166,8 @@ describe("FleetList navigation", () => {
       makeRecord({ id: "top", description: "top-level" }),
       makeRecord({ id: "nested", description: "nested-child", parentAgentId: "top" }),
     ]);
+    // Roster stays collapsed until selection is active (#169).
+    h.press(DOWN);
     const output = h.render().join("\n");
     expect(output).toContain("top-level");
     expect(output).not.toContain("nested-child");


### PR DESCRIPTION
## Summary

- hide the below-editor FleetView roster whenever it is not actively selectable
- show it after `Down` or `Left` activates selection at an empty prompt
- keep it hidden while the conversation viewer owns input

## Testing

- `npm run lint`
- `npm run typecheck`
- `npm run test`
