### PR TITLE
fix(ui): render Agent tool errors verbatim

### DIFF
--- a/src/index.ts
+++ b/src/index.ts
@@ -969,10 +969,19 @@ Terse command-style prompts produce shallow, generic work.
       return new Text("▸ " + theme.fg("toolTitle", theme.bold(displayName)) + (desc ? "  " + theme.fg("muted", desc) : ""), 0, 0);
     },
 
-    renderResult(result, { expanded, isPartial }, theme) {
+    renderResult(result, { expanded, isPartial }, theme, renderContext) {
       const details = result.details as AgentDetails | undefined;
-      if (!details) {
-        const text = result.content[0]?.type === "text" ? result.content[0].text : "";
+      const text = result.content[0]?.type === "text" ? result.content[0].text : "";
+      const knownStatuses = new Set<AgentDetails["status"]>([
+        "running",
+        "background",
+        "completed",
+        "steered",
+        "stopped",
+        "error",
+        "aborted",
+      ]);
+      if (renderContext.isError || !details || !knownStatuses.has(details.status)) {
         return new Text(text, 0, 0);
       }
 

--- a/test/agent-tool-error-rendering.test.ts
+++ b/test/agent-tool-error-rendering.test.ts
@@ -1,0 +1,59 @@
+import { describe, expect, it, vi } from "vitest";
+import subagentsExtension from "../src/index.js";
+
+function agentTool() {
+  const tools = new Map<string, any>();
+  const pi = {
+    registerMessageRenderer: vi.fn(),
+    registerTool: vi.fn((tool: any) => tools.set(tool.name, tool)),
+    registerCommand: vi.fn(),
+    on: vi.fn(),
+    events: { emit: vi.fn(), on: vi.fn(() => vi.fn()) },
+    appendEntry: vi.fn(),
+    sendMessage: vi.fn(),
+  } as any;
+  subagentsExtension(pi);
+  return tools.get("Agent");
+}
+
+const theme = {
+  fg: (_color: string, text: string) => text,
+  bold: (text: string) => text,
+} as any;
+
+function render(tool: any, result: any): string {
+  return tool.renderResult(
+    { content: result.content, details: result.details },
+    { expanded: false, isPartial: false },
+    theme,
+    { isError: result.isError },
+  ).render(120).join("\n");
+}
+
+describe("Agent tool invocation error rendering", () => {
+  it("shows a Pi tool error instead of structured terminal status", () => {
+    const output = render(agentTool(), {
+      content: [{ type: "text", text: 'Cannot run with isolation: "worktree" — Git probe failed.' }],
+      isError: true,
+      details: { status: "aborted" },
+    });
+
+    expect(output).toContain('Cannot run with isolation: "worktree" — Git probe failed.');
+    expect(output).not.toContain("Aborted (max turns exceeded)");
+  });
+
+  it.each([
+    ["missing details", undefined],
+    ["empty details", {}],
+    ["unknown status", { status: "unknown" }],
+  ])("shows the real result text for %s", (_name, details) => {
+    const output = render(agentTool(), {
+      content: [{ type: "text", text: "Unstructured Agent result." }],
+      isError: false,
+      details,
+    });
+
+    expect(output).toContain("Unstructured Agent result.");
+    expect(output).not.toContain("Aborted (max turns exceeded)");
+  });
+});


### PR DESCRIPTION
## Summary

- render Agent invocation/tool errors from Pi's public `ToolRenderContext.isError` as their actual result text
- fall back to result text when renderer details are missing, empty, or carry an unknown status
- preserve structured rendering for valid Agent lifecycle states

Previously, an error result with `details: {}` could fall through to the terminal-status branch and display `Aborted (max turns exceeded)` instead of the real startup error.

## Tests

- `npx vitest run test/agent-tool-error-rendering.test.ts` — 4 passed
- `npm run lint`
- `npm run typecheck`
- `npm run test` — 823 passed, 5 skipped
- `npm run build`

Independent review: C0/I0/M0.