### PR TITLE
feat(ui): add custom agent color badges

### DIFF
--- a/README.md
+++ b/README.md
@@ -15,7 +15,7 @@ https://github.com/user-attachments/assets/8685261b-9338-4fea-8dfe-1c590d5df543
 - **Live widget UI** — persistent above-editor widget with animated spinners, live tool activity, token counts, and colored status icons. Configurable via `/agents → Settings → Widget`: `all` (every agent), `background` (default — hides foreground runs, which already render inline as the `Agent` tool result), or `off`
 - **FleetView** — Claude Code-style navigable list of `main` + every running subagent rendered below the editor (earliest-launched first). Press `↓` (or `←`) at an empty prompt to jump in, `↑`/`↓` to move the selection, `Enter` to open the selected agent's live, auto-updating conversation, `Esc` to return. Finished agents linger briefly before dropping out, and a viewer stays open through completion so you can read the final output. Toggle via `/agents → Settings → Fleet view`
 - **Conversation viewer** — select any agent in `/agents` to open a live-scrolling overlay of its full conversation (auto-follows new content, scroll up to pause). Steer a running agent inline by pressing `Enter` to open a composer, typing, then `Enter` to send (`Esc` or an empty submit returns) — the message appears as a user message and redirects the agent after its current tool. Stop a still-running agent by pressing `x` (then `x` again to confirm) — both work for background agents too
-- **Custom agent types** — define agents in `.pi/agents/<name>.md` or `.agents/agents/<name>.md` (project) or globally, with YAML frontmatter: custom system prompts, model selection, thinking levels, tool restrictions
+- **Custom agent types** — define agents in `.pi/agents/<name>.md` or `.agents/agents/<name>.md` (project) or globally, with YAML frontmatter: custom system prompts, model selection, thinking levels, tool restrictions, and Claude Code-compatible colored name badges
 - **Nested subagents** — opt-in, default-off delegation: a custom agent that sets `allowed_subagents` gets its own ownership-scoped `Agent`, `get_subagent_result`, and `steer_subagent` tools, depth-capped from the main session (default 2). It can control only its own children, they are stopped when it finishes, and their transcripts and token spend roll up to it. The allowlist is a privilege boundary — a child runs with its own tools, so pick it as carefully as `tools:` itself
 - **Mid-run steering** — inject messages into running agents to redirect their work without restarting
 - **Session resume** — pick up where an agent left off, preserving full conversation context
@@ -164,7 +164,7 @@ Default agents can be **ejected** (`/agents` → select agent → Eject) to expo
 
 ## Custom Agents
 
-Define custom agent types by creating `.md` files. The filename becomes the agent type name. Any name is allowed — using a default agent's name overrides it.
+Define custom agent types by creating `.md` files. The filename becomes the `subagent_type` and dispatch identity; `name` and `display_name` only change the UI label. Using a default agent's filename overrides it.
 
 Agents are discovered from three locations (higher priority wins):
 
