### PR TITLE
fix: link persisted subagent sessions to parent

### DIFF
--- a/src/agent-runner.ts
+++ b/src/agent-runner.ts
@@ -831,7 +831,9 @@ export async function runAgent(
   const configuredSessionDir = resolveConfiguredSessionDir(agentConfig?.sessionDir, effectiveCwd);
   const defaultSessionDir = process.env.PI_CODING_AGENT_SESSION_DIR ?? settingsManager.getSessionDir?.();
   const sessionManager = agentConfig?.persistSession
-    ? SessionManager.create(effectiveCwd, configuredSessionDir ?? defaultSessionDir)
+    ? SessionManager.create(effectiveCwd, configuredSessionDir ?? defaultSessionDir, {
+        parentSession: ctx.sessionManager.getSessionFile(),
+      })
     : SessionManager.inMemory(effectiveCwd);
 
   // Pi 0.80.8 replaced createAgentSession's modelRegistry option with

--- a/test/agent-runner.test.ts
+++ b/test/agent-runner.test.ts
@@ -178,7 +178,10 @@ const ctx = {
   model: undefined,
   modelRegistry: { find: vi.fn(), getAvailable: vi.fn(() => []) },
   getSystemPrompt: vi.fn(() => "parent prompt"),
-  sessionManager: { getBranch: vi.fn(() => []) },
+  sessionManager: {
+    getBranch: vi.fn(() => []),
+    getSessionFile: vi.fn(() => "/sessions/parent.jsonl"),
+  },
 } as any;
 
 const pi = {} as any;
@@ -791,7 +794,7 @@ describe("agent-runner session persistence", () => {
     }));
   });
 
-  it("uses pi's normal persistent session location when persistSession is true", async () => {
+  it("uses pi's normal persistent session location and links to the parent session", async () => {
     vi.mocked(getAgentConfig).mockReturnValueOnce(makeAgentConfig({ persistSession: true }));
     settingsManagerGetSessionDir.mockReturnValue("/normal/pi/sessions");
     const { session } = createSession("OK");
@@ -800,7 +803,11 @@ describe("agent-runner session persistence", () => {
     await runAgent(ctx, "Explore", "go", { pi });
 
     expect(sessionManagerInMemory).not.toHaveBeenCalled();
-    expect(sessionManagerCreate).toHaveBeenCalledWith("/tmp", "/normal/pi/sessions");
+    expect(sessionManagerCreate).toHaveBeenCalledWith(
+      "/tmp",
+      "/normal/pi/sessions",
+      { parentSession: "/sessions/parent.jsonl" },
+    );
     expect(createAgentSession).toHaveBeenCalledWith(expect.objectContaining({
       sessionManager: { kind: "persistent-session-manager" },
     }));
@@ -819,6 +826,7 @@ describe("agent-runner session persistence", () => {
     expect(sessionManagerCreate).toHaveBeenCalledWith(
       "/repo",
       "/repo/.seams/pi-sessions/seam-plan-reviewer",
+      { parentSession: "/sessions/parent.jsonl" },
     );
   });
 });


### PR DESCRIPTION
## Summary

- pass the parent session file through `NewSessionOptions.parentSession` when creating a persisted subagent session
- keep session lineage independent from `inherit_context`, so fresh subagents still receive only their explicit prompt
- cover the parent-session option for default and configured child session directories

Closes #204.

## Validation

- `npm run lint`
- `npm run typecheck`
- `npm run test` (820 passed, 5 skipped)
- `npm run build`
- `git diff --check`
