### PR TITLE
feat(usage): report subagent cost on tool results via ToolResultMessage.usage

### DIFF
--- a/src/agent-manager.ts
+++ b/src/agent-manager.ts
@@ -14,7 +14,7 @@ import type { Model } from "@earendil-works/pi-ai";
 import type { AgentSession, ExtensionAPI, ExtensionContext } from "@earendil-works/pi-coding-agent";
 import { resumeAgent, runAgent, type ToolActivity } from "./agent-runner.js";
 import type { AgentInvocation, AgentRecord, IsolationMode, SubagentType, ThinkingLevel } from "./types.js";
-import { addUsage } from "./usage.js";
+import { addUsage, emptyUsage, type LifetimeUsage } from "./usage.js";
 import { cleanupWorktree, createWorktree, pruneWorktrees, } from "./worktree.js";
 
 export type OnAgentComplete = (record: AgentRecord) => void;
@@ -106,7 +106,7 @@ interface SpawnOptions {
   /** Called at the end of each agentic turn with the cumulative count. */
   onTurnEnd?: (turnCount: number) => void;
   /** Called once per assistant message_end with that message's usage delta. */
-  onAssistantUsage?: (usage: { input: number; output: number; cacheWrite: number }) => void;
+  onAssistantUsage?: (usage: LifetimeUsage) => void;
   /** Called when the session successfully compacts. */
   onCompaction?: (info: CompactionInfo) => void;
   /** Nesting depth: top-level subagent = 1. */
@@ -189,7 +189,7 @@ export class AgentManager {
       toolUses: 0,
       startedAt: Date.now(),
       abortController,
-      lifetimeUsage: { input: 0, output: 0, cacheWrite: 0 },
+      lifetimeUsage: emptyUsage(),
       compactionCount: 0,
       // Raw tri-state (not coerced to a boolean): true = background, false =
       // foreground (has an inline tool-result surface), undefined = caller never

--- a/src/agent-runner.ts
+++ b/src/agent-runner.ts
@@ -27,6 +27,7 @@ import { createNestedSubagentTools, getMaxSubagentDepth, type NestedAgentManager
 import { buildAgentPrompt, type PromptExtras } from "./prompts.js";
 import { preloadSkills } from "./skill-loader.js";
 import type { SubagentType, ThinkingLevel } from "./types.js";
+import type { LifetimeUsage } from "./usage.js";
 
 /**
  * Tool names registered by THIS extension. Single source of truth so the
@@ -396,7 +397,7 @@ export interface RunOptions {
    * Lets callers maintain a lifetime accumulator that survives compaction
    * (which replaces session.state.messages and resets stats-derived sums).
    */
-  onAssistantUsage?: (usage: { input: number; output: number; cacheWrite: number }) => void;
+  onAssistantUsage?: (usage: LifetimeUsage) => void;
   /**
    * Called when the session successfully compacts. `tokensBefore` is upstream's
    * pre-compaction context size estimate. Aborted compactions don't fire.
@@ -933,14 +934,7 @@ export async function runAgent(
     if (event.type === "tool_execution_end") {
       options.onToolActivity?.({ type: "end", toolName: event.toolName });
     }
-    if (event.type === "message_end" && event.message.role === "assistant") {
-      const u = (event.message as any).usage;
-      if (u) options.onAssistantUsage?.({
-        input: u.input ?? 0,
-        output: u.output ?? 0,
-        cacheWrite: u.cacheWrite ?? 0,
-      });
-    }
+    forwardAssistantUsage(event, options.onAssistantUsage);
     if (event.type === "compaction_end" && !event.aborted && event.result) {
       options.onCompaction?.({ reason: event.reason, tokensBefore: event.result.tokensBefore });
     }
@@ -981,7 +975,7 @@ export async function resumeAgent(
   prompt: string,
   options: {
     onToolActivity?: (activity: ToolActivity) => void;
-    onAssistantUsage?: (usage: { input: number; output: number; cacheWrite: number }) => void;
+    onAssistantUsage?: (usage: LifetimeUsage) => void;
     onCompaction?: (info: { reason: "manual" | "threshold" | "overflow"; tokensBefore: number }) => void;
     signal?: AbortSignal;
   } = {},
@@ -997,14 +991,7 @@ export async function resumeAgent(
     ? session.subscribe((event: AgentSessionEvent) => {
         if (event.type === "tool_execution_start") options.onToolActivity?.({ type: "start", toolName: event.toolName });
         if (event.type === "tool_execution_end") options.onToolActivity?.({ type: "end", toolName: event.toolName });
-        if (event.type === "message_end" && event.message.role === "assistant") {
-          const u = (event.message as any).usage;
-          if (u) options.onAssistantUsage?.({
-            input: u.input ?? 0,
-            output: u.output ?? 0,
-            cacheWrite: u.cacheWrite ?? 0,
-          });
-        }
+        forwardAssistantUsage(event, options.onAssistantUsage);
         if (event.type === "compaction_end" && !event.aborted && event.result) {
           options.onCompaction?.({ reason: event.reason, tokensBefore: event.result.tokensBefore });
         }
@@ -1065,4 +1052,20 @@ export function getAgentConversation(session: AgentSession): string {
   }
 
   return parts.join("\n\n");
+}
+
+function forwardAssistantUsage(
+  event: AgentSessionEvent,
+  onAssistantUsage?: (usage: LifetimeUsage) => void,
+): void {
+  if (event.type !== "message_end" || event.message.role !== "assistant") return;
+  const usage = event.message.usage;
+  if (!usage) return;
+  onAssistantUsage?.({
+    input: usage.input ?? 0,
+    output: usage.output ?? 0,
+    cacheWrite: usage.cacheWrite ?? 0,
+    cacheRead: usage.cacheRead ?? 0,
+    cost: usage.cost?.total ?? 0,
+  });
 }

--- a/src/index.ts
+++ b/src/index.ts
@@ -52,13 +52,15 @@ import {
 } from "./ui/agent-widget.js";
 import { FleetList, type FleetUICtx } from "./ui/fleet-list.js";
 import { showSchedulesMenu } from "./ui/schedule-menu.js";
-import { addUsage, getLifetimeTotal, getSessionContextPercent, type LifetimeUsage } from "./usage.js";
+import { addUsage, emptyUsage, getLifetimeTotal, getSessionContextPercent, type LifetimeUsage, type ReportableUsage, takeUnreportedUsage } from "./usage.js";
 
 // ---- Shared helpers ----
 
-/** Tool execute return value for a text response. */
-function textResult(msg: string, details?: AgentDetails) {
-  return { content: [{ type: "text" as const, text: msg }], details: details as any };
+/** Tool execute return value for a text response. `usage` (pi-ai Usage shape)
+ * rides the canonical ToolResultMessage.usage channel so pi core and
+ * statusline extensions count subagent spend in session cost. */
+function textResult(msg: string, details?: AgentDetails, usage?: ReportableUsage) {
+  return { content: [{ type: "text" as const, text: msg }], details: details as any, ...(usage ? { usage } : {}) };
 }
 
 export function renderRunningAgentStatus(
@@ -91,7 +93,7 @@ function createActivityTracker(maxTurns?: number, onStreamUpdate?: () => void) {
     maxTurns,
     responseText: "",
     session: undefined,
-    lifetimeUsage: { input: 0, output: 0, cacheWrite: 0 },
+    lifetimeUsage: emptyUsage(),
   };
 
   const callbacks = {
@@ -117,7 +119,7 @@ function createActivityTracker(maxTurns?: number, onStreamUpdate?: () => void) {
     onSessionCreated: (session: any) => {
       state.session = session;
     },
-    onAssistantUsage: (usage: { input: number; output: number; cacheWrite: number }) => {
+    onAssistantUsage: (usage: LifetimeUsage) => {
       addUsage(state.lifetimeUsage, usage);
       onStreamUpdate?.();
     },
@@ -1222,11 +1224,12 @@ Terse command-style prompts produce shallow, generic work.
         // A failed resume surfaces the error, plus any partial output THIS
         // resume produced (never the previous turn's answer, #144).
         if (record.status === "error") {
-          return textResult(`Agent failed: ${record.error}${partialOutputSuffix(record)}`, buildDetails(detailBase, record));
+          return textResult(`Agent failed: ${record.error}${partialOutputSuffix(record)}`, buildDetails(detailBase, record), takeUnreportedUsage(record));
         }
         return textResult(
           record.result?.trim() || "No output.",
           buildDetails(detailBase, record),
+          takeUnreportedUsage(record),
         );
       }
 
@@ -1415,7 +1418,7 @@ Terse command-style prompts produce shallow, generic work.
 
       if (record.status === "error") {
         // Error headline + any partial output the run produced before failing.
-        return textResult(`${fallbackNote}Agent failed: ${record.error}${partialOutputSuffix(record)}`, details);
+        return textResult(`${fallbackNote}Agent failed: ${record.error}${partialOutputSuffix(record)}`, details, takeUnreportedUsage(record));
       }
 
       const durationMs = (record.completedAt ?? Date.now()) - record.startedAt;
@@ -1425,6 +1428,7 @@ Terse command-style prompts produce shallow, generic work.
         `${fallbackNote}Agent completed in ${formatMs(durationMs)} (${statsParts.join(", ")})${getForegroundOutcomeNote(record.status)}.\n\n` +
         (record.result?.trim() || "No output."),
         details,
+        takeUnreportedUsage(record),
       );
     },
   }));
@@ -1496,10 +1500,14 @@ Terse command-style prompts produce shallow, generic work.
         output += record.result?.trim() || "No output.";
       }
 
-      // Mark result as consumed — suppresses the completion notification
+      // Mark result as consumed — suppresses the completion notification.
+      // Also report the not-yet-reported usage slice on this tool result so
+      // the parent session's cost includes the background run's spend.
+      let reportedUsage: ReportableUsage | undefined;
       if (record.status !== "running" && record.status !== "queued") {
         record.resultConsumed = true;
         cancelNudge(params.agent_id);
+        reportedUsage = takeUnreportedUsage(record);
       }
 
       // Verbose: include full conversation
@@ -1510,7 +1518,7 @@ Terse command-style prompts produce shallow, generic work.
         }
       }
 
