### PR TITLE
feat: add subagent gate with allow/disallow/steer picker

### DIFF
--- a/src/index.ts
+++ b/src/index.ts
@@ -636,6 +636,12 @@ export default function (pi: ExtensionAPI) {
   function isSchedulingEnabled(): boolean { return schedulingEnabled; }
   function setSchedulingEnabled(b: boolean) { schedulingEnabled = b; }
 
+  // Per-invocation gate: when true, every Agent tool call shows an
+  // allow/disallow/steer picker before spawning. Defaults to off.
+  let subagentGateEnabled = false;
+  function isSubagentGateEnabled(): boolean { return subagentGateEnabled; }
+  function setSubagentGateEnabled(b: boolean) { subagentGateEnabled = b; }
+
   // ---- Disable default agents configuration ----
   // When enabled, the three hardcoded default agents (general-purpose, Explore,
   // Plan) are not registered. User-defined agents from project/global custom
@@ -768,6 +774,7 @@ export default function (pi: ExtensionAPI) {
       setOutputTranscript: setOutputTranscriptDefault,
       setMaxSubagentDepth: setMaxSubagentDepth,
       setFallbackSubagent: setFallbackSubagent,
+      setSubagentGate: setSubagentGateEnabled,
     },
     (event, payload) => pi.events.emit(event, payload),
   );
@@ -1063,6 +1070,27 @@ Terse command-style prompts produce shallow, generic work.
 
       // Reload custom agents so new project/global .md files are picked up without restart
       reloadCustomAgents();
+
+      // ---- Subagent gate: allow/disallow/steer picker ----
+      // Skipped for resume (continues existing work) and scheduled jobs
+      // (fire automatically, no user present to pick).
+      if (isSubagentGateEnabled() && !params.resume && !params.schedule) {
+        const choice = await ctx.ui.select(
+          `Allow subagent: ${params.description}`,
+          ["Allow", "Disallow", "Steer"],
+        );
+        if (choice !== "Allow" && choice !== "Steer") {
+          // Disallow or Esc — block the invocation
+          return textResult(`User blocked subagent "${params.description}". Proceed without it.`);
+        }
+        if (choice === "Steer") {
+          const steerMsg = await ctx.ui.input("Steering message (prepended to agent prompt)");
+          if (steerMsg === undefined) {
+            return textResult(`User blocked subagent "${params.description}". Proceed without it.`);
+          }
+          params = { ...params, prompt: `[User guidance]\n${steerMsg}\n\n[Task]\n${params.prompt}` };
+        }
+      }
 
       const rawType = params.subagent_type as SubagentType;
       // Single decision point for dispatch (#183): unknown, disabled and
@@ -2159,6 +2187,7 @@ ${systemPrompt}
       // explicit configuration — which then fails loudly if general-purpose later
       // goes away. undefined is dropped by JSON.stringify.
       fallbackSubagent: getFallbackSubagent(),
+      subagentGate: isSubagentGateEnabled(),
     };
   }
 
@@ -2277,6 +2306,13 @@ ${systemPrompt}
           currentValue: getToolDescriptionMode(),
           values: ["full", "compact", "custom"],
         },
+        {
+          id: "subagentGate",
+          label: "Subagent gate",
+          description: "Show allow/disallow/steer picker before every Agent tool invocation (skipped for resume and scheduled jobs)",
+          currentValue: isSubagentGateEnabled() ? "on" : "off",
+          values: ["on", "off"],
+        },
       ];
     }
 
@@ -2362,6 +2398,10 @@ ${systemPrompt}
       } else if (id === "widgetMode") {
         setWidgetMode(value as WidgetMode);
         notifyApplied(ctx, `Widget set to ${value}`);
+      } else if (id === "subagentGate") {
+        const enabled = value === "on";
+        setSubagentGateEnabled(enabled);
+        notifyApplied(ctx, `Subagent gate ${enabled ? "enabled" : "disabled"}`);
       }
     }
 

--- a/src/settings.ts
+++ b/src/settings.ts
@@ -129,6 +129,15 @@ export interface SubagentsSettings {
    * meaning one thing here and another in the resolver.
    */
   fallbackSubagent?: string;
+  /**
+   * When true, every Agent tool invocation shows an allow/disallow/steer picker
+   * before the subagent spawns. The user can:
+   *   - Allow: proceed normally
+   *   - Disallow: block the invocation (returns an error to the LLM)
+   *   - Steer: prompt for a message that gets prepended to the agent's prompt
+   * Defaults to false (no gate). Skipped for resume and scheduled invocations.
+   */
+  subagentGate?: boolean;
 }
 
 export type ToolDescriptionMode = "full" | "compact" | "custom";
@@ -149,6 +158,7 @@ export interface SettingsAppliers {
   setOutputTranscript: (b: boolean) => void;
   setMaxSubagentDepth: (n: number) => void;
   setFallbackSubagent: (v: string | undefined) => void;
+  setSubagentGate: (b: boolean) => void;
 }
 
 /** Emit callback — a subset of `pi.events.emit` to keep helpers testable. */
@@ -226,6 +236,9 @@ function sanitize(raw: unknown): SubagentsSettings {
   if (typeof r.outputTranscript === "boolean") {
     out.outputTranscript = r.outputTranscript;
   }
+  if (typeof r.subagentGate === "boolean") {
+    out.subagentGate = r.subagentGate;
+  }
   if (r.fallbackSubagent === false) {
     // The only non-string spelling worth accepting: a boolean would otherwise be
     // dropped, silently leaving the PERMISSIVE default in place. Every string is
@@ -300,6 +313,7 @@ export function applySettings(s: SubagentsSettings, appliers: SettingsAppliers):
   if (typeof s.fleetView === "boolean") appliers.setFleetView(s.fleetView);
   if (s.widgetMode) appliers.setWidgetMode(s.widgetMode);
   if (typeof s.outputTranscript === "boolean") appliers.setOutputTranscript(s.outputTranscript);
+  if (typeof s.subagentGate === "boolean") appliers.setSubagentGate(s.subagentGate);
 }
 
 /**


### PR DESCRIPTION
### Changes

- **src/settings.ts** — Added `subagentGate?: boolean` to:
  - SubagentsSettings interface (with docstring)
  - SettingsAppliers interface (`setSubagentGate`)
  - `sanitize()` validation
  - `applySettings()` wiring

- **src/index.ts** — 4 integration points:
  1. State: `subagentGateEnabled` boolean + getter/setter, defaults to false
  2. Gate logic: In the execute function, after `reloadCustomAgents()` and before type resolution — shows a 3-option picker:
     - Allow → proceeds normally
     - Disallow → returns an error to the LLM telling it to proceed without the subagent
     - Steer → prompts for a message, prepends it to the agent's prompt as `[User guidance]`
     - Cancelling the steer input is treated as disallow
     - Skipped for resume and schedule invocations (no user present)
  3. Applier: Wired `setSubagentGate: setSubagentGateEnabled` in `applyAndEmitLoaded`
  4. Settings menu: Added "Subagent gate" toggle (on/off) to `/agents → Settings`, plus snapshot persistence

### Usage

- Enable via `/agents → Settings → Subagent gate → on`
- Or set `"subagentGate": true` in `~/.pi/agent/subagents.json` (global) or `<project>/.pi/subagents.json` (project)
- Once enabled, every Agent tool call will prompt you before spawning