### PR TITLE
Expose cacheRead/cacheWrite in usage payload + fix prompt cache prefix ordering

### DIFF
--- a/src/agent-manager.ts
+++ b/src/agent-manager.ts
@@ -106,7 +106,7 @@ interface SpawnOptions {
   /** Called at the end of each agentic turn with the cumulative count. */
   onTurnEnd?: (turnCount: number) => void;
   /** Called once per assistant message_end with that message's usage delta. */
-  onAssistantUsage?: (usage: { input: number; output: number; cacheWrite: number }) => void;
+  onAssistantUsage?: (usage: { input: number; output: number; cacheWrite: number; cacheRead: number }) => void;
   /** Called when the session successfully compacts. */
   onCompaction?: (info: CompactionInfo) => void;
   /** Nesting depth: top-level subagent = 1. */
@@ -189,7 +189,7 @@ export class AgentManager {
       toolUses: 0,
       startedAt: Date.now(),
       abortController,
-      lifetimeUsage: { input: 0, output: 0, cacheWrite: 0 },
+      lifetimeUsage: { input: 0, output: 0, cacheWrite: 0, cacheRead: 0 },
       compactionCount: 0,
       // Raw tri-state (not coerced to a boolean): true = background, false =
       // foreground (has an inline tool-result surface), undefined = caller never

--- a/src/agent-manager.ts
+++ b/src/agent-manager.ts
@@ -106,7 +106,7 @@ interface SpawnOptions {
   /** Called at the end of each agentic turn with the cumulative count. */
   onTurnEnd?: (turnCount: number) => void;
   /** Called once per assistant message_end with that message's usage delta. */
-  onAssistantUsage?: (usage: { input: number; output: number; cacheWrite: number; cacheRead: number }) => void;
+  onAssistantUsage?: (usage: { input: number; output: number; cacheWrite: number; cacheRead?: number }) => void;
   /** Called when the session successfully compacts. */
   onCompaction?: (info: CompactionInfo) => void;
   /** Nesting depth: top-level subagent = 1. */

--- a/src/agent-runner.ts
+++ b/src/agent-runner.ts
@@ -402,7 +402,7 @@ export interface RunOptions {
    * Lets callers maintain a lifetime accumulator that survives compaction
    * (which replaces session.state.messages and resets stats-derived sums).
    */
-  onAssistantUsage?: (usage: { input: number; output: number; cacheWrite: number; cacheRead: number }) => void;
+  onAssistantUsage?: (usage: { input: number; output: number; cacheWrite: number; cacheRead?: number }) => void;
   /**
    * Called when the session successfully compacts. `tokensBefore` is upstream's
    * pre-compaction context size estimate. Aborted compactions don't fire.
@@ -989,7 +989,7 @@ export async function resumeAgent(
   prompt: string,
   options: {
     onToolActivity?: (activity: ToolActivity) => void;
-    onAssistantUsage?: (usage: { input: number; output: number; cacheWrite: number; cacheRead: number }) => void;
+    onAssistantUsage?: (usage: { input: number; output: number; cacheWrite: number; cacheRead?: number }) => void;
     onCompaction?: (info: { reason: "manual" | "threshold" | "overflow"; tokensBefore: number }) => void;
     signal?: AbortSignal;
   } = {},

--- a/src/agent-runner.ts
+++ b/src/agent-runner.ts
@@ -402,7 +402,7 @@ export interface RunOptions {
    * Lets callers maintain a lifetime accumulator that survives compaction
    * (which replaces session.state.messages and resets stats-derived sums).
    */
-  onAssistantUsage?: (usage: { input: number; output: number; cacheWrite: number }) => void;
+  onAssistantUsage?: (usage: { input: number; output: number; cacheWrite: number; cacheRead: number }) => void;
   /**
    * Called when the session successfully compacts. `tokensBefore` is upstream's
    * pre-compaction context size estimate. Aborted compactions don't fire.
@@ -946,6 +946,7 @@ export async function runAgent(
         input: u.input ?? 0,
         output: u.output ?? 0,
         cacheWrite: u.cacheWrite ?? 0,
+        cacheRead: u.cacheRead ?? 0,
       });
     }
     if (event.type === "compaction_end" && !event.aborted && event.result) {
@@ -988,7 +989,7 @@ export async function resumeAgent(
   prompt: string,
   options: {
     onToolActivity?: (activity: ToolActivity) => void;
-    onAssistantUsage?: (usage: { input: number; output: number; cacheWrite: number }) => void;
+    onAssistantUsage?: (usage: { input: number; output: number; cacheWrite: number; cacheRead: number }) => void;
     onCompaction?: (info: { reason: "manual" | "threshold" | "overflow"; tokensBefore: number }) => void;
     signal?: AbortSignal;
   } = {},
@@ -1010,6 +1011,7 @@ export async function resumeAgent(
             input: u.input ?? 0,
             output: u.output ?? 0,
             cacheWrite: u.cacheWrite ?? 0,
+            cacheRead: u.cacheRead ?? 0,
           });
         }
         if (event.type === "compaction_end" && !event.aborted && event.result) {

--- a/src/index.ts
+++ b/src/index.ts
@@ -117,7 +117,7 @@ function createActivityTracker(maxTurns?: number, onStreamUpdate?: () => void) {
     onSessionCreated: (session: any) => {
       state.session = session;
     },
-    onAssistantUsage: (usage: { input: number; output: number; cacheWrite: number; cacheRead: number }) => {
+    onAssistantUsage: (usage: { input: number; output: number; cacheWrite: number; cacheRead?: number }) => {
       addUsage(state.lifetimeUsage, usage);
       onStreamUpdate?.();
     },
@@ -393,7 +393,7 @@ export default function (pi: ExtensionAPI) {
     const u = record.lifetimeUsage;
     const total = getLifetimeTotal(u);
     const tokens = total > 0
-      ? { input: u.input, output: u.output, total, cacheRead: u.cacheRead, cacheWrite: u.cacheWrite }
+      ? { input: u.input, output: u.output, total, cacheRead: u.cacheRead ?? 0, cacheWrite: u.cacheWrite }
       : undefined;
     return {
       id: record.id,

--- a/src/index.ts
+++ b/src/index.ts
@@ -91,7 +91,7 @@ function createActivityTracker(maxTurns?: number, onStreamUpdate?: () => void) {
     maxTurns,
     responseText: "",
     session: undefined,
-    lifetimeUsage: { input: 0, output: 0, cacheWrite: 0 },
+    lifetimeUsage: { input: 0, output: 0, cacheWrite: 0, cacheRead: 0 },
   };
 
   const callbacks = {
@@ -117,7 +117,7 @@ function createActivityTracker(maxTurns?: number, onStreamUpdate?: () => void) {
     onSessionCreated: (session: any) => {
       state.session = session;
     },
-    onAssistantUsage: (usage: { input: number; output: number; cacheWrite: number }) => {
+    onAssistantUsage: (usage: { input: number; output: number; cacheWrite: number; cacheRead: number }) => {
       addUsage(state.lifetimeUsage, usage);
       onStreamUpdate?.();
     },
@@ -380,14 +380,20 @@ export default function (pi: ExtensionAPI) {
   /** Helper: build event data for lifecycle events from an AgentRecord. */
   function buildEventData(record: AgentRecord) {
     const durationMs = record.completedAt ? record.completedAt - record.startedAt : Date.now() - record.startedAt;
-    // All three fields are lifetime-accumulated (Σ over every assistant message_end),
-    // so they survive compaction together — input + output ≤ total always.
+    // input/output/total are lifetime-accumulated (Σ over every assistant
+    // message_end), so they survive compaction together — input + output ≤
+    // total always. cacheWrite is also a true sum, folded into `total` (kept
+    // for back-compat: `total` unchanged from before this field existed).
+    // cacheRead is DELIBERATELY the most recent per-turn value, not a sum —
+    // summing it would double-count the cumulative cached-prefix re-read
+    // reported on every turn (issue #38). Both are additive fields so
+    // existing consumers reading input/output/total see no change.
     // tokens is omitted when nothing was ever produced (e.g. agent errored before
     // any message_end fired), preserving prior payload shape.
     const u = record.lifetimeUsage;
     const total = getLifetimeTotal(u);
     const tokens = total > 0
-      ? { input: u.input, output: u.output, total }
+      ? { input: u.input, output: u.output, total, cacheRead: u.cacheRead, cacheWrite: u.cacheWrite }
       : undefined;
     return {
       id: record.id,

--- a/src/nested-tools.ts
+++ b/src/nested-tools.ts
@@ -59,7 +59,7 @@ interface NestedSpawnOptions {
   isolation?: IsolationMode;
   invocation?: AgentInvocation;
   signal?: AbortSignal;
-  onAssistantUsage?: (usage: { input: number; output: number; cacheWrite: number; cacheRead: number }) => void;
+  onAssistantUsage?: (usage: { input: number; output: number; cacheWrite: number; cacheRead?: number }) => void;
   onSessionCreated?: (session: AgentSession) => void;
   depth: number;
   parentAgentId: string;

--- a/src/nested-tools.ts
+++ b/src/nested-tools.ts
@@ -59,7 +59,7 @@ interface NestedSpawnOptions {
   isolation?: IsolationMode;
   invocation?: AgentInvocation;
   signal?: AbortSignal;
-  onAssistantUsage?: (usage: { input: number; output: number; cacheWrite: number }) => void;
+  onAssistantUsage?: (usage: { input: number; output: number; cacheWrite: number; cacheRead: number }) => void;
   onSessionCreated?: (session: AgentSession) => void;
   depth: number;
   parentAgentId: string;

--- a/src/prompts.ts
+++ b/src/prompts.ts
@@ -21,8 +21,8 @@ export interface PromptExtras {
 /**
  * Build the system prompt for an agent from its config.
  *
- * - "replace" mode: env header + config.systemPrompt (full control, no parent identity)
- * - "append" mode: parent system prompt + sub-agent context + env header + config.systemPrompt
+ * - "replace" mode: config.systemPrompt (full control, no parent identity) + env header
+ * - "append" mode: parent system prompt + sub-agent context + config.systemPrompt + env header
  * - "append" with empty systemPrompt: pure parent clone
  *
  * Both modes include an `<active_agent name="${config.name}"/>` tag so downstream
@@ -31,6 +31,18 @@ export interface PromptExtras {
  * is prepended; in append mode it follows the shared inherited content so the
  * parent prompt forms an identical, cacheable byte prefix with the parent
  * session (the LLM's KV cache can then reuse those tokens across every spawn).
+ *
+ * Within each mode, the STATIC per-agent-type body (`config.systemPrompt`,
+ * typically 1-2KB) is placed BEFORE the VARIABLE env block (cwd/branch, which
+ * drifts across spawns in the same session/repo as the user cd's around or
+ * commits land) and the worktree block (which names a per-spawn path). Only
+ * `activeAgentTag` stays at the front of the static block in both modes —
+ * it depends solely on `config.name`, which is invariant for repeated spawns
+ * of the same agent type, so it doesn't break the cacheable prefix. This
+ * ordering means every spawn of the same agent type shares an identical byte
+ * prefix through the end of `config.systemPrompt`, letting the LLM's KV
+ * cache reuse it even when cwd/branch/worktree info differs between spawns.
+ * Memory/skill extras remain last (session-specific, never worth caching).
  *
  * @param parentSystemPrompt  The parent agent's effective system prompt (for append mode).
  * @param extras  Optional extra sections to inject (memory, preloaded skills).
@@ -95,18 +107,26 @@ You are operating as a sub-agent invoked to handle a specific task.
     // Place shared/stable content first so the LLM's KV cache can reuse the
     // inherited prefix across all subagent invocations. The parent prompt is
     // placed verbatim (no wrapper tag) so it forms an identical byte prefix
-    // with the parent session, maximising KV cache hits. The <active_agent>
-    // tag and env block vary per call and are placed after the cached prefix.
-    return identity + "\n\n" + bridge + "\n\n" + activeAgentTag + envBlock + worktreeBlock + customSection + extrasSuffix;
+    // with the parent session, maximising KV cache hits. `activeAgentTag` and
+    // `customSection` (config.systemPrompt) are static per agent type — kept
+    // adjacent to the cached prefix. `envBlock`/`worktreeBlock` vary per
+    // spawn (cwd/branch drift, per-spawn worktree path) and are placed after,
+    // so a run of same-type spawns keeps sharing this whole prefix even as
+    // cwd/branch change between them.
+    return identity + "\n\n" + bridge + "\n\n" + activeAgentTag + customSection + envBlock + worktreeBlock + extrasSuffix;
   }
 
-  // "replace" mode — env header + the config's full system prompt
+  // "replace" mode — the config's full system prompt + env header
   const replaceHeader = `You are a pi coding agent sub-agent.
-You have been invoked to handle a specific task autonomously.
+You have been invoked to handle a specific task autonomously.`;
 
-${envBlock}`;
-
-  return activeAgentTag + replaceHeader + worktreeBlock + "\n\n" + config.systemPrompt + extrasSuffix;
+  // Static per-agent-type body (activeAgentTag + replaceHeader + systemPrompt)
+  // comes first so it forms an identical, cacheable byte prefix across every
+  // spawn of this agent type. The variable envBlock/worktreeBlock (cwd,
+  // branch, worktree path — all of which can drift between spawns in the
+  // same session) are placed after, instead of before, so they no longer
+  // invalidate that cached prefix.
+  return activeAgentTag + replaceHeader + "\n\n" + config.systemPrompt + "\n\n" + envBlock + worktreeBlock + extrasSuffix;
 }
 
 /** Fallback base prompt when parent system prompt is unavailable in append mode. */

--- a/src/types.ts
+++ b/src/types.ts
@@ -116,8 +116,12 @@ export interface AgentRecord {
   outputCleanup?: () => void;
   /**
    * Lifetime usage breakdown, accumulated via `message_end` events. Survives
-   * compaction. Total = input + output + cacheWrite (cacheRead deliberately
-   * excluded — see issue #38). Initialized to zeros at spawn.
+   * compaction. `getLifetimeTotal()` = input + output + cacheWrite
+   * (cacheRead deliberately excluded from that sum — see issue #38 and the
+   * `LifetimeUsage` doc comment in usage.ts). `cacheRead` is exposed as an
+   * additional field on the record (most recent per-turn value, not summed)
+   * so telemetry consumers can report real cache-read/cache-write breakdown
+   * per dispatch. Initialized to zeros at spawn.
    */
   lifetimeUsage: LifetimeUsage;
   /** Number of times this agent's session has compacted. Initialized to 0 at spawn. */

--- a/src/usage.ts
+++ b/src/usage.ts
@@ -21,7 +21,7 @@
  * turns if you want the peak instead of the latest — both are legitimate,
  * summing is not.
  */
-export type LifetimeUsage = { input: number; output: number; cacheWrite: number; cacheRead: number };
+export type LifetimeUsage = { input: number; output: number; cacheWrite: number; cacheRead?: number };
 
 /**
  * Sum of lifetime usage components, or 0 if undefined. Deliberately excludes
@@ -55,7 +55,7 @@ export function addUsage(into: LifetimeUsage, delta: LifetimeUsage): void {
   into.input += delta.input;
   into.output += delta.output;
   into.cacheWrite += delta.cacheWrite;
-  into.cacheRead = delta.cacheRead;
+  into.cacheRead = delta.cacheRead ?? 0;
 }
 
 /** Minimal shape we read from upstream `getSessionStats()`. */

--- a/src/usage.ts
+++ b/src/usage.ts
@@ -3,22 +3,59 @@
 /**
  * Lifetime usage components, accumulated via `message_end` events. Survives
  * compaction (which replaces session.state.messages and would reset any
- * stats-derived sum). cacheRead is excluded because each turn's cacheRead is
- * the cumulative cached prefix re-read on that one call — summing across
- * turns counts the prefix N times. See issue #38.
+ * stats-derived sum).
+ *
+ * `input`, `output`, and `cacheWrite` are true sums across every turn — each
+ * turn's value for those fields is incremental (new tokens billed *that*
+ * turn), so summing is correct and `getLifetimeTotal()` continues to use
+ * exactly these three fields (unchanged semantics/back-compat).
+ *
+ * `cacheRead` is DELIBERATELY NOT SUMMED. Each turn's `cacheRead` from
+ * upstream already represents the *cumulative* cached prefix re-read on that
+ * one API call — summing it across N turns would count the prefix N times
+ * (quadratic inflation). See issue #38. Instead, `cacheRead` holds the most
+ * recently observed per-turn value (last-write-wins via `addUsage`), which is
+ * the best available point-in-time signal of how much cached context this
+ * dispatch is currently leaning on. Do NOT sum this field; if you need a
+ * dispatch-level figure, use the latest value as-is, or take the max across
+ * turns if you want the peak instead of the latest — both are legitimate,
+ * summing is not.
  */
-export type LifetimeUsage = { input: number; output: number; cacheWrite: number };
+export type LifetimeUsage = { input: number; output: number; cacheWrite: number; cacheRead: number };
 
-/** Sum of lifetime usage components, or 0 if undefined. */
+/**
+ * Sum of lifetime usage components, or 0 if undefined. Deliberately excludes
+ * `cacheRead` — see the `LifetimeUsage` doc comment / issue #38. This keeps
+ * pre-existing total semantics unchanged; use `u.cacheRead` directly (or
+ * `getCacheBreakdown`) to report cache-read separately.
+ */
 export function getLifetimeTotal(u?: LifetimeUsage): number {
   return u ? u.input + u.output + u.cacheWrite : 0;
 }
 
-/** Add a usage delta into a target accumulator (mutates target). */
+/**
+ * Cache-related breakdown for telemetry consumers (e.g. Langfuse
+ * `usageDetails`). `cacheWrite` is a true lifetime sum; `cacheRead` is the
+ * most recently observed per-turn value, NOT a sum (see `LifetimeUsage`).
+ * Returns zeros if `u` is undefined.
+ */
+export function getCacheBreakdown(u?: LifetimeUsage): { cacheRead: number; cacheWrite: number } {
+  return { cacheRead: u?.cacheRead ?? 0, cacheWrite: u?.cacheWrite ?? 0 };
+}
+
+/**
+ * Add a usage delta into a target accumulator (mutates target).
+ *
+ * `input`/`output`/`cacheWrite` are summed (they're incremental per turn).
+ * `cacheRead` is last-write-wins — it overwrites rather than sums, since
+ * upstream's per-turn `cacheRead` is already a cumulative snapshot for that
+ * turn, not an incremental delta (see `LifetimeUsage`, issue #38).
+ */
 export function addUsage(into: LifetimeUsage, delta: LifetimeUsage): void {
   into.input += delta.input;
   into.output += delta.output;
   into.cacheWrite += delta.cacheWrite;
+  into.cacheRead = delta.cacheRead;
 }
 
 /** Minimal shape we read from upstream `getSessionStats()`. */

--- a/test/agent-manager.test.ts
+++ b/test/agent-manager.test.ts
@@ -568,7 +568,7 @@ describe("AgentManager — lifetime usage + compaction count are eagerly initial
     });
     const record = manager.getRecord(id)!;
 
-    expect(record.lifetimeUsage).toEqual({ input: 0, output: 0, cacheWrite: 0 });
+    expect(record.lifetimeUsage).toEqual({ input: 0, output: 0, cacheWrite: 0, cacheRead: 0 });
     expect(record.compactionCount).toBe(0);
 
     manager.abort(id);
@@ -582,8 +582,8 @@ describe("AgentManager — lifetime usage + compaction count are eagerly initial
     vi.mocked(runAgent).mockImplementation(async (_ctx, _type, _prompt, opts: any) => {
       captured = opts;
       // Two assistant messages with usage
-      opts.onAssistantUsage?.({ input: 100, output: 50, cacheWrite: 10 });
-      opts.onAssistantUsage?.({ input: 200, output: 80, cacheWrite: 20 });
+      opts.onAssistantUsage?.({ input: 100, output: 50, cacheWrite: 10, cacheRead: 1000 });
+      opts.onAssistantUsage?.({ input: 200, output: 80, cacheWrite: 20, cacheRead: 2500 });
       return { responseText: "done", session: mockSession(), aborted: false, steered: false };
     });
 
@@ -595,7 +595,7 @@ describe("AgentManager — lifetime usage + compaction count are eagerly initial
 
     expect(captured).toBeDefined();
     expect(manager.getRecord(id)!.lifetimeUsage).toEqual({
-      input: 300, output: 130, cacheWrite: 30,
+      input: 300, output: 130, cacheWrite: 30, cacheRead: 2500,
     });
   });
 
@@ -647,20 +647,20 @@ describe("AgentManager — lifetime usage + compaction count are eagerly initial
     await manager.getRecord(id)!.promise;
 
     // Pre-resume: lifetimeUsage from spawn was zero (mock didn't call onAssistantUsage)
-    expect(manager.getRecord(id)!.lifetimeUsage).toEqual({ input: 0, output: 0, cacheWrite: 0 });
+    expect(manager.getRecord(id)!.lifetimeUsage).toEqual({ input: 0, output: 0, cacheWrite: 0, cacheRead: 0 });
     expect(manager.getRecord(id)!.compactionCount).toBe(0);
 
     // Now resume — drive callbacks via the mocked resumeAgent
     const { resumeAgent: resumeMock } = await import("../src/agent-runner.js");
     vi.mocked(resumeMock).mockImplementation(async (_session, _prompt, opts: any) => {
-      opts.onAssistantUsage?.({ input: 70, output: 30, cacheWrite: 5 });
+      opts.onAssistantUsage?.({ input: 70, output: 30, cacheWrite: 5, cacheRead: 4000 });
       opts.onCompaction?.({ reason: "overflow", tokensBefore: 999 });
       return { text: "second" };
     });
 
     await manager.resume(id, "more");
 
-    expect(manager.getRecord(id)!.lifetimeUsage).toEqual({ input: 70, output: 30, cacheWrite: 5 });
+    expect(manager.getRecord(id)!.lifetimeUsage).toEqual({ input: 70, output: 30, cacheWrite: 5, cacheRead: 4000 });
     expect(manager.getRecord(id)!.compactionCount).toBe(1);
   });
 });

--- a/test/agent-runner.test.ts
+++ b/test/agent-runner.test.ts
@@ -508,11 +508,14 @@ describe("agent-runner usage callback wiring", () => {
     const { session, listeners } = createSession("OK");
     createAgentSession.mockResolvedValue({ session });
 
-    const seen: Array<{ input: number; output: number; cacheWrite: number }> = [];
+    const seen: Array<{ input: number; output: number; cacheWrite: number; cacheRead: number }> = [];
     session.prompt = vi.fn(async () => {
-      // Two assistant messages over the run
-      emitMessageEnd(listeners, { input: 100, output: 50, cacheWrite: 10 });
-      emitMessageEnd(listeners, { input: 200, output: 80, cacheWrite: 20 });
+      // Two assistant messages over the run. cacheRead is a per-turn
+      // cumulative snapshot (see issue #38), so the two values are expected
+      // to differ, not sum, on the callback side — accumulation semantics
+      // live in usage.ts's addUsage(), not here.
+      emitMessageEnd(listeners, { input: 100, output: 50, cacheWrite: 10, cacheRead: 1000 });
+      emitMessageEnd(listeners, { input: 200, output: 80, cacheWrite: 20, cacheRead: 2500 });
       session.messages.push({ role: "assistant", content: [{ type: "text", text: "OK" }] });
     });
 
@@ -522,8 +525,8 @@ describe("agent-runner usage callback wiring", () => {
     });
 
     expect(seen).toEqual([
-      { input: 100, output: 50, cacheWrite: 10 },
-      { input: 200, output: 80, cacheWrite: 20 },
+      { input: 100, output: 50, cacheWrite: 10, cacheRead: 1000 },
+      { input: 200, output: 80, cacheWrite: 20, cacheRead: 2500 },
     ]);
   });
 
@@ -542,7 +545,7 @@ describe("agent-runner usage callback wiring", () => {
       onAssistantUsage: (u) => seen.push(u),
     });
 
-    expect(seen).toEqual([{ input: 50, output: 0, cacheWrite: 0 }]);
+    expect(seen).toEqual([{ input: 50, output: 0, cacheWrite: 0, cacheRead: 0 }]);
   });
 
   it("runAgent skips the callback when message_end has no usage field", async () => {
@@ -565,7 +568,7 @@ describe("agent-runner usage callback wiring", () => {
     const seen: any[] = [];
 
     session.prompt = vi.fn(async () => {
-      emitMessageEnd(listeners, { input: 10, output: 20, cacheWrite: 5 });
+      emitMessageEnd(listeners, { input: 10, output: 20, cacheWrite: 5, cacheRead: 3000 });
       session.messages.push({ role: "assistant", content: [{ type: "text", text: "RESUMED" }] });
     });
 
@@ -573,7 +576,7 @@ describe("agent-runner usage callback wiring", () => {
       onAssistantUsage: (u) => seen.push(u),
     });
 
-    expect(seen).toEqual([{ input: 10, output: 20, cacheWrite: 5 }]);
+    expect(seen).toEqual([{ input: 10, output: 20, cacheWrite: 5, cacheRead: 3000 }]);
   });
 
   it("forwards compaction_end events to onCompaction (only when not aborted)", async () => {

--- a/test/fleet-list.test.ts
+++ b/test/fleet-list.test.ts
@@ -29,7 +29,7 @@ function makeRecord(over: Partial<AgentRecord> = {}): AgentRecord {
     toolUses: 0,
     startedAt: Date.now(),
     session: FAKE_SESSION as any,
-    lifetimeUsage: { input: 13100, output: 0, cacheWrite: 0 },
+    lifetimeUsage: { input: 13100, output: 0, cacheWrite: 0, cacheRead: 0 },
     compactionCount: 0,
     ...over,
   } as AgentRecord;

--- a/test/group-join.test.ts
+++ b/test/group-join.test.ts
@@ -18,7 +18,7 @@ function makeRecord(id: string, overrides: Partial<AgentRecord> = {}): AgentReco
     status: "completed",
     toolUses: 0,
     startedAt: 0,
-    lifetimeUsage: { input: 0, output: 0, cacheWrite: 0 },
+    lifetimeUsage: { input: 0, output: 0, cacheWrite: 0, cacheRead: 0 },
     ...overrides,
   };
 }

--- a/test/nested-tools.test.ts
+++ b/test/nested-tools.test.ts
@@ -427,10 +427,10 @@ describe("child-safe nested Agent tools", () => {
   });
 
   it("attributes a nested child's token spend to the owning parent", async () => {
-    const parent = { id: "parent-1", status: "running", lifetimeUsage: { input: 0, output: 0, cacheWrite: 0 } };
+    const parent = { id: "parent-1", status: "running", lifetimeUsage: { input: 0, output: 0, cacheWrite: 0, cacheRead: 0 } };
     records.set("parent-1", parent);
     spawn.mockImplementation((_pi, _ctx, _type, _prompt, options) => {
-      options.onAssistantUsage?.({ input: 100, output: 20, cacheWrite: 5 });
+      options.onAssistantUsage?.({ input: 100, output: 20, cacheWrite: 5, cacheRead: 900 });
       return "child-1";
     });
 
@@ -442,21 +442,21 @@ describe("child-safe nested Agent tools", () => {
       run_in_background: true,
     });
 
-    expect(parent.lifetimeUsage).toEqual({ input: 100, output: 20, cacheWrite: 5 });
+    expect(parent.lifetimeUsage).toEqual({ input: 100, output: 20, cacheWrite: 5, cacheRead: 900 });
   });
 
   it("attributes spend up the whole ancestor chain, not just one level", async () => {
     // A spawn callback fires only for that child's own turns, so a deeper
     // descendant would otherwise never reach the one record anyone can see.
-    const top = { id: "top", status: "running", lifetimeUsage: { input: 0, output: 0, cacheWrite: 0 } };
+    const top = { id: "top", status: "running", lifetimeUsage: { input: 0, output: 0, cacheWrite: 0, cacheRead: 0 } };
     const middle = {
       id: "parent-1", status: "running", parentAgentId: "top",
-      lifetimeUsage: { input: 0, output: 0, cacheWrite: 0 },
+      lifetimeUsage: { input: 0, output: 0, cacheWrite: 0, cacheRead: 0 },
     };
     records.set("top", top);
     records.set("parent-1", middle);
     spawn.mockImplementation((_pi, _ctx, _type, _prompt, options) => {
-      options.onAssistantUsage?.({ input: 7, output: 3, cacheWrite: 1 });
+      options.onAssistantUsage?.({ input: 7, output: 3, cacheWrite: 1, cacheRead: 200 });
       return "child-1";
     });
 
@@ -468,8 +468,8 @@ describe("child-safe nested Agent tools", () => {
       run_in_background: true,
     });
 
-    expect(middle.lifetimeUsage).toEqual({ input: 7, output: 3, cacheWrite: 1 });
-    expect(top.lifetimeUsage).toEqual({ input: 7, output: 3, cacheWrite: 1 });
+    expect(middle.lifetimeUsage).toEqual({ input: 7, output: 3, cacheWrite: 1, cacheRead: 200 });
+    expect(top.lifetimeUsage).toEqual({ input: 7, output: 3, cacheWrite: 1, cacheRead: 200 });
   });
 
   it("files a nested transcript under the root session, honoring output_transcript", async () => {

--- a/test/prompts.test.ts
+++ b/test/prompts.test.ts
@@ -433,4 +433,98 @@ describe("buildAgentPrompt", () => {
       expect(prompt.indexOf("<worktree_isolation>")).toBeGreaterThan(prompt.indexOf("<sub_agent_context>"));
     });
   });
+
+  // The static per-agent-type body (config.systemPrompt) must
+  // form a byte-identical prefix across spawns regardless of cwd/branch
+  // drift, so it has to precede the variable env block, not follow it.
+  describe("cacheable static-body-before-env-block ordering", () => {
+    it("replace mode: config.systemPrompt precedes the env block", () => {
+      const config: AgentConfig = {
+        name: "replacer",
+        description: "Test",
+        builtinToolNames: [],
+        extensions: true,
+        skills: true,
+        systemPrompt: "UNIQUE_STATIC_BODY_MARKER",
+        promptMode: "replace",
+        inheritContext: false,
+        runInBackground: false,
+        isolated: false,
+      };
+      const prompt = buildAgentPrompt(config, "/workspace", env);
+      const bodyIdx = prompt.indexOf("UNIQUE_STATIC_BODY_MARKER");
+      const envIdx = prompt.indexOf("# Environment");
+      expect(bodyIdx).toBeGreaterThan(-1);
+      expect(envIdx).toBeGreaterThan(-1);
+      expect(bodyIdx).toBeLessThan(envIdx);
+    });
+
+    it("replace mode: prefix up to end of systemPrompt is identical across differing cwd/branch", () => {
+      const config: AgentConfig = {
+        name: "replacer",
+        description: "Test",
+        builtinToolNames: [],
+        extensions: true,
+        skills: true,
+        systemPrompt: "Static instructions that must stay cacheable.",
+        promptMode: "replace",
+        inheritContext: false,
+        runInBackground: false,
+        isolated: false,
+      };
+      const promptA = buildAgentPrompt(config, "/workspace/one", { isGitRepo: true, branch: "main", platform: "darwin" });
+      const promptB = buildAgentPrompt(config, "/workspace/two", { isGitRepo: true, branch: "feature/x", platform: "darwin" });
+      const marker = "Static instructions that must stay cacheable.";
+      const prefixEnd = promptA.indexOf(marker) + marker.length;
+      expect(promptA.slice(0, prefixEnd)).toBe(promptB.slice(0, prefixEnd));
+      // Sanity: the two prompts do genuinely differ later (env block), so this
+      // isn't a vacuous match on two identical calls.
+      expect(promptA).not.toBe(promptB);
+      expect(promptA).toContain("/workspace/one");
+      expect(promptB).toContain("/workspace/two");
+    });
+
+    it("append mode: config.systemPrompt (agent_instructions) precedes the env block", () => {
+      const config: AgentConfig = {
+        name: "appender",
+        description: "Test",
+        builtinToolNames: [],
+        extensions: true,
+        skills: true,
+        systemPrompt: "UNIQUE_STATIC_BODY_MARKER",
+        promptMode: "append",
+        inheritContext: false,
+        runInBackground: false,
+        isolated: false,
+      };
+      const prompt = buildAgentPrompt(config, "/workspace", env, "Parent prompt.");
+      const bodyIdx = prompt.indexOf("UNIQUE_STATIC_BODY_MARKER");
+      const envIdx = prompt.indexOf("# Environment");
+      expect(bodyIdx).toBeGreaterThan(-1);
+      expect(envIdx).toBeGreaterThan(-1);
+      expect(bodyIdx).toBeLessThan(envIdx);
+    });
+
+    it("append mode: prefix through customSection is identical across differing cwd/branch", () => {
+      const config: AgentConfig = {
+        name: "appender",
+        description: "Test",
+        builtinToolNames: [],
+        extensions: true,
+        skills: true,
+        systemPrompt: "Static per-type instructions.",
+        promptMode: "append",
+        inheritContext: false,
+        runInBackground: false,
+        isolated: false,
+      };
+      const promptA = buildAgentPrompt(config, "/workspace/one", { isGitRepo: true, branch: "main", platform: "darwin" }, "Parent prompt.");
+      const promptB = buildAgentPrompt(config, "/workspace/two", { isGitRepo: true, branch: "feature/x", platform: "darwin" }, "Parent prompt.");
+      const marker = "</agent_instructions>";
+      const prefixEnd = promptA.indexOf(marker) + marker.length;
+      expect(prefixEnd).toBeGreaterThan(marker.length - 1);
+      expect(promptA.slice(0, prefixEnd)).toBe(promptB.slice(0, prefixEnd));
+      expect(promptA).not.toBe(promptB);
+    });
+  });
 });

--- a/test/usage.test.ts
+++ b/test/usage.test.ts
@@ -1,5 +1,5 @@
 import { describe, expect, it } from "vitest";
-import { getLifetimeTotal, getSessionContextPercent, getSessionTokens } from "../src/usage.js";
+import { addUsage, getCacheBreakdown, getLifetimeTotal, getSessionContextPercent, getSessionTokens, type LifetimeUsage } from "../src/usage.js";
 
 // Regression for issue #38 — token semantics + context indicator
 describe("usage", () => {
@@ -50,10 +50,44 @@ describe("usage", () => {
     });
   });
 
+  // Real cache-read/cache-write breakdown per dispatch, without
+  // reintroducing the issue #38 double-counting (summing per-turn cacheRead,
+  // which is already a cumulative snapshot, across N turns).
+  describe("cacheRead breakdown", () => {
+    it("addUsage sums cacheWrite but takes the LATEST value for cacheRead (no double-count)", () => {
+      const lifetime: LifetimeUsage = { input: 0, output: 0, cacheWrite: 0, cacheRead: 0 };
+
+      // Turn 1: cacheRead already reflects the whole cached prefix re-read that turn.
+      addUsage(lifetime, { input: 100, output: 50, cacheWrite: 20, cacheRead: 10_000 });
+      expect(lifetime).toEqual({ input: 100, output: 50, cacheWrite: 20, cacheRead: 10_000 });
+
+      // Turn 2: cacheWrite is incremental (sums); cacheRead is a fresh cumulative
+      // snapshot for that turn and must overwrite, NOT add to, the previous value.
+      addUsage(lifetime, { input: 80, output: 40, cacheWrite: 15, cacheRead: 25_000 });
+      expect(lifetime).toEqual({ input: 180, output: 90, cacheWrite: 35, cacheRead: 25_000 });
+      // If cacheRead were summed we'd see 35_000 here — that's the bug this guards against.
+      expect(lifetime.cacheRead).not.toBe(35_000);
+    });
+
+    it("getLifetimeTotal is unchanged by cacheRead — still input + output + cacheWrite", () => {
+      const u: LifetimeUsage = { input: 100, output: 200, cacheWrite: 50, cacheRead: 999_999 };
+      expect(getLifetimeTotal(u)).toBe(350);
+    });
+
+    it("getCacheBreakdown exposes cacheRead/cacheWrite for telemetry consumers", () => {
+      const u: LifetimeUsage = { input: 100, output: 200, cacheWrite: 50, cacheRead: 12_345 };
+      expect(getCacheBreakdown(u)).toEqual({ cacheRead: 12_345, cacheWrite: 50 });
+    });
+
+    it("getCacheBreakdown returns zeros when usage is undefined", () => {
+      expect(getCacheBreakdown(undefined)).toEqual({ cacheRead: 0, cacheWrite: 0 });
+    });
+  });
+
   describe("getLifetimeTotal", () => {
     it("sums components and handles undefined", () => {
       expect(getLifetimeTotal(undefined)).toBe(0);
-      expect(getLifetimeTotal({ input: 100, output: 200, cacheWrite: 50 })).toBe(350);
+      expect(getLifetimeTotal({ input: 100, output: 200, cacheWrite: 50, cacheRead: 0 })).toBe(350);
     });
 
     // getSessionTokens reads upstream session stats (resets at compaction);
@@ -64,7 +98,7 @@ describe("usage", () => {
       const session = {
         getSessionStats: () => ({ tokens: sessionStatsTokens }),
       };
-      const lifetime = { input: 100, output: 200, cacheWrite: 50 };
+      const lifetime = { input: 100, output: 200, cacheWrite: 50, cacheRead: 0 };
 
       expect(getSessionTokens(session)).toBe(350);
       expect(getLifetimeTotal(lifetime)).toBe(350);
@@ -87,15 +121,11 @@ describe("usage", () => {
     // The accumulator survives compaction because it lives on AgentActivity /
     // AgentRecord, not on session.state.messages (which compaction replaces).
     it("stays monotone across simulated compaction when fed via addUsage-style accumulation", () => {
-      const usage = { input: 0, output: 0, cacheWrite: 0 };
-      const onUsage = (u: { input: number; output: number; cacheWrite: number }) => {
-        usage.input += u.input;
-        usage.output += u.output;
-        usage.cacheWrite += u.cacheWrite;
-      };
+      const usage: LifetimeUsage = { input: 0, output: 0, cacheWrite: 0, cacheRead: 0 };
+      const onUsage = (u: LifetimeUsage) => addUsage(usage, u);
 
       // 5 normal turns
-      for (let i = 0; i < 5; i++) onUsage({ input: 1000, output: 200, cacheWrite: 50 });
+      for (let i = 0; i < 5; i++) onUsage({ input: 1000, output: 200, cacheWrite: 50, cacheRead: 5_000 });
       expect(getLifetimeTotal(usage)).toBe(5 * 1250);
 
       // Compaction would replace session.state.messages, dropping any sum
@@ -103,7 +133,7 @@ describe("usage", () => {
       const beforeCompaction = getLifetimeTotal(usage);
 
       // 3 more turns post-"compaction"
-      for (let i = 0; i < 3; i++) onUsage({ input: 800, output: 150, cacheWrite: 30 });
+      for (let i = 0; i < 3; i++) onUsage({ input: 800, output: 150, cacheWrite: 30, cacheRead: 3_000 });
       expect(getLifetimeTotal(usage)).toBe(beforeCompaction + 3 * 980);
       expect(getLifetimeTotal(usage)).toBeGreaterThan(beforeCompaction); // monotone
 

--- a/test/usage.test.ts
+++ b/test/usage.test.ts
@@ -82,6 +82,18 @@ describe("usage", () => {
     it("getCacheBreakdown returns zeros when usage is undefined", () => {
       expect(getCacheBreakdown(undefined)).toEqual({ cacheRead: 0, cacheWrite: 0 });
     });
+
+    // cacheRead is optional (additive change) so consumers who construct
+    // LifetimeUsage/addUsage-delta literals without it (e.g. pre-existing
+    // callers unaware of this field) keep compiling and behaving as if it
+    // were 0 — this must never become a required-field breaking change.
+    it("cacheRead is optional — omitting it behaves as if it were 0", () => {
+      const lifetime: LifetimeUsage = { input: 0, output: 0, cacheWrite: 0 };
+      addUsage(lifetime, { input: 100, output: 50, cacheWrite: 20 });
+      expect(lifetime).toEqual({ input: 100, output: 50, cacheWrite: 20, cacheRead: 0 });
+      expect(getLifetimeTotal(lifetime)).toBe(170);
+      expect(getCacheBreakdown(lifetime)).toEqual({ cacheRead: 0, cacheWrite: 20 });
+    });
   });
 
   describe("getLifetimeTotal", () => {


### PR DESCRIPTION
## What this does

**`src/usage.ts`** — the emitted usage payload had no cache-read/cache-write fields at all, so downstream telemetry/observability tooling couldn't see cache activity for a subagent dispatch. This adds them additively:

- `cacheRead` is optional (`cacheRead?: number`) and last-write-wins — each turn overwrites rather than sums, since upstream reports it as a cumulative per-turn snapshot, not a delta.
- `getLifetimeTotal()` is unchanged; this does **not** reintroduce the double-counting issue from #38 — `cacheRead` is deliberately never summed, only overwritten with the latest observed value each turn.

**`src/prompts.ts`** — reorders `buildAgentPrompt` so the static per-agent-type content is emitted before the variable env block, restoring a stable, cacheable prompt prefix across spawns. Wording is unchanged, only ordering, applied to both `replace` and `append` modes.

These are two independent changes bundled into one branch for convenience. Happy to split into two PRs if that's easier to review.

Tests, build, and lint all pass.

Ref: #38
