### PR TITLE
Persist Agent-tool subagent sessions by default with parent link

### DIFF
--- a/src/agent-runner.ts
+++ b/src/agent-runner.ts
@@ -837,8 +837,15 @@ export async function runAgent(
   const settingsManager = SettingsManager.create(configCwd, agentDir);
   const configuredSessionDir = resolveConfiguredSessionDir(agentConfig?.sessionDir, effectiveCwd);
   const defaultSessionDir = process.env.PI_CODING_AGENT_SESSION_DIR ?? settingsManager.getSessionDir?.();
-  const sessionManager = agentConfig?.persistSession
-    ? SessionManager.create(effectiveCwd, configuredSessionDir ?? defaultSessionDir)
+  // Persist subagent sessions by default so Agent-tool subagents become
+  // first-class, parent-linked sessions (like spawn_subsession children).
+  // persist_session: false in the agent config remains an explicit opt-out.
+  const shouldPersist = agentConfig?.persistSession !== false;
+  const parentSessionFile = ctx.sessionManager?.getSessionFile?.();
+  const sessionManager = shouldPersist
+    ? SessionManager.create(effectiveCwd, configuredSessionDir ?? defaultSessionDir, {
+        ...(parentSessionFile ? { parentSession: parentSessionFile } : {}),
+      })
     : SessionManager.inMemory(effectiveCwd);
 
   // Pi 0.80.8 replaced createAgentSession's modelRegistry option with


### PR DESCRIPTION
## What

Agent-tool subagents currently run with an **in-memory** `SessionManager` unless a per-agent `persist_session: true` is configured — so they produce zero session files and no transcript. They also never record a parent link. This PR makes subagent sessions **first-class, persisted, parent-linked pi sessions by default**:

1. **Persist by default** — `persistSession` now defaults to on when the agent config leaves it unset (`persistSession !== false`). `persist_session: false` in an agent config remains the explicit opt-out for ephemeral agents.
2. **Parent link** — the parent session file (`ctx.sessionManager.getSessionFile()`) is propagated via `SessionManager.create(..., { parentSession })`, which the SDK writes into the session header (`SessionHeader.parentSession`). Session listings already map that to `SessionInfo.parentSessionPath`, so subagents appear as linked children of the spawning session — exactly like `spawn_subsession` children — in any UI that reads session files (pi-web Sessions view, Subsessions panel).

## Why

In our environment, Agent-tool subagents are the main delegation mechanism, but they were invisible in session listings and their transcripts vanished when the parent session ended. With this change a subagent spawn produces a real JSONL session file in the parent cwd's session dir (same default dir as the parent), with a `parentSession` header field, and the file grows during the run (the SDK defers file creation until the first assistant message, so aborted agents still leave nothing behind).

Steer/resume are unaffected: `resumeAgent`/`steerAgent` operate on the same `AgentSession` object, which holds the sessionManager we pass in.

## Notes / decisions for review

- **Behavior change**: persistence is now the default. The alternative (keeping it opt-in) was rejected for this environment because the entire point is that subagents are first-class sessions; `persist_session: false` preserves the old ephemeral behavior for anyone who wants it.
- `output_transcript` governs a separate output-file mechanism and is untouched.
- Worktree-isolated agents still land in the worktree's session dir (as before) — the header link is preserved either way.
- The `?.` on `ctx.sessionManager` is defensive; the type marks it required, but non-standard hosts cost nothing to guard.

## Test plan (performed in our env)

- `SessionManager.create(cwd, dir, { parentSession })` verified to write `parentSession` into the header; `buildSessionInfo` maps it to `parentSessionPath`.
- jiti load of the full extension graph after the change: OK.
- Live verification pending a sessiond restart (extensions load at startup): spawn an Agent-tool subagent → expect a JSONL file in the parent cwd session dir with a `parentSession` header equal to the parent's session file; `GET /api/sessions?cwd=<path>` lists it with `parentSessionPath`; `persist_session: false` still produces no file.
