### PR TITLE
fix: steer background completion notifications

### DIFF
--- a/src/index.ts
+++ b/src/index.ts
@@ -327,7 +327,7 @@ export default function (pi: ExtensionAPI) {
       content: notification + footer,
       display: true,
       details: buildNotificationDetails(record, 500, agentActivity.get(record.id)),
-    }, { deliverAs: "followUp", triggerTurn: true });
+    }, { deliverAs: "steer", triggerTurn: true });
   }
 
   function sendIndividualNudge(record: AgentRecord) {
@@ -365,7 +365,7 @@ export default function (pi: ExtensionAPI) {
           content: `Background agent group completed: ${label}\n\n${notifications}\n\nUse get_subagent_result for full output.`,
           display: true,
           details,
-        }, { deliverAs: "followUp", triggerTurn: true });
+        }, { deliverAs: "steer", triggerTurn: true });
       });
       widget.update();
     },

--- a/test/completion-notification-wiring.test.ts
+++ b/test/completion-notification-wiring.test.ts
@@ -1,0 +1,161 @@
+import { afterEach, describe, expect, it, vi } from "vitest";
+import type * as AgentRunnerModule from "../src/agent-runner.js";
+
+vi.mock("../src/agent-runner.js", async () => {
+  const actual = await vi.importActual<typeof AgentRunnerModule>("../src/agent-runner.js");
+  return {
+    ...actual,
+    runAgent: vi.fn(),
+  };
+});
+
+import { runAgent } from "../src/agent-runner.js";
+import subagentsExtension from "../src/index.js";
+
+interface RegisteredTool {
+  name: string;
+  execute: (
+    toolCallId: string,
+    params: Record<string, unknown>,
+    signal: AbortSignal | undefined,
+    onUpdate: undefined,
+    ctx: ReturnType<typeof makeHeadlessCtx>,
+  ) => Promise<unknown>;
+}
+
+function makePi() {
+  const tools = new Map<string, RegisteredTool>();
+  const handlers = new Map<string, (...args: never[]) => unknown>();
+
+  return {
+    pi: {
+      registerMessageRenderer: vi.fn(),
+      registerTool: vi.fn((tool: RegisteredTool) => {
+        tools.set(tool.name, tool);
+      }),
+      registerCommand: vi.fn(),
+      on: vi.fn((event: string, handler: (...args: never[]) => unknown) => {
+        handlers.set(event, handler);
+      }),
+      events: {
+        emit: vi.fn(),
+        on: vi.fn(() => vi.fn()),
+      },
+      appendEntry: vi.fn(),
+      sendMessage: vi.fn(),
+    } as never,
+    tools,
+    handlers,
+  };
+}
+
+function makeHeadlessCtx() {
+  return {
+    hasUI: false,
+    ui: {
+      setStatus: vi.fn(),
+      setWidget: vi.fn(),
+      notify: vi.fn(),
+    },
+    cwd: "/tmp",
+    model: undefined,
+    modelRegistry: {
+      find: vi.fn(),
+      getAvailable: vi.fn(() => []),
+    },
+    sessionManager: {
+      getSessionId: vi.fn(() => "session-1"),
+      getBranch: vi.fn(() => []),
+    },
+    getSystemPrompt: vi.fn(() => "parent prompt"),
+  } as never;
+}
+
+function completedRun() {
+  return {
+    responseText: "done",
+    session: { dispose: vi.fn() },
+    aborted: false,
+    steered: false,
+  } as Awaited<ReturnType<typeof runAgent>>;
+}
+
+async function spawnBackground(
+  tool: RegisteredTool,
+  toolCallId: string,
+  description: string,
+): Promise<void> {
+  await tool.execute(
+    toolCallId,
+    {
+      prompt: "reply done",
+      description,
+      subagent_type: "general-purpose",
+      run_in_background: true,
+    },
+    undefined,
+    undefined,
+    makeHeadlessCtx(),
+  );
+}
+
+describe("background completion notification wiring", () => {
+  afterEach(() => {
+    vi.restoreAllMocks();
+    vi.useRealTimers();
+  });
+
+  it("requests steering for an individual completion after the result-consumption hold", async () => {
+    vi.useFakeTimers();
+    vi.mocked(runAgent).mockResolvedValue(completedRun());
+
+    const { pi, tools, handlers } = makePi();
+    subagentsExtension(pi);
+
+    await spawnBackground(tools.get("Agent")!, "individual-call", "individual child");
+    await vi.advanceTimersByTimeAsync(300); // 100ms smart-batch debounce + 200ms hold
+
+    expect(pi.sendMessage).toHaveBeenCalledTimes(1);
+    expect(pi.sendMessage).toHaveBeenCalledWith(
+      expect.objectContaining({
+        customType: "subagent-notification",
+        content: expect.stringContaining("individual child"),
+      }),
+      { deliverAs: "steer", triggerTurn: true },
+    );
+
+    await handlers.get("session_shutdown")?.();
+  });
+
+  it("requests steering for a grouped completion after the result-consumption hold", async () => {
+    vi.useFakeTimers();
+    vi.mocked(runAgent).mockResolvedValue(completedRun());
+
+    const { pi, tools, handlers } = makePi();
+    subagentsExtension(pi);
+    const agentTool = tools.get("Agent")!;
+
+    await Promise.all([
+      spawnBackground(agentTool, "group-call-1", "first grouped child"),
+      spawnBackground(agentTool, "group-call-2", "second grouped child"),
+    ]);
+    await vi.advanceTimersByTimeAsync(300); // 100ms smart-batch debounce + 200ms group hold
+
+    expect(pi.sendMessage).toHaveBeenCalledTimes(1);
+    expect(pi.sendMessage).toHaveBeenCalledWith(
+      expect.objectContaining({
+        customType: "subagent-notification",
+        content: expect.stringContaining("Background agent group completed"),
+        details: expect.objectContaining({
+          description: expect.stringMatching(/grouped child/),
+          others: expect.arrayContaining([
+            expect.objectContaining({ description: expect.stringMatching(/grouped child/) }),
+          ]),
+        }),
+      }),
+      { deliverAs: "steer", triggerTurn: true },
+    );
+
+    await handlers.get("session_shutdown")?.();
+  });
+});