@@ -182,6 +182,8 @@ An unreadable or unparseable agent file is skipped, not fatal — a warning name
 
 ```markdown
 ---
+name: Security Auditor
+color: red
 description: Security Code Reviewer
 tools: read, grep, find, bash
 model: anthropic/claude-opus-4-6
@@ -211,7 +213,9 @@ All fields are optional — sensible defaults for everything.
 | Field | Default | Description |
 |-------|---------|-------------|
 | `description` | filename | Agent description shown in tool listings |
-| `display_name` | — | Display name for UI (e.g. widget, agent list) |
+| `name` | filename | Claude Code-compatible UI display name. The filename still determines the `subagent_type`; `display_name` wins when both are set |
+| `display_name` | `name`, then filename | Pi-specific UI display name (e.g. widget, FleetView, conversation viewer) |
+| `color` | — | Background color for the agent name badge in the Agent tool header, widget, FleetView, and conversation viewer. Supports Claude Code's `red`, `blue`, `green`, `yellow`, `purple`, `orange`, `pink`, `cyan`; quoted six-digit hex such as `"#8B5CF6"`; and Agency Agents aliases (`amber`, `teal`, `indigo`, `gold`, `neon-green`, `neon-cyan`, `metallic-blue`, `violet`, `rose`, `lime`, `gray`/`grey`, `fuchsia`, `slate`, `navy`). The badge automatically selects black or white text for at least 4.5:1 contrast against the rendered background. Invalid values render no badge and preserve each surface's existing theme foreground |
 | `tools` | all 7 | Which tools the agent can call. Built-in names (`read, grep, …`), `*` / `all` (all built-ins), `none`, and `ext:<extension>` / `ext:<extension>/<tool>` selectors for extension tools. See [Tool & extension scoping](#tool--extension-scoping) below |
 | `extensions` | `true` | Which extensions to load for the agent. `true` (all defaults), `false` (none), or an explicit list: `[mcp, "/abs/path.ts", "*"]`. See [Tool & extension scoping](#tool--extension-scoping) below |
 | `exclude_extensions` | — | Extension denylist applied after `extensions:` — exclude wins. Plain names only (case-insensitive), no paths or `*`. Useful with `extensions: true` to drop one extension (e.g. `pi-notify`) |
@@ -650,6 +654,7 @@ src/
   types.ts            # Type definitions (AgentConfig, AgentRecord, etc.)
   default-agents.ts   # Embedded default agent configs (general-purpose, Explore, Plan)
   agent-types.ts      # Unified agent registry (defaults + user), tool name resolution
+  agent-color.ts      # Claude Code/Agency Agents name color parsing and badge rendering
   agent-runner.ts     # Session creation, execution, graceful max_turns, steer/resume
   agent-manager.ts    # Agent lifecycle, concurrency queue, completion notifications
   cross-extension-rpc.ts # RPC handlers for cross-extension spawn/ping via pi.events

--- a/src/agent-color.ts
+++ b/src/agent-color.ts
@@ -1,0 +1,168 @@
+/**
+ * agent-color.ts — Claude Code-compatible agent name color rendering.
+ *
+ * Claude Code defines eight named subagent colors. Agency Agents also uses
+ * six-digit hex values and a small set of additional palette names, which are
+ * accepted here so those definitions render without conversion.
+ */
+
+import { getConfig } from "./agent-types.js";
+
+const NAMED_AGENT_COLORS: Readonly<Record<string, string>> = {
+  red: "#E74C3C",
+  blue: "#3498DB",
+  green: "#2ECC71",
+  yellow: "#EAB308",
+  purple: "#9B59B6",
+  orange: "#F39C12",
+  pink: "#E84393",
+  cyan: "#00FFFF",
+  amber: "#F59E0B",
+  teal: "#008080",
+  indigo: "#6366F1",
+  gold: "#EAB308",
+  "neon-green": "#10B981",
+  "neon-cyan": "#06B6D4",
+  "metallic-blue": "#3B82F6",
+  violet: "#8B5CF6",
+  rose: "#F43F5E",
+  lime: "#84CC16",
+  gray: "#6B7280",
+  grey: "#6B7280",
+  fuchsia: "#D946EF",
+  slate: "#64748B",
+  navy: "#1E3A8A",
+};
+
+const CUBE_VALUES = [0, 95, 135, 175, 215, 255] as const;
+const GRAY_VALUES = Array.from({ length: 24 }, (_, i) => 8 + i * 10);
+
+type Rgb = { r: number; g: number; b: number };
+type ColorMode = "truecolor" | "256color";
+
+export interface AgentNameTheme {
+  fg(color: string, text: string): string;
+  bold(text: string): string;
+  getColorMode?(): ColorMode;
+}
+
+export interface AgentNameStyle {
+  /** Existing theme foreground used when no valid agent color is configured. */
+  fallbackColor?: string;
+  /** Reapply an enclosing background after the badge instead of resetting it. */
+  restoreBackground?: string;
+  bold?: boolean;
+}
+
+/** Resolve Claude Code/Agency Agents color syntax to normalized #RRGGBB. */
+export function resolveAgentColor(value: string | undefined): string | undefined {
+  if (!value) return undefined;
+  const normalized = value.trim().toLowerCase();
+  const resolved = NAMED_AGENT_COLORS[normalized] ?? normalized;
+  return /^#[0-9a-f]{6}$/i.test(resolved) ? resolved.toUpperCase() : undefined;
+}
+
+function parseHex(hex: string): Rgb {
+  return {
+    r: Number.parseInt(hex.slice(1, 3), 16),
+    g: Number.parseInt(hex.slice(3, 5), 16),
+    b: Number.parseInt(hex.slice(5, 7), 16),
+  };
+}
+
+function nearestCubeIndex(value: number): number {
+  let best = 0;
+  for (let i = 1; i < CUBE_VALUES.length; i++) {
+    if (Math.abs(value - CUBE_VALUES[i]) < Math.abs(value - CUBE_VALUES[best])) best = i;
+  }
+  return best;
+}
+
+function rgbTo256({ r, g, b }: Rgb): { index: number; rgb: Rgb } {
+  const rIndex = nearestCubeIndex(r);
+  const gIndex = nearestCubeIndex(g);
+  const bIndex = nearestCubeIndex(b);
+  const cubeRgb = { r: CUBE_VALUES[rIndex], g: CUBE_VALUES[gIndex], b: CUBE_VALUES[bIndex] };
+  const distance = (candidate: Rgb) => {
+    const dr = r - candidate.r;
+    const dg = g - candidate.g;
+    const db = b - candidate.b;
+    return dr * dr * 0.299 + dg * dg * 0.587 + db * db * 0.114;
+  };
+
+  const gray = Math.round(0.299 * r + 0.587 * g + 0.114 * b);
+  let grayIndex = 0;
+  for (let i = 1; i < GRAY_VALUES.length; i++) {
+    if (Math.abs(gray - GRAY_VALUES[i]) < Math.abs(gray - GRAY_VALUES[grayIndex])) grayIndex = i;
+  }
+  const grayRgb = { r: GRAY_VALUES[grayIndex], g: GRAY_VALUES[grayIndex], b: GRAY_VALUES[grayIndex] };
+  if (Math.max(r, g, b) - Math.min(r, g, b) < 10 && distance(grayRgb) < distance(cubeRgb)) {
+    return { index: 232 + grayIndex, rgb: grayRgb };
+  }
+  return { index: 16 + 36 * rIndex + 6 * gIndex + bIndex, rgb: cubeRgb };
+}
+
+function ansiColor(layer: "foreground" | "background", color: Rgb | number): string {
+  const code = layer === "foreground" ? 38 : 48;
+  return typeof color === "number"
+    ? `\u001b[${code};5;${color}m`
+    : `\u001b[${code};2;${color.r};${color.g};${color.b}m`;
+}
+
+function relativeLuminance({ r, g, b }: Rgb): number {
+  const linear = (value: number) => {
+    const channel = value / 255;
+    return channel <= 0.04045 ? channel / 12.92 : ((channel + 0.055) / 1.055) ** 2.4;
+  };
+  return 0.2126 * linear(r) + 0.7152 * linear(g) + 0.0722 * linear(b);
+}
+
+/**
+ * Render one name as a padded background badge when `color` is valid.
+ * Black/white foreground is selected by WCAG contrast; invalid or omitted
+ * colors preserve the caller's existing theme styling.
+ */
+export function renderAgentNameLabel(
+  name: string,
+  color: string | undefined,
+  theme: AgentNameTheme,
+  style: AgentNameStyle = {},
+): string {
+  const resolved = resolveAgentColor(color);
+  if (!resolved) {
+    const text = style.bold ? theme.bold(name) : name;
+    return style.fallbackColor ? theme.fg(style.fallbackColor, text) : text;
+  }
+
+  const backgroundRgb = parseHex(resolved);
+  const mode = theme.getColorMode?.() ?? "truecolor";
+  let background: Rgb | number = backgroundRgb;
+  let effectiveBackground = backgroundRgb;
+  if (mode === "256color") {
+    const quantized = rgbTo256(backgroundRgb);
+    background = quantized.index;
+    effectiveBackground = quantized.rgb;
+  }
+  const foregroundRgb = relativeLuminance(effectiveBackground) > 0.179
+    ? { r: 0, g: 0, b: 0 }
+    : { r: 255, g: 255, b: 255 };
+  const foreground = mode === "256color" ? rgbTo256(foregroundRgb).index : foregroundRgb;
+  const label = style.bold ? theme.bold(` ${name} `) : ` ${name} `;
+
+  return ansiColor("background", background)
+    + ansiColor("foreground", foreground)
+    + label
+    + "\u001b[39m"
+    + (style.restoreBackground ?? "\u001b[49m");
+}
+
+/** Render a registered agent's display name with its configured color. */
+export function renderAgentName(
+  type: string | undefined,
+  theme: AgentNameTheme,
+  style: AgentNameStyle = {},
+): string {
+  if (!type) return renderAgentNameLabel("Agent", undefined, theme, style);
+  const config = getConfig(type);
+  return renderAgentNameLabel(config.displayName, config.color, theme, style);
+}

--- a/src/agent-types.ts
+++ b/src/agent-types.ts
@@ -295,6 +295,7 @@ export function getToolNamesForType(type: string): string[] {
 /** Get config for a type (case-insensitive, returns a SubagentTypeConfig-compatible object). Falls back to general-purpose. */
 export function getConfig(type: string): {
   displayName: string;
+  color?: string;
   description: string;
   builtinToolNames: string[];
   extensions: true | string[] | false;
@@ -307,6 +308,7 @@ export function getConfig(type: string): {
   if (config && config.enabled !== false) {
     return {
       displayName: config.displayName ?? config.name,
+      color: config.color,
       description: config.description,
       builtinToolNames: config.builtinToolNames ?? BUILTIN_TOOL_NAMES,
       extensions: config.extensions,
@@ -321,6 +323,7 @@ export function getConfig(type: string): {
   if (gp && gp.enabled !== false) {
     return {
       displayName: gp.displayName ?? gp.name,
+      color: gp.color,
       description: gp.description,
       builtinToolNames: gp.builtinToolNames ?? BUILTIN_TOOL_NAMES,
       extensions: gp.extensions,

--- a/src/custom-agents.ts
+++ b/src/custom-agents.ts
@@ -62,7 +62,8 @@ function loadFromDir(dir: string, agents: Map<string, AgentConfig>, source: "pro
 
     agents.set(name, {
       name,
-      displayName: str(fm.display_name),
+      displayName: str(fm.display_name) ?? str(fm.name),
+      color: str(fm.color),
       description: str(fm.description) ?? name,
       builtinToolNames,
       extSelectors,

--- a/src/index.ts
+++ b/src/index.ts
@@ -16,6 +16,7 @@ import { defineTool, type ExtensionAPI, type ExtensionCommandContext, type Exten
 import { Container, Key, matchesKey, type SettingItem, SettingsList, Spacer, Text } from "@earendil-works/pi-tui";
 import { Type } from "@sinclair/typebox";
 import { abortable } from "./abortable.js";
+import { renderAgentName } from "./agent-color.js";
 import { AgentManager } from "./agent-manager.js";
 import { getAgentConversation, getDefaultMaxTurns, getGraceTurns, normalizeMaxTurns, SUBAGENT_TOOL_NAMES, setDefaultMaxTurns, setGraceTurns, steerAgent } from "./agent-runner.js";
 import { BUILTIN_TOOL_NAMES, getAgentConfig, getAllTypes, getAvailableTypes, getFallbackSubagent, isDefaultsDisabled, NO_FALLBACK, registerAgents, resolveSpawnType, resolveType, setDefaultsDisabled, setFallbackSubagent } from "./agent-types.js";
@@ -969,10 +970,18 @@ Terse command-style prompts produce shallow, generic work.
 
     // ---- Custom rendering: Claude Code style ----
 
-    renderCall(args, theme) {
-      const displayName = args.subagent_type ? getDisplayName(args.subagent_type) : "Agent";
+    renderCall(args, theme, context) {
+      let restoreBackground = theme.getBgAnsi("toolSuccessBg");
+      if (context.isPartial) restoreBackground = theme.getBgAnsi("toolPendingBg");
+      else if (context.isError) restoreBackground = theme.getBgAnsi("toolErrorBg");
+
       const desc = args.description ?? "";
-      return new Text("▸ " + theme.fg("toolTitle", theme.bold(displayName)) + (desc ? "  " + theme.fg("muted", desc) : ""), 0, 0);
+      const name = renderAgentName(args.subagent_type, theme, {
+        fallbackColor: "toolTitle",
+        restoreBackground,
+        bold: true,
+      });
+      return new Text("▸ " + name + (desc ? "  " + theme.fg("muted", desc) : ""), 0, 0);
     },
 
     renderResult(result, { expanded, isPartial }, theme) {
@@ -1873,6 +1882,7 @@ Terse command-style prompts produce shallow, generic work.
     const fmFields: string[] = [];
     fmFields.push(`description: ${JSON.stringify(cfg.description)}`);
     if (cfg.displayName) fmFields.push(`display_name: ${cfg.displayName}`);
+    if (cfg.color) fmFields.push(`color: ${JSON.stringify(cfg.color)}`);
     fmFields.push(`tools: ${cfg.builtinToolNames?.join(", ") || "all"}`);
     if (cfg.model) fmFields.push(`model: ${cfg.model}`);
     if (cfg.thinking) fmFields.push(`thinking: ${cfg.thinking}`);
@@ -2005,7 +2015,9 @@ The file format is a markdown file with YAML frontmatter and a system prompt bod
 
 \`\`\`markdown
 ---
+name: <optional UI display name; Claude Code-compatible alias for display_name>
 description: <one-line description shown in UI>
+color: <optional name badge color: red, blue, green, yellow, purple, orange, pink, cyan, an Agency Agents alias, or quoted "#RRGGBB">
 tools: <comma-separated built-in tools: read, bash, edit, write, grep, find, ls. Use "none" for no tools. Omit for all tools>
 model: <optional model as "provider/modelId", e.g. "anthropic/claude-haiku-4-5". Omit to inherit parent model>
 thinking: <optional thinking level: ${THINKING_LEVELS.join(", ")}. Omit to inherit>

--- a/src/types.ts
+++ b/src/types.ts
@@ -23,7 +23,10 @@ export type IsolationMode = "worktree";
 /** Unified agent configuration — used for both default and user-defined agents. */
 export interface AgentConfig {
   name: string;
+  /** UI name. `display_name` wins; Claude Code's `name` is accepted as a fallback. */
   displayName?: string;
+  /** Claude Code-compatible name color (named color or #RRGGBB). */
+  color?: string;
   description: string;
   builtinToolNames?: string[];
   /** Raw `ext:` selector entries from the `tools:` CSV, e.g. ["ext:foo", "ext:bar/x"].

--- a/src/ui/agent-widget.ts
+++ b/src/ui/agent-widget.ts
@@ -6,6 +6,7 @@
  */
 
 import { truncateToWidth } from "@earendil-works/pi-tui";
+import { renderAgentName } from "../agent-color.js";
 import type { AgentManager } from "../agent-manager.js";
 import { getConfig } from "../agent-types.js";
 import type { AgentInvocation, SubagentType, WidgetMode } from "../types.js";
@@ -307,7 +308,6 @@ export class AgentWidget {
 
   /** Render a finished agent line. */
   private renderFinishedLine(a: { id: string; type: SubagentType; status: string; description: string; toolUses: number; startedAt: number; completedAt?: number; error?: string }, theme: Theme): string {
-    const name = getDisplayName(a.type);
     const modeLabel = getPromptModeLabel(a.type);
     const duration = formatMs((a.completedAt ?? Date.now()) - a.startedAt);
 
@@ -339,7 +339,7 @@ export class AgentWidget {
     parts.push(duration);
 
     const modeTag = modeLabel ? ` ${theme.fg("dim", `(${modeLabel})`)}` : "";
-    return `${icon} ${theme.fg("dim", name)}${modeTag}  ${theme.fg("dim", a.description)} ${theme.fg("dim", "·")} ${theme.fg("dim", parts.join(" · "))}${statusText}`;
+    return `${icon} ${renderAgentName(a.type, theme, { fallbackColor: "dim" })}${modeTag}  ${theme.fg("dim", a.description)} ${theme.fg("dim", "·")} ${theme.fg("dim", parts.join(" · "))}${statusText}`;
   }
 
   /**
@@ -377,7 +377,6 @@ export class AgentWidget {
 
     const runningLines: string[][] = []; // each entry is [header, activity]
     for (const a of running) {
-      const name = getDisplayName(a.type);
       const modeLabel = getPromptModeLabel(a.type);
       const modeTag = modeLabel ? ` ${theme.fg("dim", `(${modeLabel})`)}` : "";
       const elapsed = formatMs(Date.now() - a.startedAt);
@@ -398,7 +397,7 @@ export class AgentWidget {
       const activity = bg ? describeActivity(bg.activeTools, bg.responseText) : "thinking…";
 
       runningLines.push([
-        truncate(theme.fg("dim", "├─") + ` ${theme.fg("accent", frame)} ${theme.bold(name)}${modeTag}  ${theme.fg("muted", a.description)} ${theme.fg("dim", "·")} ${fgPreservingNestedStyles(theme, "dim", statsText)}`),
+        truncate(theme.fg("dim", "├─") + ` ${theme.fg("accent", frame)} ${renderAgentName(a.type, theme, { bold: true })}${modeTag}  ${theme.fg("muted", a.description)} ${theme.fg("dim", "·")} ${fgPreservingNestedStyles(theme, "dim", statsText)}`),
         truncate(theme.fg("dim", "│  ") + theme.fg("dim", `  ⎿  ${activity}`)),
       ]);
     }

--- a/src/ui/conversation-viewer.ts
+++ b/src/ui/conversation-viewer.ts
@@ -7,11 +7,12 @@
 
 import type { AgentSession } from "@earendil-works/pi-coding-agent";
 import { type Component, Input, matchesKey, type TUI, truncateToWidth, visibleWidth, wrapTextWithAnsi } from "@earendil-works/pi-tui";
+import { renderAgentName } from "../agent-color.js";
 import { extractText } from "../context.js";
 import type { AgentRecord } from "../types.js";
 import { getLifetimeTotal, getSessionContextPercent } from "../usage.js";
 import type { Theme } from "./agent-widget.js";
-import { type AgentActivity, buildInvocationTags, describeActivity, fgPreservingNestedStyles, formatDuration, formatSessionTokens, getDisplayName, getPromptModeLabel } from "./agent-widget.js";
+import { type AgentActivity, buildInvocationTags, describeActivity, fgPreservingNestedStyles, formatDuration, formatSessionTokens, getPromptModeLabel } from "./agent-widget.js";
 import { createViewerKeys, type ViewerKeybindings, type ViewerKeys } from "./viewer-keys.js";
 
 /** Base lines consumed by chrome: top border + header + header sep + footer sep + footer + bottom border. */
@@ -137,7 +138,6 @@ export class ConversationViewer implements Component {
 
     // Header
     lines.push(hrTop);
-    const name = getDisplayName(this.record.type);
     const modeLabel = getPromptModeLabel(this.record.type);
     const modeTag = modeLabel ? ` ${th.fg("dim", `(${modeLabel})`)}` : "";
     const statusIcon = this.record.status === "running"
@@ -159,7 +159,7 @@ export class ConversationViewer implements Component {
     }
 
     lines.push(row(
-      `${statusIcon} ${th.bold(name)}${modeTag}  ${th.fg("muted", this.record.description)} ${th.fg("dim", "·")} ${fgPreservingNestedStyles(th, "dim", headerParts.join(" · "))}`,
+      `${statusIcon} ${renderAgentName(this.record.type, th, { bold: true })}${modeTag}  ${th.fg("muted", this.record.description)} ${th.fg("dim", "·")} ${fgPreservingNestedStyles(th, "dim", headerParts.join(" · "))}`,
     ));
     const invocationLine = this.invocationLine();
     if (invocationLine) lines.push(row(invocationLine));

--- a/src/ui/fleet-list.ts
+++ b/src/ui/fleet-list.ts
@@ -12,10 +12,11 @@
  */
 
 import { Editor, isKeyRelease, Key, matchesKey, truncateToWidth, visibleWidth } from "@earendil-works/pi-tui";
+import { renderAgentName } from "../agent-color.js";
 import type { AgentManager } from "../agent-manager.js";
 import type { AgentRecord } from "../types.js";
 import { getLifetimeTotal } from "../usage.js";
-import { type AgentActivity, getDisplayName, type Theme } from "./agent-widget.js";
+import { type AgentActivity, type Theme } from "./agent-widget.js";
 import { ConversationViewer, VIEWPORT_HEIGHT_PCT } from "./conversation-viewer.js";
 
 /** Widget key for the below-editor fleet list. */
@@ -371,7 +372,7 @@ export class FleetList {
   }
 
   private renderAgentRow(rosterIndex: number, sel: number, record: AgentRecord, width: number, theme: Theme): string {
-    const left = `  ${this.bullet(rosterIndex, sel, theme)} ${theme.fg("muted", getDisplayName(record.type))}  ${record.description}`;
+    const left = `  ${this.bullet(rosterIndex, sel, theme)} ${renderAgentName(record.type, theme, { fallbackColor: "muted" })}  ${record.description}`;
     const tokens = getLifetimeTotal(this.agentActivity.get(record.id)?.lifetimeUsage ?? record.lifetimeUsage);
     const elapsedMs = (record.completedAt ?? Date.now()) - record.startedAt; // freezes once finished
     const right = theme.fg("dim", `${formatFleetElapsed(elapsedMs)} · ${formatFleetTokens(tokens)}`);

--- a/test/agent-color-surfaces.test.ts
+++ b/test/agent-color-surfaces.test.ts
@@ -1,0 +1,230 @@
+import { afterEach, beforeEach, describe, expect, it, vi } from "vitest";
+import { registerAgents } from "../src/agent-types.js";
+import subagentsExtension from "../src/index.js";
+import type { AgentConfig, AgentRecord } from "../src/types.js";
+import { type AgentActivity, AgentWidget } from "../src/ui/agent-widget.js";
+import { ConversationViewer } from "../src/ui/conversation-viewer.js";
+import { FleetList, type FleetUICtx } from "../src/ui/fleet-list.js";
+
+const TYPE = "colored-reviewer";
+const DISPLAY_NAME = "Code Reviewer";
+const PURPLE_BACKGROUND = "\u001b[48;2;155;89;182m";
+
+const config: AgentConfig = {
+  name: TYPE,
+  displayName: DISPLAY_NAME,
+  color: "purple",
+  description: "Reviews code",
+  extensions: false,
+  skills: false,
+  systemPrompt: "Review code.",
+  promptMode: "replace",
+};
+
+const theme = {
+  fg: (color: string, text: string) => `<${color}>${text}</${color}>`,
+  bold: (text: string) => `*${text}*`,
+  getBgAnsi: (color: string) => `<${color}>`,
+  getColorMode: () => "truecolor" as const,
+};
+
+type RenderedComponent = { render(width?: number): string[] };
+type WidgetFactory = (
+  tui: { terminal: { columns: number; rows?: number }; requestRender: ReturnType<typeof vi.fn> },
+  activeTheme: typeof theme,
+) => RenderedComponent;
+type SessionHandler = (...args: unknown[]) => unknown;
+
+interface RegisteredTool {
+  name: string;
+  renderCall(
+    args: Record<string, unknown>,
+    activeTheme: typeof theme,
+    context: { isPartial: boolean; isError: boolean },
+  ): RenderedComponent;
+}
+
+function registerColoredReviewer(color = "purple"): void {
+  registerAgents(new Map([[TYPE, { ...config, color }]]));
+}
+
+function makeRecord(): AgentRecord {
+  return {
+    id: "review-1",
+    type: TYPE,
+    description: "Review this change",
+    status: "running",
+    toolUses: 0,
+    startedAt: Date.now(),
+    session: {
+      messages: [],
+      subscribe: vi.fn(() => vi.fn()),
+    } as unknown as AgentRecord["session"],
+    lifetimeUsage: { input: 0, output: 0, cacheWrite: 0 },
+    compactionCount: 0,
+  };
+}
+
+function makeActivity(): AgentActivity {
+  return {
+    activeTools: new Map(),
+    toolUses: 0,
+    responseText: "",
+    turnCount: 1,
+    lifetimeUsage: { input: 0, output: 0, cacheWrite: 0 },
+  };
+}
+
+function makePi() {
+  const tools = new Map<string, RegisteredTool>();
+  const handlers = new Map<string, SessionHandler>();
+  const pi = {
+    registerMessageRenderer: vi.fn(),
+    registerTool: vi.fn((tool: unknown) => {
+      const registered = tool as RegisteredTool;
+      tools.set(registered.name, registered);
+    }),
+    registerCommand: vi.fn(),
+    on: vi.fn((event: string, handler: unknown) => handlers.set(event, handler as SessionHandler)),
+    events: { emit: vi.fn(), on: vi.fn(() => vi.fn()) },
+    appendEntry: vi.fn(),
+    sendMessage: vi.fn(),
+  } as unknown as Parameters<typeof subagentsExtension>[0];
+  return { pi, tools, handlers };
+}
+
+beforeEach(() => {
+  registerColoredReviewer();
+});
+
+afterEach(() => {
+  registerAgents(new Map());
+});
+
+describe("custom agent color runtime surfaces", () => {
+  it("renders the registered Agent tool call header with the display name and color", async () => {
+    const { pi, tools, handlers } = makePi();
+    subagentsExtension(pi);
+    registerColoredReviewer();
+
+    try {
+      const tool = tools.get("Agent");
+      if (!tool) throw new Error("Agent tool was not registered");
+      const render = (context: { isPartial: boolean; isError: boolean }) => tool.renderCall(
+        { subagent_type: TYPE, description: "Review this change" },
+        theme,
+        context,
+      ).render(120).join("\n");
+      const output = render({ isPartial: false, isError: false });
+
+      expect(output).toContain(DISPLAY_NAME);
+      expect(output).toContain(PURPLE_BACKGROUND);
+      expect(output).toContain("<toolSuccessBg>");
+      expect(render({ isPartial: true, isError: false })).toContain("<toolPendingBg>");
+      expect(render({ isPartial: false, isError: true })).toContain("<toolErrorBg>");
+
+      const missingType = tool.renderCall(
+        { description: "Review this change" },
+        theme,
+        { isPartial: false, isError: false },
+      ).render(120).join("\n");
+      expect(missingType).toContain("<toolTitle>*Agent*</toolTitle>");
+      expect(missingType).not.toContain("\u001b[48;2;155;89;182m");
+    } finally {
+      await handlers.get("session_shutdown")?.({}, { hasUI: false, ui: {} });
+    }
+  });
+
+  it("renders the above-editor Agent widget with the display name and color", () => {
+    const record = makeRecord();
+    const widget = new AgentWidget(
+      { listAgents: () => [record] } as unknown as ConstructorParameters<typeof AgentWidget>[0],
+      new Map([[record.id, makeActivity()]]),
+      () => "all",
+    );
+    let factory: WidgetFactory | undefined;
+    let placement: string | undefined;
+    widget.setUICtx({
+      setStatus: vi.fn(),
+      setWidget: (_key, content, options) => {
+        if (typeof content === "function") factory = content as WidgetFactory;
+        placement = options?.placement;
+      },
+    });
+
+    try {
+      widget.update();
+      const output = factory?.(
+        { terminal: { columns: 120 }, requestRender: vi.fn() },
+        theme,
+      ).render().join("\n");
+
+      expect(placement).toBe("aboveEditor");
+      expect(output).toContain(DISPLAY_NAME);
+      expect(output).toContain(PURPLE_BACKGROUND);
+    } finally {
+      widget.dispose();
+    }
+  });
+
+  it("renders the FleetView row with the display name and color", () => {
+    const record = makeRecord();
+    const manager = {
+      listAgents: () => [record],
+      abort: vi.fn(() => true),
+      steer: vi.fn(() => true),
+    } as unknown as ConstructorParameters<typeof FleetList>[0];
+    const fleet = new FleetList(manager, new Map());
+    let factory: WidgetFactory | undefined;
+    fleet.setUICtx({
+      setWidget: (_key, content) => {
+        if (typeof content === "function") factory = content as WidgetFactory;
+      },
+      onTerminalInput: vi.fn(() => vi.fn()),
+      getEditorText: vi.fn(() => ""),
+      notify: vi.fn(),
+      custom: (() => new Promise<undefined>(() => {})) as FleetUICtx["custom"],
+    });
+
+    try {
+      fleet.update();
+      const output = factory?.(
+        { requestRender: vi.fn(), terminal: { columns: 120, rows: 40 } },
+        theme,
+      ).render(120).join("\n");
+
+      expect(output).toContain(DISPLAY_NAME);
+      expect(output).toContain(PURPLE_BACKGROUND);
+
+      registerColoredReviewer("invalid");
+      const fallback = factory?.(
+        { requestRender: vi.fn(), terminal: { columns: 120, rows: 40 } },
+        theme,
+      ).render(120).join("\n");
+      expect(fallback).toContain(`<muted>${DISPLAY_NAME}</muted>`);
+      expect(fallback).not.toContain(PURPLE_BACKGROUND);
+    } finally {
+      fleet.dispose();
+    }
+  });
+
+  it("renders the conversation viewer header with the display name and color", () => {
+    const record = makeRecord();
+    const viewer = new ConversationViewer(
+      { terminal: { rows: 30, columns: 120 }, requestRender: vi.fn() } as unknown as ConstructorParameters<typeof ConversationViewer>[0],
+      record.session!,
+      record,
+      undefined,
+      theme,
+      vi.fn(),
+    );
+
+    try {
+      const output = viewer.render(120).join("\n");
+      expect(output).toContain(DISPLAY_NAME);
+      expect(output).toContain(PURPLE_BACKGROUND);
+    } finally {
+      viewer.dispose();
+    }
+  });
+});

--- a/test/agent-color.test.ts
+++ b/test/agent-color.test.ts
@@ -1,0 +1,64 @@
+import { visibleWidth } from "@earendil-works/pi-tui";
+import { describe, expect, it } from "vitest";
+import { renderAgentNameLabel, resolveAgentColor } from "../src/agent-color.js";
+
+const theme = {
+  fg: (color: string, text: string) => `<${color}>${text}</${color}>`,
+  bold: (text: string) => `*${text}*`,
+  getColorMode: () => "truecolor" as const,
+};
+
+describe("resolveAgentColor", () => {
+  it("resolves Claude Code names and Agency Agents aliases", () => {
+    expect(resolveAgentColor("purple")).toBe("#9B59B6");
+    expect(resolveAgentColor("neon-cyan")).toBe("#06B6D4");
+    expect(resolveAgentColor("slate")).toBe("#64748B");
+  });
+
+  it("normalizes six-digit hex and rejects unsupported values", () => {
+    expect(resolveAgentColor(" #8b5cf6 ")).toBe("#8B5CF6");
+    expect(resolveAgentColor("not-a-color")).toBeUndefined();
+    expect(resolveAgentColor("#123")).toBeUndefined();
+  });
+});
+
+describe("renderAgentNameLabel", () => {
+  it("renders a padded truecolor badge with readable foreground", () => {
+    const ansiTheme = {
+      ...theme,
+      bold: (text: string) => `\u001b[1m${text}\u001b[22m`,
+    };
+    const dark = renderAgentNameLabel("Code Reviewer", "purple", ansiTheme, { bold: true });
+    expect(dark).toContain("\u001b[48;2;155;89;182m");
+    expect(dark).toContain("\u001b[38;2;255;255;255m");
+    expect(dark).toContain(" Code Reviewer ");
+    expect(visibleWidth(dark)).toBe("Code Reviewer".length + 2);
+
+    const light = renderAgentNameLabel("Tester", "yellow", theme);
+    expect(light).toContain("\u001b[38;2;0;0;0m");
+  });
+
+  it("uses effective xterm palette colors for 256-color contrast", () => {
+    const ansiTheme = { ...theme, getColorMode: () => "256color" as const };
+    const label = renderAgentNameLabel("Reviewer", "#C430C4", ansiTheme);
+    expect(label).toContain("\u001b[48;5;170m");
+    expect(label).toContain("\u001b[38;5;16m");
+
+    const neutral = renderAgentNameLabel("Reviewer", "#808080", ansiTheme);
+    expect(neutral).toContain("\u001b[48;5;244m");
+  });
+
+  it("restores an enclosing tool background after the badge", () => {
+    const label = renderAgentNameLabel("Reviewer", "purple", theme, {
+      restoreBackground: "\u001b[48;2;1;2;3m",
+    });
+    expect(label).toMatch(/\u001b\[39m\u001b\[48;2;1;2;3m$/);
+  });
+
+  it("preserves existing theme styling without a valid color", () => {
+    expect(renderAgentNameLabel("Agent", undefined, theme, { fallbackColor: "toolTitle", bold: true }))
+      .toBe("<toolTitle>*Agent*</toolTitle>");
+    expect(renderAgentNameLabel("Agent", "invalid", theme, { fallbackColor: "muted" }))
+      .toBe("<muted>Agent</muted>");
+  });
+});

--- a/test/custom-agents.test.ts
+++ b/test/custom-agents.test.ts
@@ -149,6 +149,8 @@ Just a prompt.`);
     const agent = result.get("minimal")!;
 
     expect(agent.name).toBe("minimal");
+    expect(agent.displayName).toBeUndefined();
+    expect(agent.color).toBeUndefined();
     expect(agent.description).toBe("minimal"); // defaults to filename
     expect(agent.builtinToolNames).toEqual(BUILTIN_TOOL_NAMES); // all tools
     expect(agent.extensions).toBe(true); // inherit all
@@ -580,8 +582,9 @@ enabled: false
     expect(agent.enabled).toBe(false);
   });
 
-  it("parses display_name frontmatter", () => {
+  it("parses display_name frontmatter and gives it precedence over Claude Code name", () => {
     writeAgent("myagent", `---
+name: Claude Name
 description: My Agent
 display_name: MyAgent
 ---
@@ -590,6 +593,21 @@ Agent prompt.`);
 
     const result = loadCustomAgents(tmpDir);
     expect(result.get("myagent")!.displayName).toBe("MyAgent");
+  });
+
+  it("uses Claude Code name as the display-name fallback", () => {
+    writeAgent("code-reviewer", `---
+name: Code Reviewer
+description: Reviews code
+color: "#8B5CF6"
+---
+
+Agent prompt.`);
+
+    const result = loadCustomAgents(tmpDir);
+    expect(result.get("code-reviewer")!.name).toBe("code-reviewer");
+    expect(result.get("code-reviewer")!.displayName).toBe("Code Reviewer");
+    expect(result.get("code-reviewer")!.color).toBe("#8B5CF6");
   });
 
   it("parses disallowed_tools as csv list", () => {


### PR DESCRIPTION
## Summary

- accept `name` as a UI display-name fallback while keeping the filename as `subagent_type`
- parse Claude Code named colors, six-digit hex colors, and common Agency Agents aliases
- render contrast-safe name badges in the Agent tool header, widget, FleetView, and conversation viewer
- preserve existing theme styling for missing or invalid colors, including truecolor and 256-color terminals

## Demo

![Custom agent color badges in the widget and FleetView](https://raw.githubusercontent.com/HerbertGao/pi-subagents/pr-assets/agent-color-badges.png)

## Tests

- `npm run lint`
- `npm run typecheck`
- `npm run test` — 845 passed, 5 skipped
- `npm run build`

Closes #216