-      return textResult(output);
+      return textResult(output, undefined, reportedUsage);
     },
   }));
 

--- a/src/nested-tools.ts
+++ b/src/nested-tools.ts
@@ -33,7 +33,7 @@ import type {
   IsolationMode,
   ThinkingLevel,
 } from "./types.js";
-import { addUsage } from "./usage.js";
+import { addUsage, type LifetimeUsage } from "./usage.js";
 
 /**
  * Hard ceiling on nesting for every branch: main session = 0, its subagents = 1,
@@ -59,7 +59,7 @@ interface NestedSpawnOptions {
   isolation?: IsolationMode;
   invocation?: AgentInvocation;
   signal?: AbortSignal;
-  onAssistantUsage?: (usage: { input: number; output: number; cacheWrite: number }) => void;
+  onAssistantUsage?: (usage: LifetimeUsage) => void;
   onSessionCreated?: (session: AgentSession) => void;
   depth: number;
   parentAgentId: string;

--- a/src/types.ts
+++ b/src/types.ts
@@ -118,6 +118,13 @@ export interface AgentRecord {
    * excluded — see issue #38). Initialized to zeros at spawn.
    */
   lifetimeUsage: LifetimeUsage;
+  /**
+   * Slice of lifetimeUsage already attached to a tool result via
+   * takeUnreportedUsage — prevents double-counting when both the spawn
+   * return and later get_subagent_result calls report usage. Undefined
+   * until the first report.
+   */
+  reportedUsage?: LifetimeUsage;
   /** Number of times this agent's session has compacted. Initialized to 0 at spawn. */
   compactionCount: number;
   /**

--- a/src/usage.ts
+++ b/src/usage.ts
@@ -1,15 +1,14 @@
 /** usage.ts — Token usage: shapes, accumulator operators, session-stats readers. */
 