--- a/test/fixtures/blocking-tool-ext.mjs
+++ b/test/fixtures/blocking-tool-ext.mjs
@@ -1,0 +1,23 @@
+import { Type } from "@sinclair/typebox";
+
+const CONTROL_KEY = Symbol.for("pi-subagents:test:blocking-tool");
+
+export default function (pi) {
+  pi.events.on("subagents:completed", (data) => {
+    globalThis[CONTROL_KEY]?.agentCompleted(data);
+  });
+  pi.registerTool({
+    name: "blocking_tool",
+    label: "Blocking tool",
+    description: "Blocks a test-controlled parent tool batch.",
+    parameters: Type.Object({}),
+    async execute(_toolCallId, _params, signal) {
+      const control = globalThis[CONTROL_KEY];
+      if (!control) throw new Error("blocking tool test control was not installed");
+      control.entered(signal);
+      await control.release;
+      control.completed(signal);
+      return { content: [{ type: "text", text: "blocking tool completed" }] };
+    },
+  });
+}

--- a/test/helpers/print-mode-runner.ts
+++ b/test/helpers/print-mode-runner.ts
@@ -131,6 +131,10 @@ export interface RunPrintModeOptions {
   timeoutMs?: number;
   /** Abort the parent (and forwarded children) externally. */
   signal?: AbortSignal;
+  /** Additional extension paths loaded only for this test run. */
+  extensionPaths?: string[];
+  /** Called once after the real parent session is created and extensions are bound. */
+  onParentSession?: (session: AgentSession, manager: ManagerHandle | undefined) => void;
   /**
    * Force live mode against a specific provider/model (overrides PI_E2E_LIVE).
    * When omitted, live mode is on iff `PI_E2E_LIVE` is truthy. In live mode, if
@@ -335,7 +339,7 @@ export async function runPrintMode(options: RunPrintModeOptions): Promise<PrintM
   const loader = new DefaultResourceLoader({
     cwd,
     agentDir,
-    additionalExtensionPaths: [EXTENSION_PATH],
+    additionalExtensionPaths: [EXTENSION_PATH, ...(options.extensionPaths ?? [])],
     systemPromptOverride: () => options.systemPrompt ?? DEFAULT_SYSTEM_PROMPT,
     appendSystemPromptOverride: () => [],
     noPromptTemplates: true,
@@ -372,6 +376,7 @@ export async function runPrintMode(options: RunPrintModeOptions): Promise<PrintM
   const manager = (globalThis as Record<symbol, unknown>)[MANAGER_KEY] as
     | ManagerHandle
     | undefined;
+  options.onParentSession?.(session, manager);
 
   // --- subagent hold condition (the pi-chonky-step monkey-patch) ---
   // Block the parent agent loop while background subagents are still running, so

--- a/test/steer-scheduling-e2e.test.ts
+++ b/test/steer-scheduling-e2e.test.ts
@@ -130,7 +130,7 @@ describe("background completion steering scheduling", () => {
       new Promise<never>((_, reject) => {
         setTimeout(() => {
           reject(new Error(`blocking tool was not entered; parent=${parentModelCalls} child=${childModelCalls}`));
-        }, 2_000);
+        }, 10_000);
       }),
     ]);
     expect(parentModelCalls).toBe(1);
@@ -138,7 +138,7 @@ describe("background completion steering scheduling", () => {
     await Promise.race([
       backgroundAgentCompleted,
       new Promise<never>((_, reject) => {
-        setTimeout(() => reject(new Error("background completion event was not emitted")), 2_000);
+        setTimeout(() => reject(new Error("background completion event was not emitted")), 10_000);
       }),
     ]);
     expect(completedAgentEvent).toEqual(expect.objectContaining({ description: "background child" }));

--- a/test/steer-scheduling-e2e.test.ts
+++ b/test/steer-scheduling-e2e.test.ts
@@ -115,12 +115,13 @@ describe("background completion steering scheduling", () => {
         return "completion was missing";
       },
       beforeRun: () => {
-        const control = (globalThis as Record<symbol, Record<string, unknown>>)[BLOCKING_TOOL_CONTROL];
+        const control = (globalThis as Record<symbol, Record<string, unknown>>)[BLOCKING_TOOL_CONTROL] ?? {};
         Object.assign(control, {
           entered: (signal: AbortSignal | undefined) => enteredBlockingTool?.(signal),
           release: releaseBlockingTool,
           completed: (signal: AbortSignal | undefined) => completedBlockingTool?.(signal),
         });
+        (globalThis as Record<symbol, Record<string, unknown>>)[BLOCKING_TOOL_CONTROL] = control;
       },
     });
 

--- a/test/steer-scheduling-e2e.test.ts
+++ b/test/steer-scheduling-e2e.test.ts
@@ -1,0 +1,199 @@
+import { mkdtempSync, rmSync } from "node:fs";
+import { tmpdir } from "node:os";
+import { join } from "node:path";
+import { fileURLToPath } from "node:url";
+import type { Context } from "@earendil-works/pi-ai";
+import { afterEach, describe, expect, it, vi } from "vitest";
+import { agentCall, type PrintModeRun, runPrintMode } from "./helpers/print-mode-runner.js";
+
+vi.setConfig({ testTimeout: 30_000 });
+
+const BLOCKING_TOOL_EXTENSION = fileURLToPath(
+  new URL("./fixtures/blocking-tool-ext.mjs", import.meta.url),
+);
+const COMPLETION_MARKER = "BACKGROUND_COMPLETION_VISIBLE";
+const BLOCKING_TOOL_CONTROL = Symbol.for("pi-subagents:test:blocking-tool");
+
+function parentHasCompletion(context: Context): boolean {
+  return context.messages.some(
+    (message) =>
+      message.role === "user" &&
+      message.content.some(
+        (block) => block.type === "text" && block.text.includes(COMPLETION_MARKER),
+      ),
+  );
+}
+
+describe("background completion steering scheduling", () => {
+  let run: PrintModeRun | undefined;
+  let cwd: string | undefined;
+  let releaseBlockedTool: (() => void) | undefined;
+
+  afterEach(async () => {
+    releaseBlockedTool?.();
+    releaseBlockedTool = undefined;
+    await run?.dispose();
+    run = undefined;
+    delete (globalThis as Record<symbol, unknown>)[BLOCKING_TOOL_CONTROL];
+    if (cwd) rmSync(cwd, { recursive: true, force: true });
+    cwd = undefined;
+  });
+
+  it("finishes a blocking tool batch, then delivers the completion before the next model call", async () => {
+    cwd = mkdtempSync(join(tmpdir(), "subagents-steer-scheduling-"));
+
+    let enteredBlockingTool: ((signal: AbortSignal | undefined) => void) | undefined;
+    let completedBlockingTool: ((signal: AbortSignal | undefined) => void) | undefined;
+    let toolSignalAtEntry: AbortSignal | undefined;
+    let toolSignalAtCompletion: AbortSignal | undefined;
+    const blockingToolEntered = new Promise<void>((resolve) => {
+      enteredBlockingTool = (signal) => {
+        toolSignalAtEntry = signal;
+        resolve();
+      };
+    });
+    const blockingToolCompleted = new Promise<void>((resolve) => {
+      completedBlockingTool = (signal) => {
+        toolSignalAtCompletion = signal;
+        resolve();
+      };
+    });
+    const releaseBlockingTool = new Promise<void>((resolve) => {
+      releaseBlockedTool = resolve;
+    });
+    let completedAgentEvent: unknown;
+    const backgroundAgentCompleted = new Promise<void>((resolve) => {
+      completedAgentEvent = undefined;
+      (globalThis as Record<symbol, unknown>)[BLOCKING_TOOL_CONTROL] = {
+        agentCompleted: (data: unknown) => {
+          completedAgentEvent = data;
+          resolve();
+        },
+      };
+    });
+
+    const firstParentCall = agentCall({
+      description: "background child",
+      prompt: "Reply with the completion marker.",
+      run_in_background: true,
+    });
+    const blockingToolCall = {
+      type: "toolCall" as const,
+      id: "blocking-call",
+      name: "blocking_tool",
+      arguments: {},
+    };
+
+    let parentModelCalls = 0;
+    let childModelCalls = 0;
+    const completionVisibleByParentCall: boolean[] = [];
+    let currentParentSession: {
+      isStreaming: boolean;
+      messages: Array<{ role: string; content: unknown }>;
+    } | undefined;
+
+    const runPromise = runPrintMode({
+      cwd,
+      hold: false,
+      extensionPaths: [BLOCKING_TOOL_EXTENSION],
+      prompt: "Start a background child and keep working with a blocking tool.",
+      onParentSession: (session) => {
+        currentParentSession = session;
+      },
+      respond: async (context) => {
+        const isParent = (context.tools ?? []).some((tool) => tool.name === "Agent");
+        if (!isParent) {
+          childModelCalls++;
+          return COMPLETION_MARKER;
+        }
+
+        parentModelCalls++;
+        const completionVisible = parentHasCompletion(context);
+        completionVisibleByParentCall.push(completionVisible);
+        if (completionVisible) return "parent processed the completion";
+        if (parentModelCalls === 1) return [firstParentCall, blockingToolCall];
+        return "completion was missing";
+      },
+      beforeRun: () => {
+        const control = (globalThis as Record<symbol, Record<string, unknown>>)[BLOCKING_TOOL_CONTROL];
+        Object.assign(control, {
+          entered: (signal: AbortSignal | undefined) => enteredBlockingTool?.(signal),
+          release: releaseBlockingTool,
+          completed: (signal: AbortSignal | undefined) => completedBlockingTool?.(signal),
+        });
+      },
+    });
+
+    await Promise.race([
+      blockingToolEntered,
+      new Promise<never>((_, reject) => {
+        setTimeout(() => {
+          reject(new Error(`blocking tool was not entered; parent=${parentModelCalls} child=${childModelCalls}`));
+        }, 2_000);
+      }),
+    ]);
+    expect(parentModelCalls).toBe(1);
+
+    await Promise.race([
+      backgroundAgentCompleted,
+      new Promise<never>((_, reject) => {
+        setTimeout(() => reject(new Error("background completion event was not emitted")), 2_000);
+      }),
+    ]);
+    expect(completedAgentEvent).toEqual(expect.objectContaining({ description: "background child" }));
+    await new Promise((resolve) => setTimeout(resolve, 350));
+    expect(childModelCalls).toBe(1);
+    expect(parentModelCalls).toBe(1);
+    expect(currentParentSession?.isStreaming).toBe(true);
+    expect(currentParentSession?.messages.some((message) =>
+      message.role === "custom" && JSON.stringify(message.content).includes(COMPLETION_MARKER)
+    )).toBe(false);
+
+    expect(toolSignalAtEntry?.aborted).toBe(false);
+    releaseBlockedTool?.();
+    releaseBlockedTool = undefined;
+    await blockingToolCompleted;
+
+    run = await runPromise;
+
+    expect(toolSignalAtCompletion?.aborted).toBe(false);
+    expect(completionVisibleByParentCall[1]).toBe(true);
+    expect(parentModelCalls).toBeGreaterThanOrEqual(2);
+    expect(childModelCalls).toBe(1);
+  });
+
+  it("starts an idle parent turn when a completion is delivered with triggerTurn", async () => {
+    let sendCompletion: (() => Promise<void>) | undefined;
+    let parentCalls = 0;
+    let completionWasVisible = false;
+
+    run = await runPrintMode({
+      hold: false,
+      prompt: "Answer once, then wait for a completion notification.",
+      onParentSession: (session) => {
+        sendCompletion = () => session.sendCustomMessage(
+          {
+            customType: "subagent-notification",
+            content: COMPLETION_MARKER,
+            display: true,
+          },
+          { deliverAs: "steer", triggerTurn: true },
+        );
+      },
+      respond: (context) => {
+        parentCalls++;
+        completionWasVisible = parentHasCompletion(context);
+        return completionWasVisible ? "processed idle completion" : "initial answer";
+      },
+    });
+
+    expect(parentCalls).toBe(1);
+    expect(completionWasVisible).toBe(false);
+
+    await sendCompletion?.();
+    await run.parentSession.waitForIdle();
+
+    expect(parentCalls).toBe(2);
+    expect(completionWasVisible).toBe(true);
+  });
+});


### PR DESCRIPTION
## Summary

- deliver individual and grouped background completions through Pi's steering queue
- retain `triggerTurn: true` so idle parents still process completions without user input
- cover extension wiring plus active/idle scheduling through a real headless Pi session

## Behavior

While the parent is active, Pi now exposes a completed child after the current assistant turn's complete tool batch and before the next model call. Already-running tools are not aborted.

This follows the behavior used by `nicobailon/pi-subagents`, whose completion notifier leaves `deliverAs` at Pi's default `steer` mode while setting `triggerTurn`.

There is an explicit policy trade-off with the related proposals:

- #185 / #186 prioritize suppressing notifications for results consumed before delivery by holding them until `agent_settled`.
- #61 prioritizes a later user-initiated turn so `before_agent_start` hooks run.
- This PR prioritizes prompt delivery to a continuously active parent. Once Pi has accepted a steering message, a later same-turn `get_subagent_result` cannot retract it.

The maintainer can choose which guarantee the extension should provide; this PR keeps the alternatives separate rather than combining their lifecycle models.

Closes #188.

Related: #14, #61, #185, #186.

## Tests

- `npx vitest run test/completion-notification-wiring.test.ts test/steer-scheduling-e2e.test.ts`
- `npm run lint`
- `npm run typecheck`
- `npm run test` — 759 passed, 5 skipped
- `npm run build`
- `git diff --check upstream/master...HEAD`

The active-parent test waits for the public `subagents:completed` event while a controlled parent tool remains blocked, verifies the notification is not injected during that tool batch and the tool is not aborted, then verifies the immediately following parent model call sees the completion.