### PR TITLE
fix(ui): track RPC-spawned agent activity

### DIFF
--- a/src/index.ts
+++ b/src/index.ts
@@ -20,7 +20,7 @@ import { AgentManager } from "./agent-manager.js";
 import { getAgentConversation, getDefaultMaxTurns, getGraceTurns, normalizeMaxTurns, SUBAGENT_TOOL_NAMES, setDefaultMaxTurns, setGraceTurns, steerAgent } from "./agent-runner.js";
 import { BUILTIN_TOOL_NAMES, getAgentConfig, getAllTypes, getAvailableTypes, getFallbackSubagent, isDefaultsDisabled, NO_FALLBACK, registerAgents, resolveSpawnType, resolveType, setDefaultsDisabled, setFallbackSubagent } from "./agent-types.js";
 import { inChildSessionContext } from "./child-context.js";
-import { type RpcHandle, registerRpcHandlers } from "./cross-extension-rpc.js";
+import { type RpcHandle, registerRpcHandlers, type SpawnCapable } from "./cross-extension-rpc.js";
 import { loadCustomAgents } from "./custom-agents.js";
 import { GroupJoinManager } from "./group-join.js";
 import { resolveAgentInvocationConfig, resolveJoinMode } from "./invocation-config.js";
@@ -508,6 +508,35 @@ export default function (pi: ExtensionAPI) {
     (globalThis as any)[MANAGER_KEY] = registryEntry;
   }
 
+  // Cross-extension callers such as pi-tasks bypass the Agent tool, so they do
+  // not create its UI activity tracker. Wrap only that programmatic spawn path
+  // with the same callbacks before AgentManager starts the child session.
+  const rpcManager: SpawnCapable = {
+    spawn(piRef, ctxRef, type, prompt, options) {
+      const { state, callbacks } = createActivityTracker(options.maxTurns);
+      // Wrap spawnTopLevel (not raw manager.spawn) so RPC-spawned agents keep
+      // the #164 internal-option sanitization while gaining activity tracking.
+      const id = spawnTopLevel(
+        piRef,
+        ctxRef,
+        type,
+        prompt,
+        { ...options, ...callbacks },
+      );
+      agentActivity.set(id, state);
+      widget.ensureTimer();
+      widget.update();
+      fleet.ensureTimer();
+      fleet.update();
+      return id;
+    },
+    // Preserve the #164 guard: RPC must not abort nested (child) agents.
+    abort: (id) => {
+      const record = manager.getRecord(id);
+      return !record?.parentAgentId && manager.abort(id);
+    },
+  };
+
   // --- Cross-extension RPC via pi.events ---
   let currentCtx: ExtensionContext | undefined;
   // RPC handlers + the `subagents:ready` broadcast are wired on `session_start`
@@ -553,13 +582,7 @@ export default function (pi: ExtensionAPI) {
         events: pi.events,
         pi,
         getCtx: () => currentCtx,
-        manager: {
-          spawn: spawnTopLevel,
-          abort: (id) => {
-            const record = manager.getRecord(id);
-            return !record?.parentAgentId && manager.abort(id);
-          },
-        },
+        manager: rpcManager,
       });
       // Broadcast readiness so extensions loaded alongside us can discover us.
       // Emitting after all factories have run (rather than at factory time)

--- a/test/rpc-lifecycle-gating.test.ts
+++ b/test/rpc-lifecycle-gating.test.ts
@@ -52,10 +52,16 @@ function makePi() {
   return { pi, tools, lifecycle, busHandlers };
 }
 
-function ctx() {
+function ctx(setWidget = vi.fn()) {
   return {
     hasUI: false,
-    ui: { setStatus: vi.fn(), setWidget: vi.fn(), notify: vi.fn() },
+    ui: {
+      setStatus: vi.fn(),
+      setWidget,
+      notify: vi.fn(),
+      onTerminalInput: vi.fn(() => vi.fn()),
+      getEditorText: vi.fn(() => ""),
+    },
     cwd: process.cwd(),
     model: undefined,
     modelRegistry: { find: vi.fn(), getAvailable: vi.fn(() => []) },
@@ -144,6 +150,43 @@ describe("issue #142: RPC handlers + subagents:ready are gated on session_start"
     expect(reply, "spawn emitted a reply").toBeTruthy();
     expect(reply![1].success, `spawn succeeded, got: ${JSON.stringify(reply![1])}`).toBe(true);
     expect(reply![1].data.id).toBeTruthy();
+  });
+
+  it("shows live tool activity for an RPC-spawned background agent", async () => {
+    const { pi, lifecycle, busHandlers } = makePi();
+    let widgetFactory: any;
+    const setWidget = vi.fn((key: string, content: any) => {
+      if (key === "agents" && content) widgetFactory = content;
+    });
+    const extensionCtx = ctx(setWidget);
+    let onToolActivity: ((activity: { type: "start" | "end"; toolName: string }) => void) | undefined;
+    vi.mocked(runAgent).mockImplementation((_ctx, _type, _prompt, options: any) => {
+      onToolActivity = options.onToolActivity;
+      options.onSessionCreated?.({ subscribe: () => vi.fn() });
+      return new Promise(() => {}) as any;
+    });
+    subagentsExtension(pi);
+
+    await lifecycle.get("session_start")({}, extensionCtx);
+    // TaskExecute runs inside a root tool call, so the extension already has
+    // the UI context before pi-tasks sends its cross-extension spawn request.
+    await lifecycle.get("tool_execution_start")({}, extensionCtx);
+    await busHandlers.get("subagents:rpc:spawn")!({
+      requestId: "req-activity",
+      type: "general-purpose",
+      prompt: "go",
+      options: { description: "rpc activity test", isBackground: true },
+    });
+    await vi.waitFor(() => expect(onToolActivity).toBeTypeOf("function"));
+    onToolActivity!({ type: "start", toolName: "bash" });
+
+    expect(widgetFactory).toBeTypeOf("function");
+    const lines = widgetFactory(
+      { terminal: { columns: 120 }, requestRender: vi.fn() },
+      { fg: (_color: string, text: string) => text, bold: (text: string) => text },
+    ).render().join("\n");
+    expect(lines).toContain("running command…");
+    expect(lines).not.toContain("thinking…");
   });
 
   it("is idempotent — a second session_start does not re-advertise or double-register", async () => {


### PR DESCRIPTION
## Summary

- create the normal live activity tracker for agents spawned through the cross-extension RPC used by `TaskExecute`
- register RPC-spawned activity with the agent widget and FleetView
- add an extension-level regression test covering a running tool being shown instead of a permanent `thinking…` fallback

## Problem

`TaskExecute` starts agents through `subagents:rpc:spawn`, which called `AgentManager.spawn()` directly. Unlike the `Agent` tool path, that path never created an `AgentActivity` tracker or supplied its callbacks.

This produced contradictory UI: the header's tool-use count continued increasing and Conversation Viewer showed real work, while the activity line stayed at `thinking…` for the entire run.

## Fix

The RPC handler now receives a narrow manager wrapper that creates the existing tracker before spawning, composes its callbacks into the spawn options, and registers the returned agent ID with the existing widget/FleetView activity map. Direct `Agent` spawns and scheduled agents remain unchanged.

## Verification

- regression test proved RED before the fix (`thinking…` while a `bash` tool was active)
- `npm run lint`
- `npm run typecheck`
- `npm run test` — 756 passed, 5 skipped
- `npm run build`
- `git diff --check`
