### PR TITLE
fix: treat clean-stop final turns with no text as failures

### DIFF
--- a/src/agent-runner.ts
+++ b/src/agent-runner.ts
@@ -475,14 +475,18 @@ function getLastAssistantText(session: AgentSession, startIndex = 0): string {
 
 /**
  * Error message of THIS invocation's final assistant message, when that turn
- * failed. Two failure shapes, both keyed off how the final turn STOPPED:
+ * failed. Three failure shapes, all keyed off how the final turn STOPPED:
  *   - stopReason "error": a provider failure pi resolved instead of rejecting
  *     (any text; partial output is surfaced separately).
  *   - stopReason "length" with NO text: a silent max-token death — the run hit
  *     the output-token ceiling before writing anything, which would otherwise
  *     land as a "completed" run with an empty result (the #144 symptom).
- * Everything else completes: a clean "stop"/"toolUse" final, and — crucially — a
- * "length" stop that DID produce text (a legitimate truncated-but-useful answer).
+ *   - any non-"toolUse" stop with NO text: the model ended its final turn
+ *     without writing output — a "stop"/"end_turn" final with an empty text
+ *     block must not report "completed" with a stale fallback answer.
+ * Everything else completes: a "toolUse" stop (never final), and — crucially — a
+ * "length" or "stop" stop that DID produce text (a legitimate truncated or
+ * concluding answer).
  * "aborted" is handled by the manager's abort flag / "stopped" guard, not here.
  * Bounded by `startIndex` (like the text fallback) so a resume that produced no
  * assistant message of its own never inherits a PRIOR turn's stop reason.
@@ -496,6 +500,9 @@ function finalTurnError(session: AgentSession, startIndex = 0): string | undefin
     }
     if (msg.stopReason === "length" && !extractText(msg.content).trim()) {
       return "run hit the output token limit before producing any text";
+    }
+    if (msg.stopReason !== "toolUse" && !extractText(msg.content).trim()) {
+      return "run ended without producing any text";
     }
     return undefined;
   }

--- a/test/agent-runner.test.ts
+++ b/test/agent-runner.test.ts
@@ -413,7 +413,10 @@ describe("agent-runner failed-final-turn detection (#144)", () => {
     expect(result.responseText).toBe("truncated but useful answer");
   });
 
-  it("does NOT flag an empty final turn that stopped cleanly (no false failures)", async () => {
+  it("flags an empty final turn that stopped cleanly even when an EARLIER message had text", async () => {
+    // Pre-fix this passed as "completed": the terminal "stop" with no text
+    // slipped through, and the walk-back fallback surfaced the earlier
+    // "did the work" as the result. An empty terminal stop is a no-output run.
     const session = sessionEnding(
       { role: "assistant", content: [{ type: "text", text: "did the work" }] },
       { role: "toolResult", content: [] },
@@ -423,8 +426,50 @@ describe("agent-runner failed-final-turn detection (#144)", () => {
 
     const result = await runAgent(ctx, "Explore", "go", { pi });
 
-    expect(result.failure).toBeUndefined();
+    expect(result.failure).toBe("run ended without producing any text");
     expect(result.responseText).toBe("did the work"); // walk-back fallback preserved
+  });
+
+  it("flags a final clean stop whose text block is empty (the stale-result hole)", async () => {
+    // Observed on long opus runs: the final assistant message is
+    // content: [{ type: "thinking", ... }, { type: "text", text: "" }] with
+    // stopReason "stop". The empty text block used to pass as "completed" and
+    // the walk-back fallback surfaced the run's OPENING line as the result.
+    const session = sessionEnding({
+      role: "assistant",
+      content: [{ type: "thinking", thinking: "…" }, { type: "text", text: "" }],
+      stopReason: "stop",
+    });
+    createAgentSession.mockResolvedValue({ session });
+
+    const result = await runAgent(ctx, "Explore", "go", { pi });
+
+    expect(result.failure).toBe("run ended without producing any text");
+    expect(result.responseText).toBe("");
+  });
+
+  it("does NOT flag a clean stop that produced text", async () => {
+    const session = sessionEnding({
+      role: "assistant",
+      content: [{ type: "text", text: "the answer" }],
+      stopReason: "stop",
+    });
+    createAgentSession.mockResolvedValue({ session });
+
+    const result = await runAgent(ctx, "Explore", "go", { pi });
+
+    expect(result.failure).toBeUndefined();
+    expect(result.responseText).toBe("the answer");
+  });
+
+  it("does NOT flag an empty turn that stopped with toolUse (mid-run, never final)", async () => {
+    const session = sessionEnding({ role: "assistant", content: [], stopReason: "toolUse" });
+    createAgentSession.mockResolvedValue({ session });
+
+    const result = await runAgent(ctx, "Explore", "go", { pi });
+
+    expect(result.failure).toBeUndefined();
+    expect(result.responseText).toBe(""); // a tool call, not a terminal answer
   });
 
   it("resumeAgent applies the same rule", async () => {


### PR DESCRIPTION
## Symptom

A run whose final assistant turn stops cleanly (`stopReason` `"stop"` / `"end_turn"`) with an **empty text block** is reported as "completed" with a **STALE result**. The `responseText` fallback (`getLastAssistantText`) walks back to the last non-empty assistant message, surfacing the agent's **first** line instead of a verdict. Observed on long thinking-heavy runs.

## Root cause

`finalTurnError` only flags `stopReason` `"error"` and `"length"` with no text (the #144 fix); a clean stop with empty text fell through to completion.

## The fix

Added a third failure shape in `finalTurnError` (shared by the `runAgent` and `resumeAgent` paths):

```ts
if (msg.stopReason !== "toolUse" && !extractText(msg.content).trim()) return "run ended without producing any text";
```

## Tests

- 3 new regression cases: stop + empty → failure; stop + text → no failure; toolUse + empty → no failure
- 1 flipped pre-existing test that encoded the old contract
- 115/115 tests pass in `test/agent-runner.test.ts` + `test/subagent-error-status-e2e.test.ts`; `tsc --noEmit` clean

References issue #144. The same patch is applied to the vendored install locally pending this release.