-/**
- * Lifetime usage components, accumulated via `message_end` events. Survives
- * compaction (which replaces session.state.messages and would reset any
- * stats-derived sum). cacheRead is excluded because each turn's cacheRead is
- * the cumulative cached prefix re-read on that one call — summing across
- * turns counts the prefix N times. See issue #38.
- */
-export type LifetimeUsage = { input: number; output: number; cacheWrite: number };
+/** Per-agent usage accumulated from `message_end` deltas. Survives compaction, which replaces session messages and resets stats-derived sums. */
+export type LifetimeUsage = { input: number; output: number; cacheWrite: number; cacheRead: number; cost: number };
 
-/** Sum of lifetime usage components, or 0 if undefined. */
+/** A zeroed accumulator. */
+export function emptyUsage(): LifetimeUsage {
+  return { input: 0, output: 0, cacheWrite: 0, cacheRead: 0, cost: 0 };
+}
+
+/** Display total excluding repeatedly reported cacheRead prefixes (issue #38). */
 export function getLifetimeTotal(u?: LifetimeUsage): number {
   return u ? u.input + u.output + u.cacheWrite : 0;
 }
@@ -19,6 +18,52 @@ export function addUsage(into: LifetimeUsage, delta: LifetimeUsage): void {
   into.input += delta.input;
   into.output += delta.output;
   into.cacheWrite += delta.cacheWrite;
+  into.cacheRead += delta.cacheRead;
+  into.cost += delta.cost;
+}
+
+/**
+ * pi-ai `Usage` shape for `ToolResultMessage.usage` — the canonical channel
+ * pi core (getUsageCostBreakdown, "Tools/summaries" bucket) and statusline
+ * extensions aggregate into session cost. Component costs are not tracked
+ * per bucket, so only `cost.total` is populated.
+ */
+export type ReportableUsage = {
+  input: number; output: number; cacheRead: number; cacheWrite: number;
+  totalTokens: number;
+  cost: { input: number; output: number; cacheRead: number; cacheWrite: number; total: number };
+};
+
+/**
+ * Return the not-yet-reported slice of an agent's lifetime usage as a pi-ai
+ * `Usage`, and mark it reported (mutates record.reportedUsage). Returns
+ * undefined when there is nothing new to report — callers must not attach
+ * an all-zero usage. Delta semantics make repeated reporting safe: a resumed
+ * agent or a second get_subagent_result call reports only new spend, so the
+ * parent session never double-counts.
+ */
+export function takeUnreportedUsage(record: { lifetimeUsage: LifetimeUsage; reportedUsage?: LifetimeUsage }): ReportableUsage | undefined {
+  const total = record.lifetimeUsage;
+  const prior = record.reportedUsage ?? emptyUsage();
+  const delta: LifetimeUsage = {
+    input: Math.max(0, total.input - prior.input),
+    output: Math.max(0, total.output - prior.output),
+    cacheWrite: Math.max(0, total.cacheWrite - prior.cacheWrite),
+    cacheRead: Math.max(0, total.cacheRead - prior.cacheRead),
+    cost: Math.max(0, total.cost - prior.cost),
+  };
+  if (delta.input === 0 && delta.output === 0 && delta.cacheWrite === 0 && delta.cacheRead === 0 && delta.cost === 0) {
+    return undefined;
+  }
+  record.reportedUsage = { ...total };
+  return {
+    input: delta.input,
+    output: delta.output,
+    cacheRead: delta.cacheRead,
+    cacheWrite: delta.cacheWrite,
+    totalTokens: delta.input + delta.output + delta.cacheRead + delta.cacheWrite,
+    cost: { input: 0, output: 0, cacheRead: 0, cacheWrite: 0, total: delta.cost },
+  };
 }
 
 /** Minimal shape we read from upstream `getSessionStats()`. */

