### PR TITLE
feat(widget): show live working-tree diff stats

### DIFF
--- a/src/agent-manager.ts
+++ b/src/agent-manager.ts
@@ -258,6 +258,7 @@ export class AgentManager {
       this.worktreeRepos.add(baseCwd);
     }
 
+    record.cwd = worktreeCwd ?? customCwd ?? ctx.cwd;
     record.status = "running";
     record.startedAt = Date.now();
     if (occupiesPoolSlot(record)) this.runningBackground++;

--- a/src/index.ts
+++ b/src/index.ts
@@ -602,7 +602,7 @@ export default function (pi: ExtensionAPI) {
   // everything else; "off" = hide the widget entirely. Read live at render time.
   let widgetMode: WidgetMode = "background";
   function getWidgetMode(): WidgetMode { return widgetMode; }
-  const widget = new AgentWidget(manager, agentActivity, getWidgetMode);
+  const widget = new AgentWidget(manager, agentActivity, getWidgetMode, pi);
   function setWidgetMode(m: WidgetMode): void { widgetMode = m; widget.update(); }
 
   // Claude Code-style FleetView: navigable list of main + subagents below the editor.
@@ -1232,12 +1232,15 @@ Terse command-style prompts produce shallow, generic work.
 
       // Background execution
       if (runInBackground) {
-        const { state: bgState, callbacks: bgCallbacks } = createActivityTracker(effectiveMaxTurns);
+        let id: string;
+        const { state: bgState, callbacks: bgCallbacks } = createActivityTracker(
+          effectiveMaxTurns,
+          () => { if (id) widget.onActivity(id); },
+        );
 
         // Wrap onSessionCreated to wire output file streaming.
         // The callback lazily reads record.outputFile (set right after spawn)
         // rather than closing over a value that doesn't exist yet.
-        let id: string;
         const origBgOnSession = bgCallbacks.onSessionCreated;
         bgCallbacks.onSessionCreated = (session: any) => {
           origBgOnSession(session);
@@ -1338,7 +1341,13 @@ Terse command-style prompts produce shallow, generic work.
         });
       };
 
-      const { state: fgState, callbacks: fgCallbacks } = createActivityTracker(effectiveMaxTurns, streamUpdate);
+      const { state: fgState, callbacks: fgCallbacks } = createActivityTracker(
+        effectiveMaxTurns,
+        () => {
+          streamUpdate();
+          if (fgId) widget.onActivity(fgId);
+        },
+      );
 
       // Wire session creation: register in widget + stream to output file.
       // The output file path is set synchronously after spawn (below),

