### PR TITLE
feat(isolation): add 'off' option to explicitly disable isolation

### DIFF
--- a/src/agent-manager.ts
+++ b/src/agent-manager.ts
@@ -216,7 +216,7 @@ export class AgentManager {
       if (!wt) {
         throw new Error(
           'Cannot run with isolation: "worktree" — not a git repo, no commits yet, or `git worktree add` failed. ' +
-          'Initialize git and commit at least once, or omit `isolation`.',
+          'Initialize git and commit at least once, or set `isolation: "off"` (or omit the field).',
         );
       }
       record.worktree = wt;

--- a/src/custom-agents.ts
+++ b/src/custom-agents.ts
@@ -79,7 +79,7 @@ function loadFromDir(dir: string, agents: Map<string, AgentConfig>, source: "pro
       runInBackground: fm.run_in_background != null ? fm.run_in_background === true : undefined,
       isolated: fm.isolated != null ? fm.isolated === true : undefined,
       memory: parseMemory(fm.memory),
-      isolation: fm.isolation === "worktree" ? "worktree" : undefined,
+      isolation: fm.isolation === "worktree" || fm.isolation === "off" ? fm.isolation : undefined,
       enabled: fm.enabled !== false,  // default true; explicitly false disables
       source,
     });

--- a/src/index.ts
+++ b/src/index.ts
@@ -814,7 +814,8 @@ Notes:
 - Parallel work: one message, multiple Agent calls, run_in_background: true on each. You are notified when background agents finish — never poll or sleep.
 - The result is not shown to the user — summarize it for them. Verify an agent's claimed code changes before reporting work done.
 - resume continues a previous agent by ID; steer_subagent messages a running one.
-- isolation: "worktree" runs the agent in an isolated git worktree; changes land on a branch.`;
+- isolation: "worktree" runs the agent in an isolated git worktree; changes land on a branch.
+- isolation: "off" runs without isolation — same as omitting the field.`;
 
   const fullAgentToolDescription = `Launch a new agent to handle complex, multi-step tasks autonomously. Each agent type has specific capabilities and tools available to it.
 
@@ -844,7 +845,8 @@ If the target is already known, use a direct tool — \`read\` for a known path,
 - Use model to specify a different model (as "provider/modelId", or fuzzy e.g. "haiku", "sonnet").
 - Use thinking to control extended thinking level.
 - Use inherit_context if the agent needs the parent conversation history.
-- Use isolation: "worktree" to run the agent in an isolated git worktree (safe parallel file modifications). The worktree is automatically cleaned up if the agent makes no changes; otherwise the path and branch are returned in the result.${scheduleGuideline}
+- Use isolation: "worktree" to run the agent in an isolated git worktree (safe parallel file modifications). The worktree is automatically cleaned up if the agent makes no changes; otherwise the path and branch are returned in the result.
+- Use isolation: "off" to opt out of isolation explicitly — same effect as omitting the field.${scheduleGuideline}
 
 ## Writing the prompt
 
@@ -965,9 +967,14 @@ Terse command-style prompts produce shallow, generic work.
         }),
       ),
       isolation: Type.Optional(
-        Type.Literal("worktree", {
-          description: 'Set to "worktree" to run the agent in a temporary git worktree (isolated copy of the repo). Changes are saved to a branch on completion.',
-        }),
+        Type.Union([
+          Type.Literal("worktree", {
+            description: 'Set to "worktree" to run the agent in a temporary git worktree (isolated copy of the repo). Changes are saved to a branch on completion.',
+          }),
+          Type.Literal("off", {
+            description: 'Explicitly disable isolation. Same effect as omitting the field.',
+          }),
+        ]),
       ),
       ...scheduleParam,
     }),
@@ -2017,7 +2024,7 @@ run_in_background: <true to run in background by default. Default: false>
 output_transcript: <false to write no transcript file or path for this agent. Independent of persist_session. Default: true>
 isolated: <true for no extension/MCP tools, only built-in tools. Default: false>
 memory: <"user" (global), "project" (per-project), or "local" (gitignored per-project) for persistent memory. Omit for none>
-isolation: <"worktree" to run in isolated git worktree. Omit for normal>
+isolation: <"worktree" to run in isolated git worktree, or "off" to skip isolation explicitly (same as omitting).>
 ---
 
 <system prompt body — instructions for the agent>

--- a/src/types.ts
+++ b/src/types.ts
@@ -17,8 +17,14 @@ export const DEFAULT_AGENT_NAMES = ["general-purpose", "Explore", "Plan"] as con
 /** Memory scope for persistent agent memory. */
 export type MemoryScope = "user" | "project" | "local";
 
-/** Isolation mode for agent execution. */
-export type IsolationMode = "worktree";
+/**
+ * Isolation mode for agent execution.
+ *
+ * - `"worktree"` — run the agent in a temporary git worktree; changes land on a branch.
+ * - `"off"` — explicitly disable isolation. Semantically identical to omitting the
+ *   field, surfaced so users can opt out without leaving the option unset.
+ */
+export type IsolationMode = "worktree" | "off";
 
 /** Unified agent configuration — used for both default and user-defined agents. */
 export interface AgentConfig {

--- a/test/custom-agents.test.ts
+++ b/test/custom-agents.test.ts
@@ -616,6 +616,18 @@ Isolated.`);
     expect(result.get("isolated-wt")!.isolation).toBe("worktree");
   });
 
+  it("parses isolation: off (explicit opt-out)", () => {
+    writeAgent("isolated-off", `---
+description: Explicit off
+isolation: off
+---
+
+Off.`);
+
+    const result = loadCustomAgents(tmpDir);
+    expect(result.get("isolated-off")!.isolation).toBe("off");
+  });
+
   it("isolation defaults to undefined when omitted", () => {
     writeAgent("no-isolation", `---
 description: Normal

--- a/test/tool-description-mode.test.ts
+++ b/test/tool-description-mode.test.ts
@@ -122,6 +122,7 @@ describe("toolDescriptionMode", () => {
       "resume",
       "steer_subagent",
       'isolation: "worktree"',
+      'isolation: "off"',
       ".pi/agents/",
       "self-contained",
     ]) {


### PR DESCRIPTION
GPT 5.6 uses `worktree` as the `isolation` when calling an `Agent`.
It was useless even when I was asked to leave the `isolation` empty. 

After adding the `off` option to isolation, GPT 5.6 did not use `worktree` in isolation even without any instruction.