--- a/test/agent-manager.test.ts
+++ b/test/agent-manager.test.ts
@@ -568,7 +568,7 @@ describe("AgentManager — lifetime usage + compaction count are eagerly initial
     });
     const record = manager.getRecord(id)!;
 
-    expect(record.lifetimeUsage).toEqual({ input: 0, output: 0, cacheWrite: 0 });
+    expect(record.lifetimeUsage).toEqual({ input: 0, output: 0, cacheWrite: 0, cacheRead: 0, cost: 0 });
     expect(record.compactionCount).toBe(0);
 
     manager.abort(id);
@@ -582,8 +582,8 @@ describe("AgentManager — lifetime usage + compaction count are eagerly initial
     vi.mocked(runAgent).mockImplementation(async (_ctx, _type, _prompt, opts: any) => {
       captured = opts;
       // Two assistant messages with usage
-      opts.onAssistantUsage?.({ input: 100, output: 50, cacheWrite: 10 });
-      opts.onAssistantUsage?.({ input: 200, output: 80, cacheWrite: 20 });
+      opts.onAssistantUsage?.({ input: 100, output: 50, cacheWrite: 10, cacheRead: 1000, cost: 0.01 });
+      opts.onAssistantUsage?.({ input: 200, output: 80, cacheWrite: 20, cacheRead: 2000, cost: 0.02 });
       return { responseText: "done", session: mockSession(), aborted: false, steered: false };
     });
 
@@ -595,7 +595,7 @@ describe("AgentManager — lifetime usage + compaction count are eagerly initial
 
     expect(captured).toBeDefined();
     expect(manager.getRecord(id)!.lifetimeUsage).toEqual({
-      input: 300, output: 130, cacheWrite: 30,
+      input: 300, output: 130, cacheWrite: 30, cacheRead: 3000, cost: 0.03,
     });
   });
 
