### PR TITLE
feat(isolation): add 'off' option to explicitly disable isolation

### DIFF
--- a/src/custom-agents.ts
+++ b/src/custom-agents.ts
@@ -80,7 +80,7 @@ function loadFromDir(dir: string, agents: Map<string, AgentConfig>, source: "pro
       runInBackground: fm.run_in_background != null ? fm.run_in_background === true : undefined,
       isolated: fm.isolated != null ? fm.isolated === true : undefined,
       memory: parseMemory(fm.memory),
-      isolation: fm.isolation === "worktree" ? "worktree" : undefined,
+      isolation: (fm.isolation === "worktree" || fm.isolation === "off") ? fm.isolation : undefined,
       enabled: fm.enabled !== false,  // default true; explicitly false disables
       source,
     });

--- a/src/index.ts
+++ b/src/index.ts
@@ -803,7 +803,7 @@ Notes:
 - Parallel work: one message, multiple Agent calls, run_in_background: true on each. You are notified when background agents finish — never poll or sleep.
 - The result is not shown to the user — summarize it for them. Verify an agent's claimed code changes before reporting work done.
 - resume continues a previous agent by ID; steer_subagent messages a running one.
-- isolation: "worktree" runs the agent in an isolated git worktree; changes land on a branch.`;
+- isolation: "worktree" runs the agent in an isolated git worktree; changes land on a branch. isolation: "off" explicitly disables isolation (same as omitting).`;
 
   const fullAgentToolDescription = `Launch a new agent to handle complex, multi-step tasks autonomously. Each agent type has specific capabilities and tools available to it.
 
@@ -954,9 +954,14 @@ Terse command-style prompts produce shallow, generic work.
         }),
       ),
       isolation: Type.Optional(
-        Type.Literal("worktree", {
-          description: 'Set to "worktree" to run the agent in a temporary git worktree (isolated copy of the repo). Changes are saved to a branch on completion.',
-        }),
+        Type.Union([
+          Type.Literal("worktree", {
+            description: 'Set to "worktree" to run the agent in a temporary git worktree (isolated copy of the repo). Changes are saved to a branch on completion.',
+          }),
+          Type.Literal("off", {
+            description: 'Explicitly disable isolation. Same effect as omitting the field.',
+          }),
+        ]),
       ),
       ...scheduleParam,
     }),

--- a/src/types.ts
+++ b/src/types.ts
@@ -18,7 +18,7 @@ export const DEFAULT_AGENT_NAMES = ["general-purpose", "Explore", "Plan"] as con
 export type MemoryScope = "user" | "project" | "local";
 
 /** Isolation mode for agent execution. */
-export type IsolationMode = "worktree";
+export type IsolationMode = "worktree" | "off";
 
 /** Unified agent configuration — used for both default and user-defined agents. */
 export interface AgentConfig {

--- a/test/custom-agents.test.ts
+++ b/test/custom-agents.test.ts
@@ -673,6 +673,18 @@ Isolated.`);
     expect(result.get("isolated-wt")!.isolation).toBe("worktree");
   });
 
+  it("parses isolation: off (explicit opt-out)", () => {
+    writeAgent("isolated-off", `---
+description: Explicit off
+isolation: off
+---
+
+Off.`);
+
+    const result = loadCustomAgents(tmpDir);
+    expect(result.get("isolated-off")!.isolation).toBe("off");
+  });
+
   it("isolation defaults to undefined when omitted", () => {
     writeAgent("no-isolation", `---
 description: Normal

--- a/test/tool-description-mode.test.ts
+++ b/test/tool-description-mode.test.ts
@@ -122,6 +122,7 @@ describe("toolDescriptionMode", () => {
       "resume",
       "steer_subagent",
       'isolation: "worktree"',
+      'isolation: "off"',
       ".pi/agents/",
       "self-contained",
     ]) {


### PR DESCRIPTION
GPT 5.6 always uses `worktree` as the `isolation` when calling an `Agent`.
It was useless even when I was asked to leave the `isolation` empty. 

After adding the `off` option to isolation, GPT 5.6 did not use `worktree` in isolation even without any instruction.