--- a/src/types.ts
+++ b/src/types.ts
@@ -102,6 +102,8 @@ export interface AgentRecord {
   resultConsumed?: boolean;
   /** Steering messages queued before the session was ready. */
   pendingSteers?: string[];
+  /** The actual working directory used by the agent process, once running. */
+  cwd?: string;
   /** Worktree info if the agent is running in an isolated worktree. */
   worktree?: { path: string; branch: string; baseSha: string; workPath: string };
   /** Worktree cleanup result after agent completion. */

--- a/src/ui/agent-widget.ts
+++ b/src/ui/agent-widget.ts
@@ -5,6 +5,7 @@
  * Uses the callback form of setWidget for themed rendering.
  */
 
+import type { ExtensionAPI } from "@earendil-works/pi-coding-agent";
 import { truncateToWidth } from "@earendil-works/pi-tui";
 import type { AgentManager } from "../agent-manager.js";
 import { getConfig } from "../agent-types.js";
@@ -86,6 +87,26 @@ export interface AgentDetails {
   maxTurns?: number;
   agentId?: string;
   error?: string;
+}
+
+/** Cached read-only working-tree statistics for a running agent. */
+export interface GitWorkingTreeSummary {
+  trackedFiles: number;
+  additions: number;
+  deletions: number;
+  untrackedFiles: number;
+}
+
+const GIT_SUMMARY_DEBOUNCE_MS = 250;
+const GIT_SUMMARY_TIMEOUT_MS = 1_000;
+
+/** Format tracked diff stats, explicitly separating untracked files from line totals. */
+export function formatGitSummary(summary: GitWorkingTreeSummary): string {
+  const files = `${summary.trackedFiles} file${summary.trackedFiles === 1 ? "" : "s"}`;
+  const untracked = summary.untrackedFiles > 0
+    ? ` · ${summary.untrackedFiles} untracked`
+    : "";
+  return `${files} · +${summary.additions} −${summary.deletions}${untracked}`;
 }
 
 // ---- Formatting helpers ----
@@ -227,6 +248,19 @@ export class AgentWidget {
   private tui: any | undefined;
   /** Last status bar text, used to avoid redundant setStatus calls. */
   private lastStatusText: string | undefined;
+  /** Latest successful Git summary per agent. */
+  private gitSummaries = new Map<string, GitWorkingTreeSummary>();
+  /** Debounce timers for Git refreshes, keyed by agent. */
+  private gitRefreshTimers = new Map<string, ReturnType<typeof setTimeout>>();
+  /** Agents with a Git query currently in flight. */
+  private gitRefreshes = new Set<string>();
+  /** Activity received while a Git query was in flight. */
+  private gitRefreshAgain = new Set<string>();
+  /** Prevent the render loop from retrying failed queries continuously. */
+  private gitRefreshAttempted = new Set<string>();
+  /** Generation guards late results after disposal, completion, or newer activity. */
+  private gitRefreshGeneration = new Map<string, number>();
+  private disposed = false;
 
   constructor(
     private manager: AgentManager,
@@ -237,6 +271,7 @@ export class AgentWidget {
      * extension supplies one defaulting to `"background"`.
      */
     private mode: () => WidgetMode = () => "all",
+    private pi?: Pick<ExtensionAPI, "exec">,
   ) {}
 
   /**
@@ -303,6 +338,110 @@ export class AgentWidget {
     if (!this.finishedTurnAge.has(agentId)) {
       this.finishedTurnAge.set(agentId, 0);
     }
+    this.clearGitState(agentId);
+  }
+
+  /** Schedule a refresh after activity settles without overlapping Git calls. */
+  onActivity(agentId: string) {
+    if (this.disposed) return;
+    const agent = this.manager.getRecord(agentId);
+    if (!agent || agent.status !== "running" || !agent.cwd || !this.pi) return;
+    const cwd = agent.cwd;
+
+    this.gitRefreshAttempted.add(agentId);
+    const generation = (this.gitRefreshGeneration.get(agentId) ?? 0) + 1;
+    this.gitRefreshGeneration.set(agentId, generation);
+    const existing = this.gitRefreshTimers.get(agentId);
+    if (existing != null) clearTimeout(existing);
+    this.gitRefreshTimers.set(agentId, setTimeout(() => {
+      this.gitRefreshTimers.delete(agentId);
+      const current = this.manager.getRecord(agentId);
+      if (!current || current.status !== "running" || current.cwd !== cwd) return;
+      void this.refreshGitSummary(agentId, cwd, generation);
+    }, GIT_SUMMARY_DEBOUNCE_MS));
+  }
+
+  private ensureGitRefresh(agent: { id: string; status: string; cwd?: string }) {
+    if (!this.pi || agent.status !== "running" || !agent.cwd) return;
+    if (this.gitRefreshAttempted.has(agent.id)
+      || this.gitRefreshes.has(agent.id)
+      || this.gitRefreshTimers.has(agent.id)) return;
+    this.onActivity(agent.id);
+  }
+
+  private async refreshGitSummary(agentId: string, cwd: string, generation: number) {
+    const pi = this.pi;
+    if (!pi || this.gitRefreshes.has(agentId)) {
+      this.gitRefreshAgain.add(agentId);
+      return;
+    }
+    this.gitRefreshes.add(agentId);
+    try {
+      const diff = await pi.exec("git", ["diff", "--numstat", "HEAD", "--"], {
+        cwd,
+        timeout: GIT_SUMMARY_TIMEOUT_MS,
+      });
+      if (diff.code !== 0) {
+        this.omitGitSummary(agentId, cwd, generation);
+        return;
+      }
+
+      const untracked = await pi.exec("git", ["ls-files", "--others", "--exclude-standard"], {
+        cwd,
+        timeout: GIT_SUMMARY_TIMEOUT_MS,
+      });
+      if (untracked.code !== 0) {
+        this.omitGitSummary(agentId, cwd, generation);
+        return;
+      }
+
+      let trackedFiles = 0;
+      let additions = 0;
+      let deletions = 0;
+      for (const line of diff.stdout.split("\n")) {
+        if (!line) continue;
+        const [added, deleted] = line.split("\t");
+        trackedFiles++;
+        if (/^\d+$/.test(added ?? "")) additions += Number(added);
+        if (/^\d+$/.test(deleted ?? "")) deletions += Number(deleted);
+      }
+
+      const current = this.manager.getRecord(agentId);
+      if (this.disposed || generation !== this.gitRefreshGeneration.get(agentId)
+        || current?.status !== "running" || current.cwd !== cwd) return;
+      this.gitSummaries.set(agentId, {
+        trackedFiles,
+        additions,
+        deletions,
+        untrackedFiles: untracked.stdout.split("\n").filter(Boolean).length,
+      });
+      this.tui?.requestRender();
+    } catch {
+      // Git is an optional display enhancement; command failures stay invisible.
+      this.omitGitSummary(agentId, cwd, generation);
+    } finally {
+      this.gitRefreshes.delete(agentId);
+      if (this.gitRefreshAgain.delete(agentId)) this.onActivity(agentId);
+    }
+  }
+
+  /** Remove stale stats when the current Git refresh cannot produce a summary. */
+  private omitGitSummary(agentId: string, cwd: string, generation: number) {
+    const current = this.manager.getRecord(agentId);
+    if (this.disposed || generation !== this.gitRefreshGeneration.get(agentId)
+      || current?.status !== "running" || current.cwd !== cwd) return;
+    if (this.gitSummaries.delete(agentId)) this.tui?.requestRender();
+  }
+
+  private clearGitState(agentId: string) {
+    const timer = this.gitRefreshTimers.get(agentId);
+    if (timer != null) clearTimeout(timer);
+    this.gitRefreshTimers.delete(agentId);
+    this.gitRefreshes.delete(agentId);
+    this.gitRefreshAgain.delete(agentId);
+    this.gitRefreshAttempted.delete(agentId);
+    this.gitSummaries.delete(agentId);
+    this.gitRefreshGeneration.set(agentId, (this.gitRefreshGeneration.get(agentId) ?? 0) + 1);
   }
 
   /** Render a finished agent line. */
@@ -392,6 +531,8 @@ export class AgentWidget {
       if (bg) parts.push(formatTurns(bg.turnCount, bg.maxTurns));
       if (toolUses > 0) parts.push(`${toolUses} tool use${toolUses === 1 ? "" : "s"}`);
       if (tokenText) parts.push(tokenText);
+      const gitSummary = this.gitSummaries.get(a.id);
+      if (gitSummary) parts.push(formatGitSummary(gitSummary));
       parts.push(elapsed);
       const statsText = parts.join(" · ");
 
@@ -488,7 +629,7 @@ export class AgentWidget {
     let queuedCount = 0;
     let hasFinished = false;
     for (const a of allAgents) {
-      if (a.status === "running") { runningCount++; }
+      if (a.status === "running") { runningCount++; this.ensureGitRefresh(a); }
       else if (a.status === "queued") { queuedCount++; }
       else if (a.completedAt && this.shouldShowFinished(a.id, a.status)) { hasFinished = true; }
     }
@@ -562,5 +703,12 @@ export class AgentWidget {
     this.widgetRegistered = false;
     this.tui = undefined;
     this.lastStatusText = undefined;
+    this.disposed = true;
+    for (const timer of this.gitRefreshTimers.values()) clearTimeout(timer);
+    this.gitRefreshTimers.clear();
+    this.gitRefreshAgain.clear();
+    this.gitRefreshAttempted.clear();
+    this.gitSummaries.clear();
+    this.gitRefreshGeneration.clear();
   }
 }

--- a/test/agent-manager.test.ts
+++ b/test/agent-manager.test.ts
@@ -710,6 +710,7 @@ describe("AgentManager — SpawnOptions.cwd passthrough (#96)", () => {
       mockCtx, "general-purpose", "test",
       expect.objectContaining({ cwd: "/", configCwd: "/tmp" }),
     );
+    expect(manager.getRecord(id)?.cwd).toBe("/");
   });
 
   it("without cwd, configCwd stays unset — existing behavior untouched", async () => {
@@ -726,6 +727,7 @@ describe("AgentManager — SpawnOptions.cwd passthrough (#96)", () => {
     const opts = vi.mocked(runAgent).mock.lastCall![3];
     expect(opts.cwd).toBeUndefined();
     expect(opts.configCwd).toBeUndefined();
+    expect(manager.getRecord(id)?.cwd).toBe("/tmp");
   });
 
   it("cwd: null (RPC 'unset') behaves exactly like omitting cwd", async () => {
@@ -766,6 +768,7 @@ describe("AgentManager — SpawnOptions.cwd passthrough (#96)", () => {
       expect.objectContaining({ cwd: "/wt/copy/packages/api", configCwd: "/tmp" }),
     );
     expect(cleanupWorktree).toHaveBeenCalledWith("/", expect.anything(), "test");
+    expect(manager.getRecord(id)?.cwd).toBe("/wt/copy/packages/api");
   });
 
   it("plain worktree (no cwd) keeps the historical root working dir even when workPath differs", async () => {

--- a/test/agent-widget.test.ts
+++ b/test/agent-widget.test.ts
@@ -1,7 +1,14 @@
-import { describe, expect, it } from "vitest";
+import type { ExtensionAPI } from "@earendil-works/pi-coding-agent";
+import { describe, expect, it, vi } from "vitest";
 import { renderRunningAgentStatus } from "../src/index.js";
 import type { WidgetMode } from "../src/types.js";
-import { type AgentActivity, AgentWidget, fgPreservingNestedStyles, formatSessionTokens } from "../src/ui/agent-widget.js";
+import {
+  type AgentActivity,
+  AgentWidget,
+  fgPreservingNestedStyles,
+  formatGitSummary,
+  formatSessionTokens,
+} from "../src/ui/agent-widget.js";
 
 describe("formatSessionTokens", () => {
   const theme = { fg: (c: string, s: string) => `<${c}>${s}</${c}>`, bold: (s: string) => s };
@@ -67,18 +74,26 @@ describe("AgentWidget", () => {
     };
   }
 
-  function makeRecord(id: string, opts: { isBackground?: boolean; parentAgentId?: string } = {}) {
+  function makeRecord(id: string, opts: {
+    isBackground?: boolean;
+    parentAgentId?: string;
+    status?: "running" | "queued" | "completed";
+    cwd?: string;
+    completedAt?: number;
+  } = {}) {
     return {
       id,
       type: "general-purpose",
       description: `${id} description`,
-      status: "running",
+      status: opts.status ?? "running",
       toolUses: 0,
       startedAt: Date.now(),
       lifetimeUsage: { input: 0, output: 0, cacheRead: 0, cacheWrite: 0 },
       compactionCount: 0,
       isBackground: opts.isBackground,
       parentAgentId: opts.parentAgentId,
+      cwd: opts.cwd,
+      completedAt: opts.completedAt,
     };
   }
 
@@ -142,5 +157,123 @@ describe("AgentWidget", () => {
   it("renders nothing in 'off' mode", () => {
     const manager = { listAgents: () => [makeRecord("background", { isBackground: true })] };
     expect(renderLines(manager, "background", () => "off")).toBe("");
+  });
+
+  it("renders a debounced Git summary in the running card", async () => {
+    vi.useFakeTimers();
+    try {
+      const record = makeRecord("live", { cwd: "/repo" });
+      const exec = vi.fn()
+        .mockResolvedValueOnce({ code: 0, stdout: "82\t16\tsrc/file.ts\n" })
+        .mockResolvedValueOnce({ code: 0, stdout: "" });
+      const manager = {
+        listAgents: () => [record],
+        getRecord: (id: string) => id === record.id ? record : undefined,
+      };
+      const widget = new AgentWidget(
+        manager as any,
+        new Map([[record.id, makeActivity()]]),
+        () => "all",
+        { exec } as unknown as Pick<ExtensionAPI, "exec">,
+      );
+      let factory: any;
+      widget.setUICtx({
+        setStatus: () => {},
+        setWidget: (_key, content) => { factory = content; },
+      });
+      widget.update();
+      await vi.runAllTimersAsync();
+
+      const lines = factory({ terminal: { columns: 120 }, requestRender: () => {} }, theme)
+        .render()
+        .join("\n");
+      expect(lines).toContain("1 file · +82 −16");
+      expect(exec).toHaveBeenNthCalledWith(
+        1,
+        "git",
+        ["diff", "--numstat", "HEAD", "--"],
+        expect.objectContaining({ cwd: "/repo" }),
+      );
+      widget.dispose();
+    } finally {
+      vi.useRealTimers();
+    }
+  });
+
+  it("omits a cached Git summary after the current refresh fails", async () => {
+    vi.useFakeTimers();
+    try {
+      const record = makeRecord("live", { cwd: "/repo" });
+      const exec = vi.fn()
+        .mockResolvedValueOnce({ code: 0, stdout: "82\t16\tsrc/file.ts\n" })
+        .mockResolvedValueOnce({ code: 0, stdout: "" })
+        .mockResolvedValueOnce({ code: 128, stdout: "" });
+      const manager = {
+        listAgents: () => [record],
+        getRecord: (id: string) => id === record.id ? record : undefined,
+      };
+      const widget = new AgentWidget(
+        manager as any,
+        new Map([[record.id, makeActivity()]]),
+        () => "all",
+        { exec } as unknown as Pick<ExtensionAPI, "exec">,
+      );
+      let factory: any;
+      widget.setUICtx({
+        setStatus: () => {},
+        setWidget: (_key, content) => { factory = content; },
+      });
+      widget.update();
+      await vi.runAllTimersAsync();
+      widget.onActivity(record.id);
+      await vi.runAllTimersAsync();
+
+      const lines = factory({ terminal: { columns: 120 }, requestRender: () => {} }, theme)
+        .render()
+        .join("\n");
+      expect(lines).not.toContain("1 file · +82 −16");
+      widget.dispose();
+    } finally {
+      vi.useRealTimers();
+    }
+  });
+
+  it("labels untracked files instead of including them in line totals", () => {
+    expect(formatGitSummary({ trackedFiles: 2, additions: 82, deletions: 16, untrackedFiles: 1 }))
+      .toBe("2 files · +82 −16 · 1 untracked");
+  });
+
+  it("does not query queued, completed, or no-cwd records", async () => {
+    vi.useFakeTimers();
+    try {
+      const records = [
+        makeRecord("queued", { status: "queued", cwd: "/repo" }),
+        makeRecord("completed", { status: "completed", cwd: "/repo", completedAt: Date.now() }),
+        makeRecord("no-cwd"),
+      ];
+      const exec = vi.fn();
+      const manager = {
+        listAgents: () => records,
+        getRecord: (id: string) => records.find(record => record.id === id),
+      };
+      const widget = new AgentWidget(
+        manager as any,
+        new Map(records.map(record => [record.id, makeActivity()])),
+        () => "all",
+        { exec } as unknown as Pick<ExtensionAPI, "exec">,
+      );
+      widget.setUICtx({
+        setStatus: () => {},
+        setWidget: (_key, content) => {
+          if (content) content({ terminal: { columns: 120 }, requestRender: () => {} }, theme);
+        },
+      });
+      widget.update();
+      await vi.runAllTimersAsync();
+      expect(exec).not.toHaveBeenCalled();
+      widget.dispose();
+    } finally {
+      vi.useRealTimers();
+    }
   });
 });


### PR DESCRIPTION
## Summary

- show a debounced, live Git working-tree summary on active AgentWidget cards
- use each running agent's actual execution cwd, including its worktree path
- label untracked files separately from tracked `+additions −deletions` totals
- silently omit stale stats when Git is unavailable or a refresh fails

The indicator describes the current working tree, not perfect per-agent attribution; pre-existing changes in a shared checkout can be included.

Closes #207

## Verification

- `npm run lint`
- `npm run typecheck`
- `npx vitest run test/agent-widget.test.ts test/agent-manager.test.ts` — 72 passed
- `npm run test` — 824 passed, 5 skipped
- `npm run build`
- independent focused review: PASS (`871771a86fead1fe9c1679e166855170d059c191`)