@@ -647,20 +647,20 @@ describe("AgentManager — lifetime usage + compaction count are eagerly initial
     await manager.getRecord(id)!.promise;
 
     // Pre-resume: lifetimeUsage from spawn was zero (mock didn't call onAssistantUsage)
-    expect(manager.getRecord(id)!.lifetimeUsage).toEqual({ input: 0, output: 0, cacheWrite: 0 });
+    expect(manager.getRecord(id)!.lifetimeUsage).toEqual({ input: 0, output: 0, cacheWrite: 0, cacheRead: 0, cost: 0 });
     expect(manager.getRecord(id)!.compactionCount).toBe(0);
 
     // Now resume — drive callbacks via the mocked resumeAgent
     const { resumeAgent: resumeMock } = await import("../src/agent-runner.js");
     vi.mocked(resumeMock).mockImplementation(async (_session, _prompt, opts: any) => {
-      opts.onAssistantUsage?.({ input: 70, output: 30, cacheWrite: 5 });
+      opts.onAssistantUsage?.({ input: 70, output: 30, cacheWrite: 5, cacheRead: 500, cost: 0.005 });
       opts.onCompaction?.({ reason: "overflow", tokensBefore: 999 });
       return { text: "second" };
     });
 
     await manager.resume(id, "more");
 
-    expect(manager.getRecord(id)!.lifetimeUsage).toEqual({ input: 70, output: 30, cacheWrite: 5 });
+    expect(manager.getRecord(id)!.lifetimeUsage).toEqual({ input: 70, output: 30, cacheWrite: 5, cacheRead: 500, cost: 0.005 });
     expect(manager.getRecord(id)!.compactionCount).toBe(1);
   });
 });

