### PR TITLE
fix: shut down child sessions before disposal

### DIFF
--- a/src/agent-manager.ts
+++ b/src/agent-manager.ts
@@ -24,6 +24,28 @@ export type CompactionInfo = { reason: "manual" | "threshold" | "overflow"; toke
 /** Default max concurrent background agents. */
 const DEFAULT_MAX_CONCURRENT = 4;
 
+/** Shut down and dispose every child session, logging failures after all settle. */
+async function shutdownAgentSessions(sessions: AgentSession[]): Promise<void> {
+  const outcomes = await Promise.allSettled(
+    sessions.map(async (session) => {
+      try {
+        await session.extensionRunner.emit({ type: "session_shutdown", reason: "quit" });
+      } finally {
+        session.dispose();
+      }
+    }),
+  );
+  const failures = outcomes
+    .filter((outcome): outcome is PromiseRejectedResult => outcome.status === "rejected")
+    .map((outcome) => outcome.reason);
+  if (failures.length > 0) {
+    console.warn(
+      `[pi-subagents] Failed to shut down ${failures.length} child agent session(s):`,
+      failures,
+    );
+  }
+}
+
 /**
  * Validate a caller-supplied SpawnOptions.cwd. `undefined`/`null` mean "unset"
  * (parent cwd). Anything else must be an absolute path to an existing
@@ -124,7 +146,11 @@ export class AgentManager {
     this.onCompact = onCompact;
     this.maxConcurrent = maxConcurrent;
     // Cleanup completed agents after 10 minutes (but keep sessions for resume)
-    this.cleanupInterval = setInterval(() => this.cleanup(), 60_000);
+    this.cleanupInterval = setInterval(() => {
+      void this.cleanup().catch((error) => {
+        console.warn("[pi-subagents] Failed to clean up completed agent sessions:", error);
+      });
+    }, 60_000);
     this.cleanupInterval.unref();
   }
 
@@ -535,20 +561,24 @@ export class AgentManager {
     return true;
   }
 
-  /** Dispose a record's session and remove it from the map. */
-  private removeRecord(id: string, record: AgentRecord): void {
-    record.session?.dispose?.();
+  /** Remove a record and transfer ownership of its session to the cleanup caller. */
+  private detachRecordSession(id: string, record: AgentRecord): AgentSession | undefined {
+    const session = record.session;
     record.session = undefined;
     this.agents.delete(id);
+    return session;
   }
 
-  private cleanup() {
+  private async cleanup(): Promise<void> {
     const cutoff = Date.now() - 10 * 60_000;
+    const sessions: AgentSession[] = [];
     for (const [id, record] of this.agents) {
       if (record.status === "running" || record.status === "queued") continue;
       if ((record.completedAt ?? 0) >= cutoff) continue;
-      this.removeRecord(id, record);
+      const session = this.detachRecordSession(id, record);
+      if (session) sessions.push(session);
     }
+    await shutdownAgentSessions(sessions);
   }
 
   /**
@@ -556,13 +586,17 @@ export class AgentManager {
    * Called on session start/switch so tasks from a prior session don't persist.
    * Pass skipUnconsumed=true to preserve records the LLM hasn't read yet
    * (resultConsumed=false) — they will be evicted by the 10-minute cleanup timer instead.
+   * Resolves after every removed child session has completed lifecycle teardown.
    */
-  clearCompleted(skipUnconsumed = false): void {
+  async clearCompleted(skipUnconsumed = false): Promise<void> {
+    const sessions: AgentSession[] = [];
     for (const [id, record] of this.agents) {
       if (record.status === "running" || record.status === "queued") continue;
       if (skipUnconsumed && !record.resultConsumed) continue;
-      this.removeRecord(id, record);
+      const session = this.detachRecordSession(id, record);
+      if (session) sessions.push(session);
     }
+    await shutdownAgentSessions(sessions);
   }
 
   /** Whether any agents are still running or queued. */
@@ -612,20 +646,27 @@ export class AgentManager {
     }
   }
 
-  dispose() {
+  /** Tear down every retained child session, then release manager-owned resources. */
+  async dispose(): Promise<void> {
     clearInterval(this.cleanupInterval);
     // Clear queue
     this.queue = [];
+    const sessions: AgentSession[] = [];
     for (const record of this.agents.values()) {
-      record.session?.dispose();
+      if (record.session) sessions.push(record.session);
+      record.session = undefined;
     }
     this.agents.clear();
-    // Prune any orphaned git worktrees (crash recovery)
-    try { pruneWorktrees(process.cwd()); } catch { /* ignore */ }
-    // Also prune repos that caller-supplied cwds created worktrees in — a clean
-    // exit with in-flight agents would otherwise leave stale registrations there.
-    for (const repo of this.worktreeRepos) {
-      try { pruneWorktrees(repo); } catch { /* ignore */ }
+    try {
+      await shutdownAgentSessions(sessions);
+    } finally {
+      // Prune any orphaned git worktrees (crash recovery)
+      try { pruneWorktrees(process.cwd()); } catch { /* ignore */ }
+      // Also prune repos that caller-supplied cwds created worktrees in — a clean
+      // exit with in-flight agents would otherwise leave stale registrations there.
+      for (const repo of this.worktreeRepos) {
+        try { pruneWorktrees(repo); } catch { /* ignore */ }
+      }
     }
   }
 }

--- a/src/index.ts
+++ b/src/index.ts
@@ -551,7 +551,7 @@ export default function (pi: ExtensionAPI) {
   // bound session_start, so a filtered-out activation never advertises (#142).
   pi.on("session_start", async (_event, ctx) => {
     currentCtx = ctx;
-    manager.clearCompleted(true);
+    await manager.clearCompleted(true);
     // Guard mirrors the `!scheduler.isActive()` pattern below: session_start
     // fires once per activation, but a double-bind must not leak listeners.
     if (!rpcHandle) {
@@ -569,8 +569,8 @@ export default function (pi: ExtensionAPI) {
     if (isSchedulingEnabled() && !scheduler.isActive()) startScheduler(ctx);
   });
 
-  pi.on("session_before_switch", () => {
-    manager.clearCompleted(true);
+  pi.on("session_before_switch", async () => {
+    await manager.clearCompleted(true);
     scheduler.stop();
   });
 
@@ -592,7 +592,7 @@ export default function (pi: ExtensionAPI) {
     for (const timer of pendingNudges.values()) clearTimeout(timer);
     pendingNudges.clear();
     fleet.dispose();
-    manager.dispose();
+    await manager.dispose();
   });
 
   // Live widget: show running agents above editor.

--- a/test/agent-manager.test.ts
+++ b/test/agent-manager.test.ts
@@ -19,7 +19,10 @@ import { runAgent } from "../src/agent-runner.js";
 const mockPi = {} as any;
 const mockCtx = { cwd: "/tmp" } as any;
 
-const mockSession = () => ({ dispose: vi.fn() } as any);
+const mockSession = () => ({
+  extensionRunner: { emit: vi.fn().mockResolvedValue(undefined) },
+  dispose: vi.fn(),
+} as any);
 
 const resolvedRun = () =>
   vi.mocked(runAgent).mockResolvedValue({
@@ -32,9 +35,7 @@ const resolvedRun = () =>
 describe("AgentManager — Bug 1 race condition (resultConsumed vs onComplete)", () => {
   let manager: AgentManager;
 
-  afterEach(() => {
-    manager?.dispose();
-  });
+  afterEach(() => manager?.dispose());
 
   it("reproduces bug: onComplete fires with resultConsumed=false when set after await", async () => {
     let seenConsumed: boolean | undefined;
@@ -182,9 +183,7 @@ describe("AgentManager — spawnAndWait onSpawned + foreground output file wirin
 describe("AgentManager — completion callbacks", () => {
   let manager: AgentManager;
 
-  afterEach(() => {
-    manager?.dispose();
-  });
+  afterEach(() => manager?.dispose());
 
   it("does not let onComplete errors turn a completed agent into a failed run", async () => {
     manager = new AgentManager(() => {
@@ -205,9 +204,7 @@ describe("AgentManager — completion callbacks", () => {
 describe("AgentManager — cleanup timer", () => {
   let manager: AgentManager;
 
-  afterEach(() => {
-    manager?.dispose();
-  });
+  afterEach(() => manager?.dispose());
 
   it("does not keep the process alive on its own", () => {
     manager = new AgentManager();
@@ -216,12 +213,104 @@ describe("AgentManager — cleanup timer", () => {
   });
 });
 
+describe("AgentManager — child session shutdown", () => {
+  let manager: AgentManager;
+
+  afterEach(() => manager?.dispose());
+
+  it("awaits session_shutdown before disposing a child session", async () => {
+    const events: string[] = [];
+    let releaseShutdown!: () => void;
+    const shutdownGate = new Promise<void>((resolve) => {
+      releaseShutdown = resolve;
+    });
+    const session = {
+      extensionRunner: {
+        emit: vi.fn(async () => {
+          events.push("shutdown:start");
+          await shutdownGate;
+          events.push("shutdown:end");
+        }),
+      },
+      dispose: vi.fn(() => events.push("dispose")),
+    };
+    vi.mocked(runAgent).mockResolvedValue({
+      responseText: "done",
+      session: session as any,
+      aborted: false,
+      steered: false,
+    });
+    manager = new AgentManager();
+
+    const id = manager.spawn(mockPi, mockCtx, "general-purpose", "test", {
+      description: "test",
+      isBackground: true,
+    });
+    await manager.getRecord(id)!.promise;
+
+    const disposing = manager.dispose();
+    await vi.waitFor(() => expect(session.extensionRunner.emit).toHaveBeenCalledOnce());
+    expect(session.dispose).not.toHaveBeenCalled();
+
+    releaseShutdown();
+    await disposing;
+
+    expect(events).toEqual(["shutdown:start", "shutdown:end", "dispose"]);
+  });
+
+  it("logs a runner emission failure after disposing every child session", async () => {
+    const shutdownError = new Error("bridge close failed");
+    const failedSession = {
+      extensionRunner: { emit: vi.fn().mockRejectedValue(shutdownError) },
+      dispose: vi.fn(),
+    };
+    const healthySession = mockSession();
+    vi.mocked(runAgent)
+      .mockResolvedValueOnce({
+        responseText: "failed runner",
+        session: failedSession as any,
+        aborted: false,
+        steered: false,
+      })
+      .mockResolvedValueOnce({
+        responseText: "healthy runner",
+        session: healthySession,
+        aborted: false,
+        steered: false,
+      });
+    const warn = vi.spyOn(console, "warn").mockImplementation(() => {});
+    manager = new AgentManager();
+
+    const failedId = manager.spawn(mockPi, mockCtx, "general-purpose", "test", {
+      description: "failed runner",
+      isBackground: true,
+    });
+    const healthyId = manager.spawn(mockPi, mockCtx, "general-purpose", "test", {
+      description: "healthy runner",
+      isBackground: true,
+    });
+    await Promise.all([
+      manager.getRecord(failedId)!.promise,
+      manager.getRecord(healthyId)!.promise,
+    ]);
+
+    await manager.dispose();
+
+    expect(failedSession.dispose).toHaveBeenCalledOnce();
+    expect(healthySession.extensionRunner.emit).toHaveBeenCalledOnce();
+    expect(healthySession.dispose).toHaveBeenCalledOnce();
+    expect(warn).toHaveBeenCalledWith(
+      "[pi-subagents] Failed to shut down 1 child agent session(s):",
+      [shutdownError],
+    );
+    warn.mockRestore();
+  });
+});
+
 describe("AgentManager — Bug 3 clearCompleted", () => {
   let manager: AgentManager;
 
-  afterEach(() => {
-    manager?.dispose();
-  });
+  afterEach(() => manager?.dispose());
 
   it("clearCompleted removes completed records", async () => {
     manager = new AgentManager();
@@ -234,7 +323,7 @@ describe("AgentManager — Bug 3 clearCompleted", () => {
     await manager.getRecord(id)!.promise;
 
     expect(manager.listAgents()).toHaveLength(1);
-    manager.clearCompleted();
+    await manager.clearCompleted();
     expect(manager.listAgents()).toHaveLength(0);
   });
 
@@ -260,7 +349,7 @@ describe("AgentManager — Bug 3 clearCompleted", () => {
     expect(manager.getRecord(id1)!.status).toBe("running");
     expect(manager.getRecord(id2)!.status).toBe("queued");
 
-    manager.clearCompleted();
+    await manager.clearCompleted();
 
     // Both should still be present
     expect(manager.getRecord(id1)).toBeDefined();
@@ -271,10 +360,17 @@ describe("AgentManager — Bug 3 clearCompleted", () => {
     manager.abort(id2);
   });
 
-  it("clearCompleted calls dispose on sessions of removed records", async () => {
+  it("clearCompleted shuts down extensions before disposing removed sessions", async () => {
     manager = new AgentManager();
-    const disposeSpy = vi.fn();
-    const sess = { dispose: disposeSpy };
+    const events: string[] = [];
+    const sess = {
+      extensionRunner: {
+        emit: vi.fn(async () => {
+          events.push("shutdown");
+        }),
+      },
+      dispose: vi.fn(() => events.push("dispose")),
+    };
     vi.mocked(runAgent).mockResolvedValue({
       responseText: "done",
       session: sess as any,
@@ -288,9 +384,13 @@ describe("AgentManager — Bug 3 clearCompleted", () => {
     });
     await manager.getRecord(id)!.promise;
 
-    manager.clearCompleted();
+    await manager.clearCompleted();
 
-    expect(disposeSpy).toHaveBeenCalledOnce();
+    expect(sess.extensionRunner.emit).toHaveBeenCalledWith({
+      type: "session_shutdown",
+      reason: "quit",
+    });
+    expect(events).toEqual(["shutdown", "dispose"]);
   });
 
   it("clearCompleted removes error and stopped records", async () => {
@@ -304,7 +404,7 @@ describe("AgentManager — Bug 3 clearCompleted", () => {
     await manager.getRecord(id)!.promise;
     expect(manager.getRecord(id)!.status).toBe("error");
 
-    manager.clearCompleted();
+    await manager.clearCompleted();
     expect(manager.getRecord(id)).toBeUndefined();
   });
 
@@ -320,7 +420,7 @@ describe("AgentManager — Bug 3 clearCompleted", () => {
     expect(manager.getRecord(id)!.status).toBe("completed");
     expect(manager.getRecord(id)!.resultConsumed).toBeFalsy();
 
-    manager.clearCompleted(true);
+    await manager.clearCompleted(true);
     expect(manager.getRecord(id)).toBeDefined();
   });
 
@@ -336,7 +436,7 @@ describe("AgentManager — Bug 3 clearCompleted", () => {
     await record.promise;
     record.resultConsumed = true;
 
-    manager.clearCompleted(true);
+    await manager.clearCompleted(true);
     expect(manager.getRecord(id)).toBeUndefined();
   });
 
@@ -355,7 +455,7 @@ describe("AgentManager — Bug 3 clearCompleted", () => {
     // Error records with unread results are also preserved — the LLM should
     // be able to read the error message via get_subagent_result before the
     // record is evicted.
-    manager.clearCompleted(true);
+    await manager.clearCompleted(true);
     expect(manager.getRecord(id)).toBeDefined();
   });
 });
@@ -365,9 +465,7 @@ describe("AgentManager — Bug 3 clearCompleted", () => {
 describe("AgentManager — lifetime usage + compaction count are eagerly initialized", () => {
   let manager: AgentManager;
 
-  afterEach(() => {
-    manager?.dispose();
-  });
+  afterEach(() => manager?.dispose());
 
   it("spawn initializes lifetimeUsage to zeros and compactionCount to 0", () => {
     manager = new AgentManager();
@@ -483,9 +581,7 @@ describe("AgentManager — lifetime usage + compaction count are eagerly initial
 describe("AgentManager — isolation: worktree fails loud, no silent fallback", () => {
   let manager: AgentManager;
 
-  afterEach(() => {
-    manager?.dispose();
-  });
+  afterEach(() => manager?.dispose());
 
   it("spawn() throws when createWorktree returns undefined; no orphan record left behind", async () => {
     const { createWorktree } = await import("../src/worktree.js");
@@ -760,7 +856,7 @@ describe("AgentManager — steer()", () => {
     });
     const id = manager.spawn(mockPi, mockCtx, "X", "p", { description: "r", isBackground: true });
     // Simulate the session becoming ready.
-    captured?.({ steer, dispose: vi.fn() });
+    captured?.({ ...mockSession(), steer });
 
     expect(manager.steer(id, "go left")).toBe(true);
     expect(steer).toHaveBeenCalledWith("go left");

--- a/test/clear-completed-wiring.test.ts
+++ b/test/clear-completed-wiring.test.ts
@@ -71,7 +71,10 @@ const flush = async () => {
 async function spawnCompletedBackgroundAgent(tools: Map<string, any>): Promise<string> {
   vi.mocked(runAgent).mockResolvedValue({
     responseText: "THE-RESULT-PAYLOAD",
-    session: { dispose: vi.fn() } as any,
+    session: {
+      extensionRunner: { emit: vi.fn().mockResolvedValue(undefined) },
+      dispose: vi.fn(),
+    } as any,
     aborted: false,
     steered: false,
   });

--- a/test/fleet-wiring.test.ts
+++ b/test/fleet-wiring.test.ts
@@ -111,7 +111,10 @@ describe("FleetView wiring (real extension lifecycle)", () => {
   it("registers the belowEditor widget once a spawned agent has a session, then clears it on shutdown", async () => {
     vi.mocked(runAgent).mockResolvedValue({
       responseText: "done",
-      session: { dispose: vi.fn() } as any,
+      session: {
+        extensionRunner: { emit: vi.fn().mockResolvedValue(undefined) },
+        dispose: vi.fn(),
+      } as any,
       aborted: false,
       steered: false,
     });

--- a/test/output-transcript-wiring.test.ts
+++ b/test/output-transcript-wiring.test.ts
@@ -73,7 +73,12 @@ describe("output_transcript agent wiring", () => {
     process.chdir(cwd);
     vi.mocked(runAgent).mockImplementation(async (_ctx, _type, _prompt, options) => {
       await Promise.resolve();
-      const session = { messages: [], subscribe: vi.fn(() => vi.fn()), dispose: vi.fn() } as any;
+      const session = {
+        messages: [],
+        subscribe: vi.fn(() => vi.fn()),
+        extensionRunner: { emit: vi.fn().mockResolvedValue(undefined) },
+        dispose: vi.fn(),
+      } as any;
       options.onSessionCreated?.(session);
       return { responseText: "done", session, aborted: false, steered: false };
     });

--- a/test/print-mode.test.ts
+++ b/test/print-mode.test.ts
@@ -73,7 +73,10 @@ describe("print mode background notifications", () => {
   it("ignores stale-context errors from delayed completion nudges", async () => {
     vi.mocked(runAgent).mockResolvedValue({
       responseText: "done",
-      session: { dispose: vi.fn() } as any,
+      session: {
+        extensionRunner: { emit: vi.fn().mockResolvedValue(undefined) },
+        dispose: vi.fn(),
+      } as any,
       aborted: false,
       steered: false,
     });

--- a/test/wait-queued.test.ts
+++ b/test/wait-queued.test.ts
@@ -65,7 +65,10 @@ function deferredRuns() {
         resolvers.push(() =>
           resolve({
             responseText: "THE-RESULT-PAYLOAD",
-            session: { dispose: vi.fn() } as any,
+            session: {
+              extensionRunner: { emit: vi.fn().mockResolvedValue(undefined) },
+              dispose: vi.fn(),
+            } as any,
             aborted: false,
             steered: false,
           }),
@@ -138,7 +141,10 @@ describe("get_subagent_result wait:true on a queued agent", () => {
           childSignal = options.signal;
           resolveRun = () => resolve({
             responseText: "THE-RESULT-PAYLOAD",
-            session: { dispose: vi.fn() } as any,
+            session: {
+              extensionRunner: { emit: vi.fn().mockResolvedValue(undefined) },
+              dispose: vi.fn(),
+            } as any,
             aborted: false,
             steered: false,
           });


### PR DESCRIPTION
## Summary

- emit and await `session_shutdown` before disposing retained child `AgentSession` instances
- apply the teardown contract to timed eviction, `clearCompleted()`, and manager shutdown
- detach records before awaiting teardown so concurrent cleanup paths cannot shut down the same session twice
- finish every child teardown with `Promise.allSettled`; log runner-level failures without blocking sibling or parent lifecycle cleanup

## Problem

`runAgent()` creates a standalone session and binds extensions, but `AgentSession.dispose()` only invalidates the extension context. It does not emit `session_shutdown`. The parent manager therefore discarded retained child sessions without giving child extensions a chance to release timers, transports, or subprocesses.

The unref'd manager interval described in #126 is one symptom. A child extension with a referenced MCP transport can also keep a settled headless process alive indefinitely.

## Design

`AgentManager` already owns child retention for resume and record eviction, so teardown stays private to that module. This mirrors the ordering used by Pi's `AgentSessionRuntime.dispose()` without migrating subagents to the larger runtime/session-replacement interface.

Completed sessions remain available for resume until the existing cleanup conditions remove their records. Production lifecycle handlers now await cleanup before proceeding.

## Verification

- `npm run lint`
- `npm run typecheck`
- `npm run test` — 752 passed, 5 skipped
- `npm run test:e2e` — 47 passed, 5 skipped
- `npm run build`
- real Pi 0.81.1 probe with an auto-connected Xcode MCP child: parent reached `agent_settled`, exited naturally with code 0, and left no process after 3 seconds

Closes #126