--- a/test/agent-runner.test.ts
+++ b/test/agent-runner.test.ts
@@ -499,8 +499,8 @@ describe("agent-runner usage callback wiring", () => {
     const seen: Array<{ input: number; output: number; cacheWrite: number }> = [];
     session.prompt = vi.fn(async () => {
       // Two assistant messages over the run
-      emitMessageEnd(listeners, { input: 100, output: 50, cacheWrite: 10 });
-      emitMessageEnd(listeners, { input: 200, output: 80, cacheWrite: 20 });
+      emitMessageEnd(listeners, { input: 100, output: 50, cacheWrite: 10, cacheRead: 1000, cost: { total: 0.01 } });
+      emitMessageEnd(listeners, { input: 200, output: 80, cacheWrite: 20, cacheRead: 2000, cost: { total: 0.02 } });
       session.messages.push({ role: "assistant", content: [{ type: "text", text: "OK" }] });
     });
 
@@ -510,8 +510,8 @@ describe("agent-runner usage callback wiring", () => {
     });
 
     expect(seen).toEqual([
-      { input: 100, output: 50, cacheWrite: 10 },
-      { input: 200, output: 80, cacheWrite: 20 },
+      { input: 100, output: 50, cacheWrite: 10, cacheRead: 1000, cost: 0.01 },
+      { input: 200, output: 80, cacheWrite: 20, cacheRead: 2000, cost: 0.02 },
     ]);
   });
 
@@ -521,7 +521,7 @@ describe("agent-runner usage callback wiring", () => {
 
     const seen: any[] = [];
     session.prompt = vi.fn(async () => {
-      emitMessageEnd(listeners, { input: 50 }); // output, cacheWrite missing
+      emitMessageEnd(listeners, { input: 50 }); // output, cacheWrite, cacheRead, cost missing
       session.messages.push({ role: "assistant", content: [{ type: "text", text: "OK" }] });
     });
 
@@ -530,7 +530,7 @@ describe("agent-runner usage callback wiring", () => {
       onAssistantUsage: (u) => seen.push(u),
     });
 
-    expect(seen).toEqual([{ input: 50, output: 0, cacheWrite: 0 }]);
+    expect(seen).toEqual([{ input: 50, output: 0, cacheWrite: 0, cacheRead: 0, cost: 0 }]);
   });
 
   it("runAgent skips the callback when message_end has no usage field", async () => {
@@ -553,7 +553,7 @@ describe("agent-runner usage callback wiring", () => {
     const seen: any[] = [];
 
     session.prompt = vi.fn(async () => {
-      emitMessageEnd(listeners, { input: 10, output: 20, cacheWrite: 5 });
+      emitMessageEnd(listeners, { input: 10, output: 20, cacheWrite: 5, cacheRead: 100, cost: { total: 0.001 } });
       session.messages.push({ role: "assistant", content: [{ type: "text", text: "RESUMED" }] });
     });
 
@@ -561,7 +561,7 @@ describe("agent-runner usage callback wiring", () => {
       onAssistantUsage: (u) => seen.push(u),
     });
 
-    expect(seen).toEqual([{ input: 10, output: 20, cacheWrite: 5 }]);
+    expect(seen).toEqual([{ input: 10, output: 20, cacheWrite: 5, cacheRead: 100, cost: 0.001 }]);
   });
 
   it("forwards compaction_end events to onCompaction (only when not aborted)", async () => {

--- a/test/nested-tools.test.ts
+++ b/test/nested-tools.test.ts
@@ -427,10 +427,10 @@ describe("child-safe nested Agent tools", () => {
   });
 
   it("attributes a nested child's token spend to the owning parent", async () => {
-    const parent = { id: "parent-1", status: "running", lifetimeUsage: { input: 0, output: 0, cacheWrite: 0 } };
+    const parent = { id: "parent-1", status: "running", lifetimeUsage: { input: 0, output: 0, cacheWrite: 0, cacheRead: 0, cost: 0 } };
     records.set("parent-1", parent);
     spawn.mockImplementation((_pi, _ctx, _type, _prompt, options) => {
-      options.onAssistantUsage?.({ input: 100, output: 20, cacheWrite: 5 });
+      options.onAssistantUsage?.({ input: 100, output: 20, cacheWrite: 5, cacheRead: 200, cost: 0.002 });
       return "child-1";
     });
 
@@ -442,21 +442,21 @@ describe("child-safe nested Agent tools", () => {
       run_in_background: true,
     });
 
-    expect(parent.lifetimeUsage).toEqual({ input: 100, output: 20, cacheWrite: 5 });
+    expect(parent.lifetimeUsage).toEqual({ input: 100, output: 20, cacheWrite: 5, cacheRead: 200, cost: 0.002 });
   });
 
   it("attributes spend up the whole ancestor chain, not just one level", async () => {
     // A spawn callback fires only for that child's own turns, so a deeper
     // descendant would otherwise never reach the one record anyone can see.
-    const top = { id: "top", status: "running", lifetimeUsage: { input: 0, output: 0, cacheWrite: 0 } };
+    const top = { id: "top", status: "running", lifetimeUsage: { input: 0, output: 0, cacheWrite: 0, cacheRead: 0, cost: 0 } };
     const middle = {
       id: "parent-1", status: "running", parentAgentId: "top",
-      lifetimeUsage: { input: 0, output: 0, cacheWrite: 0 },
+      lifetimeUsage: { input: 0, output: 0, cacheWrite: 0, cacheRead: 0, cost: 0 },
     };
     records.set("top", top);
     records.set("parent-1", middle);
     spawn.mockImplementation((_pi, _ctx, _type, _prompt, options) => {
-      options.onAssistantUsage?.({ input: 7, output: 3, cacheWrite: 1 });
+      options.onAssistantUsage?.({ input: 7, output: 3, cacheWrite: 1, cacheRead: 70, cost: 0.0007 });
       return "child-1";
     });
 
@@ -468,8 +468,8 @@ describe("child-safe nested Agent tools", () => {
       run_in_background: true,
     });
 
-    expect(middle.lifetimeUsage).toEqual({ input: 7, output: 3, cacheWrite: 1 });
-    expect(top.lifetimeUsage).toEqual({ input: 7, output: 3, cacheWrite: 1 });
+    expect(middle.lifetimeUsage).toEqual({ input: 7, output: 3, cacheWrite: 1, cacheRead: 70, cost: 0.0007 });
+    expect(top.lifetimeUsage).toEqual({ input: 7, output: 3, cacheWrite: 1, cacheRead: 70, cost: 0.0007 });
   });
 
   it("files a nested transcript under the root session, honoring output_transcript", async () => {

--- a/test/usage.test.ts
+++ b/test/usage.test.ts
@@ -1,5 +1,5 @@
 import { describe, expect, it } from "vitest";
-import { getLifetimeTotal, getSessionContextPercent, getSessionTokens } from "../src/usage.js";
+import { getLifetimeTotal, getSessionContextPercent, getSessionTokens, takeUnreportedUsage } from "../src/usage.js";
 
 // Regression for issue #38 — token semantics + context indicator
 describe("usage", () => {
@@ -109,6 +109,61 @@ describe("usage", () => {
 
       // input + output + cacheWrite = total — by construction, no drift
       expect(usage.input + usage.output + usage.cacheWrite).toBe(getLifetimeTotal(usage));
+    });
+  });
+
+  // Tool-result usage reporting — the canonical ToolResultMessage.usage channel
+  // that lets pi core and statusline extensions count subagent spend in the
+  // parent session's cost.
+  describe("takeUnreportedUsage", () => {
+    const lifetime = (input: number, output: number, cacheWrite: number, cacheRead: number, cost: number) =>
+      ({ input, output, cacheWrite, cacheRead, cost });
+
+    it("returns full lifetime usage as pi-ai Usage on first call", () => {
+      const record = { lifetimeUsage: lifetime(100, 50, 10, 1000, 0.05) };
+      expect(takeUnreportedUsage(record)).toEqual({
+        input: 100,
+        output: 50,
+        cacheRead: 1000,
+        cacheWrite: 10,
+        totalTokens: 1160,
+        cost: { input: 0, output: 0, cacheRead: 0, cacheWrite: 0, total: 0.05 },
+      });
+    });
+
+    it("returns undefined when there is nothing to report", () => {
+      expect(takeUnreportedUsage({ lifetimeUsage: lifetime(0, 0, 0, 0, 0) })).toBeUndefined();
+    });
+
+    it("reports only the delta on subsequent calls (no double counting)", () => {
+      const record: { lifetimeUsage: ReturnType<typeof lifetime>; reportedUsage?: ReturnType<typeof lifetime> } = {
+        lifetimeUsage: lifetime(100, 50, 10, 1000, 0.05),
+      };
+      takeUnreportedUsage(record);
+
+      // Nothing new — a second get_subagent_result on the same terminal agent
+      expect(takeUnreportedUsage(record)).toBeUndefined();
+
+      // Resume adds spend — only the new slice is reported
+      record.lifetimeUsage = lifetime(150, 80, 15, 1500, 0.08);
+      expect(takeUnreportedUsage(record)).toEqual({
+        input: 50,
+        output: 30,
+        cacheRead: 500,
+        cacheWrite: 5,
+        totalTokens: 585,
+        cost: { input: 0, output: 0, cacheRead: 0, cacheWrite: 0, total: 0.03 },
+      });
+      expect(takeUnreportedUsage(record)).toBeUndefined();
+    });
+
+    it("clamps negative deltas to zero", () => {
+      const record = {
+        lifetimeUsage: lifetime(50, 20, 5, 100, 0.01),
+        reportedUsage: lifetime(100, 50, 10, 1000, 0.05),
+      };
+      // All components below the reported watermark — nothing to report
+      expect(takeUnreportedUsage(record)).toBeUndefined();
     });
   });
 });


### PR DESCRIPTION
Closes #203.

## Problem

Subagent LLM spend is invisible to the parent session's cost accounting. Subagents run in their own `AgentSession`, and the `Agent` and `get_subagent_result` tool results carry token counts as display text only. Every surface that reads parent session cost under-reports total spend: pi core's `getUsageCostBreakdown`, `/session`, and statusline extensions such as pi-starship and pi-powerline-footer. In a test on pi 0.83.0, two one-turn subagent runs spent $0.066 and none of it reached the parent session's cost accounting.

## Solution

Pi provides a channel for exactly this: `ToolResultMessage.usage` ("Usage from the tool execution itself"). Pi core aggregates it into the "Tools/summaries" cost bucket, and statusline extensions sum the same field. This PR attaches the subagent's accumulated usage, including `cost.total`, to the tool results the extension returns.

### Changes

- `LifetimeUsage` gains `cacheRead` and `cost`. The token display total still excludes `cacheRead` (#38 unchanged). Summing `cacheRead` across `message_end` events is billing-correct for the usage report because each call re-reads and is billed for the cached prefix.
- The `message_end` handlers in `runAgent` and `resumeAgent` forward `cacheRead` and `usage.cost.total`.
- `takeUnreportedUsage()` returns the not-yet-reported slice as a pi-ai `Usage` and advances a per-record watermark (`AgentRecord.reportedUsage`). Delta semantics make repeated reporting safe. A resume reports only new spend. A second `get_subagent_result` reports nothing. The parent session never double-counts.
- Usage attaches on foreground `Agent` completion and failure, `resume` returns, and terminal `get_subagent_result`. Background spawn returns and still-running polls attach nothing.
- Nested subagents keep propagating usage up ancestor `lifetimeUsage`, now including cost, so one top-level tool result covers the whole subtree.

## Testing

All four checks pass locally: `lint` (clean), `typecheck`, `test` (824 passed, 5 skipped), and `build`. `test:e2e` also passes (49 passed, 5 skipped).

New `takeUnreportedUsage` unit tests cover: full report on first call, `undefined` on empty report, delta-only report after resume, no double count on repeat calls, and negative-delta clamp.

Verified end-to-end on pi 0.83.0 with bedrock:

| Path | `usage` on toolResult |
|---|---|
| Failed spawn (model not in scope) | none |
| Foreground `Agent` completion | full usage, cost $0.057 |
| Background spawn return | none (still running) |
| 1st `get_subagent_result` | full usage, cost $0.009 |
| 2nd `get_subagent_result` | none (already reported) |

Statusline extensions such as pi-starship sum the same toolResult field, so they pick up subagent cost with no changes.
