### PR TITLE
fix(#206): per-session config discovery — registry, settings, and Agent tool schema follow the session cwd

### DIFF
--- a/src/agent-manager.ts
+++ b/src/agent-manager.ts
@@ -13,7 +13,7 @@ import { isAbsolute } from "node:path";
 import type { Model } from "@earendil-works/pi-ai";
 import type { AgentSession, ExtensionAPI, ExtensionContext } from "@earendil-works/pi-coding-agent";
 import { resumeAgent, runAgent, type ToolActivity } from "./agent-runner.js";
-import type { AgentInvocation, AgentRecord, IsolationMode, SubagentType, ThinkingLevel } from "./types.js";
+import type { AgentConfig, AgentInvocation, AgentRecord, IsolationMode, SubagentType, ThinkingLevel } from "./types.js";
 import { addUsage } from "./usage.js";
 import { cleanupWorktree, createWorktree, pruneWorktrees, } from "./worktree.js";
 
@@ -119,10 +119,20 @@ interface SpawnOptions {
   configCwd?: string;
   /** Root session id, inherited by nested launches so transcripts stay grouped. */
   rootSessionId?: string;
+  /** Registry the spawned agent's config resolves from — the spawning session's live registry, or a nested branch's root registry. */
+  registry: Map<string, AgentConfig>;
+  /** Registry builder threaded to nested delegation (applies the session's `disableDefaultAgents`). */
+  buildRegistryFor?: (configCwd: string) => Map<string, AgentConfig>;
 }
 
 export class AgentManager {
   private agents = new Map<string, AgentRecord>();
+  /**
+   * The owning session's working directory — where dispose() prunes orphaned
+   * worktrees. Set by the session (index.ts, on session_start); falls back to
+   * `process.cwd()`, which is the same directory in the CLI.
+   */
+  sessionCwd?: string;
   private cleanupInterval: ReturnType<typeof setInterval>;
   private onComplete?: OnAgentComplete;
   private onStart?: OnAgentStart;
@@ -275,6 +285,8 @@ export class AgentManager {
     const promise = runAgent(ctx, type, prompt, {
       pi,
       agentId: id,
+      registry: options.registry,
+      buildRegistryFor: options.buildRegistryFor,
       model: options.model,
       maxTurns: options.maxTurns,
       isolated: options.isolated,
@@ -682,7 +694,7 @@ export class AgentManager {
     }
     this.agents.clear();
     // Prune any orphaned git worktrees (crash recovery)
-    try { pruneWorktrees(process.cwd()); } catch { /* ignore */ }
+    try { pruneWorktrees(this.sessionCwd ?? process.cwd()); } catch { /* ignore */ }
     // Also prune repos that caller-supplied cwds created worktrees in — a clean
     // exit with in-flight agents would otherwise leave stale registrations there.
     for (const repo of this.worktreeRepos) {

--- a/src/agent-runner.ts
+++ b/src/agent-runner.ts
@@ -17,16 +17,17 @@ import {
   SessionManager,
   SettingsManager,
 } from "@earendil-works/pi-coding-agent";
-import { BUILTIN_TOOL_NAMES, getAgentConfig, getConfig, getMemoryToolNames, getReadOnlyMemoryToolNames, getToolNamesForType } from "./agent-types.js";
+import { BUILTIN_TOOL_NAMES, buildAgentRegistry, getAgentConfigIn, getConfigIn, getMemoryToolNames, getReadOnlyMemoryToolNames, getToolNamesForTypeIn } from "./agent-types.js";
 import { runInChildSessionContext } from "./child-context.js";
 import { buildParentContext, extractText } from "./context.js";
+import { loadCustomAgents } from "./custom-agents.js";
 import { DEFAULT_AGENTS } from "./default-agents.js";
 import { detectEnv } from "./env.js";
 import { buildMemoryBlock, buildReadOnlyMemoryBlock } from "./memory.js";
 import { createNestedSubagentTools, getMaxSubagentDepth, type NestedAgentManager } from "./nested-tools.js";
 import { buildAgentPrompt, type PromptExtras } from "./prompts.js";
 import { preloadSkills } from "./skill-loader.js";
-import type { SubagentType, ThinkingLevel } from "./types.js";
+import type { AgentConfig, SubagentType, ThinkingLevel } from "./types.js";
 
 /**
  * Tool names registered by THIS extension. Single source of truth so the
@@ -360,6 +361,20 @@ export interface ToolActivity {
 export interface RunOptions {
   /** ExtensionAPI instance — used for pi.exec() instead of execSync. */
   pi: ExtensionAPI;
+  /**
+   * The agent registry this run resolves its type against — the spawning
+   * session's live registry (per-session state in index.ts), or the nested
+   * root registry for nested delegation. Read at run time rather than at
+   * spawn time so a queued spawn sees mid-session agent-file reloads, the
+   * same semantics the process-wide registry had.
+   */
+  registry: Map<string, AgentConfig>;
+  /**
+   * Build a registry for a config root, applying the session's registry
+   * settings (`disableDefaultAgents`). Threaded to nested delegation, whose
+   * own config root may differ from the session's.
+   */
+  buildRegistryFor?: (configCwd: string) => Map<string, AgentConfig>;
   /** Manager-assigned id; suffixes session name to disambiguate parallel spawns (e.g. `Explore#a1b2c3d4`). */
   agentId?: string;
   model?: Model<any>;
@@ -526,8 +541,8 @@ export async function runAgent(
   prompt: string,
   options: RunOptions,
 ): Promise<RunResult> {
-  const config = getConfig(type);
-  const agentConfig = getAgentConfig(type);
+  const config = getConfigIn(options.registry, type);
+  const agentConfig = getAgentConfigIn(options.registry, type);
 
   // Resolve working directory: worktree override > parent cwd
   const effectiveCwd = options.cwd ?? ctx.cwd;
@@ -559,7 +574,7 @@ export async function runAgent(
     }
   }
 
-  let toolNames = getToolNamesForType(type);
+  let toolNames = getToolNamesForTypeIn(options.registry, type);
 
   // Persistent memory: detect write capability and branch accordingly.
   // Account for disallowedTools — a tool in the base set but on the denylist is not truly available.
@@ -773,6 +788,10 @@ export async function runAgent(
         maxSubagentDepth: effectiveMaxDepth,
         allowedSubagents: agentConfig.allowedSubagents,
         configCwd,
+        // Default preserves the pre-threading nested behavior: defaults
+        // enabled, non-strict load from the branch's own config root.
+        buildRegistryFor:
+          options.buildRegistryFor ?? ((root: string) => buildAgentRegistry(loadCustomAgents(root))),
       })
     : [];
   const nestedToolNames = new Set(nestedTools.map(tool => tool.name));

--- a/src/agent-types.ts
+++ b/src/agent-types.ts
@@ -21,63 +21,25 @@ export const BUILTIN_TOOL_NAMES: string[] = [
   ...new Set([...createCodingTools("."), ...createReadOnlyTools(".")].map((t) => t.name)),
 ];
 
-/** Unified runtime registry of all agents (defaults + user-defined). */
-const agents = new Map<string, AgentConfig>();
-
-/** When true, DEFAULT_AGENTS are skipped during registration. */
-let disableDefaults = false;
-
-/** Check whether default agents are disabled. */
-export function isDefaultsDisabled(): boolean { return disableDefaults; }
-
-/** Set whether default agents are disabled. */
-export function setDefaultsDisabled(b: boolean): void { disableDefaults = b; }
-
 /** `fallbackSubagent` value that disables the fallback entirely (strict dispatch). */
 export const NO_FALLBACK = "none";
 
 /**
- * Agent type substituted when a caller-supplied `subagent_type` doesn't resolve
- * to exactly one enabled agent. `undefined` keeps the historical behavior
- * (general-purpose); `NO_FALLBACK` makes dispatch fail closed. Set from
- * `subagents.json` (`fallbackSubagent`).
- *
- * Module state rather than an index.ts closure because every caller-supplied
- * spawn path needs it — the Agent tool, the scheduler, and cross-extension RPC.
- */
-let fallbackSubagent: string | undefined;
-
-/** Get the configured fallback agent type. undefined = general-purpose. */
-export function getFallbackSubagent(): string | undefined { return fallbackSubagent; }
-
-/** Set the configured fallback agent type. undefined = general-purpose. */
-export function setFallbackSubagent(v: string | undefined): void { fallbackSubagent = v; }
-
-/**
  * Build a registry map: DEFAULT_AGENTS first (unless disabled via settings),
  * then user agents overlaid on top (same name overrides the default).
- * Pure — callers that must not disturb the process-wide registry (nested
- * delegation resolving agents from its own config root) build their own map.
+ * Pure — every caller builds registries for its own root: the per-session
+ * state below for the session's config root, nested delegation for its own.
  */
-export function buildAgentRegistry(userAgents: Map<string, AgentConfig>): Map<string, AgentConfig> {
+export function buildAgentRegistry(
+  userAgents: Map<string, AgentConfig>,
+  disableDefaults = false,
+): Map<string, AgentConfig> {
   const registry = new Map<string, AgentConfig>();
   if (!disableDefaults) {
     for (const [name, config] of DEFAULT_AGENTS) registry.set(name, config);
   }
   for (const [name, config] of userAgents) registry.set(name, config);
   return registry;
-}
-
-/**
- * Register agents into the unified registry.
- * Starts with DEFAULT_AGENTS, then overlays user agents (overrides defaults with same name).
- * Disabled agents (enabled === false) are kept in the registry but excluded from spawning.
- */
-export function registerAgents(userAgents: Map<string, AgentConfig>): void {
-  agents.clear();
-  for (const [name, config] of buildAgentRegistry(userAgents)) {
-    agents.set(name, config);
-  }
 }
 
 /** Case-insensitive key resolution within a registry. */
@@ -88,11 +50,6 @@ function resolveKeyIn(registry: Map<string, AgentConfig>, name: string): string 
     if (key.toLowerCase() === lower) return key;
   }
   return undefined;
-}
-
-/** Case-insensitive key resolution. */
-function resolveKey(name: string): string | undefined {
-  return resolveKeyIn(agents, name);
 }
 
 /** Resolve a type name case-insensitively in a registry. Returns the canonical key or undefined. */
@@ -161,19 +118,25 @@ export type SpawnTypeResolution =
  * Resolve a caller-supplied agent type against a registry, applying the
  * `fallbackSubagent` policy. The single decision point for every caller-supplied
  * spawn — the Agent tool, the scheduler, cross-extension RPC, and the nested
- * tools — so a type that fails here never reaches `runAgent`, where `getConfig`
+ * tools — so a type that fails here never reaches `runAgent`, where `getConfigIn`
  * would silently substitute general-purpose.
  *
  * Unknown, disabled, and case-ambiguous names are all treated the same way:
  * the caller named something that doesn't identify exactly one enabled agent.
  *
- * Pure over `registry` — callers that need fresh agent files reload before
- * calling (the Agent tool already does, per spawn). Reloading here would mean
- * importing custom-agents.ts, which imports this module.
+ * Pure over `registry` and `fallbackSubagent` — callers that need fresh agent
+ * files reload before calling (the Agent tool already does, per spawn).
+ * Reloading here would mean importing custom-agents.ts, which imports this
+ * module.
+ *
+ * `fallbackSubagent` is the type substituted when the requested one doesn't
+ * resolve: `undefined` keeps the historical behavior (general-purpose);
+ * `NO_FALLBACK` makes dispatch fail closed. Set from `subagents.json`.
  */
 export function resolveSpawnTypeIn(
   registry: Map<string, AgentConfig>,
   requested: unknown,
+  fallbackSubagent?: string,
 ): SpawnTypeResolution {
   const raw = typeof requested === "string" ? requested.trim() : "";
   const available = () => getAvailableTypesIn(registry).join(", ") || "(none)";
@@ -218,48 +181,23 @@ export function resolveSpawnTypeIn(
   return { ok: true, type: "general-purpose", fellBackFrom: raw };
 }
 
-/** Resolve a caller-supplied agent type against the process-wide registry. */
-export function resolveSpawnType(requested: unknown): SpawnTypeResolution {
-  return resolveSpawnTypeIn(agents, requested);
+/** Get all type names in a registry, including disabled (for UI listing). */
+export function getAllTypesIn(registry: Map<string, AgentConfig>): string[] {
+  return [...registry.keys()];
 }
 
-/** Resolve a type name case-insensitively. Returns the canonical key or undefined. */
-export function resolveType(name: string): string | undefined {
-  return resolveKey(name);
-}
-
-/** Get the agent config for a type (case-insensitive). */
-export function getAgentConfig(name: string): AgentConfig | undefined {
-  return getAgentConfigIn(agents, name);
-}
-
-/** Get all enabled type names (for spawning and tool descriptions). */
-export function getAvailableTypes(): string[] {
-  return getAvailableTypesIn(agents);
-}
-
-/** Get all type names including disabled (for UI listing). */
-export function getAllTypes(): string[] {
-  return [...agents.keys()];
-}
-
-/** Get names of default agents currently in the registry. */
-export function getDefaultAgentNames(): string[] {
-  return [...agents.entries()]
+/** Get names of default agents in a registry. */
+export function getDefaultAgentNamesIn(registry: Map<string, AgentConfig>): string[] {
+  return [...registry.entries()]
     .filter(([_, config]) => config.isDefault === true)
     .map(([name]) => name);
 }
 
-/** Get names of user-defined agents (non-defaults) currently in the registry. */
-export function getUserAgentNames(): string[] {
-  return [...agents.entries()]
+/** Get names of user-defined agents (non-defaults) in a registry. */
+export function getUserAgentNamesIn(registry: Map<string, AgentConfig>): string[] {
+  return [...registry.entries()]
     .filter(([_, config]) => config.isDefault !== true)
     .map(([name]) => name);
-}
-
-/** Check if a type is valid and enabled (case-insensitive). */
-export function isValidType(type: string): boolean {
-  return isValidTypeIn(agents, type);
 }
 
 /** Tool names required for memory management. */
@@ -282,18 +220,18 @@ export function getReadOnlyMemoryToolNames(existingToolNames: Set<string>): stri
   return READONLY_MEMORY_TOOL_NAMES.filter(n => !existingToolNames.has(n));
 }
 
-/** Get built-in tool names for a type (case-insensitive). */
-export function getToolNamesForType(type: string): string[] {
-  const key = resolveKey(type);
-  const raw = key ? agents.get(key) : undefined;
+/** Get built-in tool names for a type (case-insensitive) from a registry. */
+export function getToolNamesForTypeIn(registry: Map<string, AgentConfig>, type: string): string[] {
+  const key = resolveKeyIn(registry, type);
+  const raw = key ? registry.get(key) : undefined;
   const config = raw?.enabled !== false ? raw : undefined;
   // `undefined` (definition omitted the field) → all built-ins; an explicit `[]`
   // (`tools: none` or a `tools:` with only `ext:` entries) → zero built-ins.
   return config?.builtinToolNames ?? [...BUILTIN_TOOL_NAMES];
 }
 
-/** Get config for a type (case-insensitive, returns a SubagentTypeConfig-compatible object). Falls back to general-purpose. */
-export function getConfig(type: string): {
+/** Get config for a type (case-insensitive, returns a SubagentTypeConfig-compatible object) from a registry. Falls back to general-purpose. */
+export function getConfigIn(registry: Map<string, AgentConfig>, type: string): {
   displayName: string;
   description: string;
   builtinToolNames: string[];
@@ -302,8 +240,8 @@ export function getConfig(type: string): {
   skills: true | string[] | false;
   promptMode: "replace" | "append";
 } {
-  const key = resolveKey(type);
-  const config = key ? agents.get(key) : undefined;
+  const key = resolveKeyIn(registry, type);
+  const config = key ? registry.get(key) : undefined;
   if (config && config.enabled !== false) {
     return {
       displayName: config.displayName ?? config.name,
@@ -317,7 +255,7 @@ export function getConfig(type: string): {
   }
 
   // Fallback for unknown/disabled types — general-purpose config
-  const gp = agents.get("general-purpose");
+  const gp = registry.get("general-purpose");
   if (gp && gp.enabled !== false) {
     return {
       displayName: gp.displayName ?? gp.name,
@@ -341,3 +279,69 @@ export function getConfig(type: string): {
   };
 }
 
+/**
+ * Per-session agent-type state: the registry plus the two settings that shape
+ * it (`disableDefaultAgents`, `fallbackSubagent`).
+ *
+ * One instance lives in the extension's activation closure — activation is
+ * per-session, so sessions in one embedding host process (SDK: several
+ * concurrent `createAgentSession`s in different directories) each resolve
+ * against their own registry instead of a process-wide singleton, where
+ * per-session reloads would be last-writer-wins. In the CLI (one session,
+ * `process.cwd() === ctx.cwd`) behavior is unchanged.
+ *
+ * `registry()` returns a stable Map reference that `register()` mutates in
+ * place, so a spawn queued with the reference observes mid-session reloads —
+ * the same live semantics the process-wide registry had.
+ */
+export interface AgentTypeState {
+  /** The live registry. Stable reference; contents replaced by `register()`. */
+  registry(): Map<string, AgentConfig>;
+  /** Rebuild the registry from user agents (defaults first unless disabled). */
+  register(userAgents: Map<string, AgentConfig>): void;
+  isDefaultsDisabled(): boolean;
+  setDefaultsDisabled(b: boolean): void;
+  getFallbackSubagent(): string | undefined;
+  setFallbackSubagent(v: string | undefined): void;
+  resolveType(name: string): string | undefined;
+  getAgentConfig(name: string): AgentConfig | undefined;
+  getAvailableTypes(): string[];
+  getAllTypes(): string[];
+  getDefaultAgentNames(): string[];
+  getUserAgentNames(): string[];
+  isValidType(type: string): boolean;
+  getToolNamesForType(type: string): string[];
+  getConfig(type: string): ReturnType<typeof getConfigIn>;
+  resolveSpawnType(requested: unknown): SpawnTypeResolution;
+}
+
+/** Create an empty per-session agent-type state. */
+export function createAgentTypeState(): AgentTypeState {
+  const agents = new Map<string, AgentConfig>();
+  let disableDefaults = false;
+  let fallbackSubagent: string | undefined;
+
+  return {
+    registry: () => agents,
+    register(userAgents) {
+      agents.clear();
+      for (const [name, config] of buildAgentRegistry(userAgents, disableDefaults)) {
+        agents.set(name, config);
+      }
+    },
+    isDefaultsDisabled: () => disableDefaults,
+    setDefaultsDisabled(b) { disableDefaults = b; },
+    getFallbackSubagent: () => fallbackSubagent,
+    setFallbackSubagent(v) { fallbackSubagent = v; },
+    resolveType: (name) => resolveTypeIn(agents, name),
+    getAgentConfig: (name) => getAgentConfigIn(agents, name),
+    getAvailableTypes: () => getAvailableTypesIn(agents),
+    getAllTypes: () => getAllTypesIn(agents),
+    getDefaultAgentNames: () => getDefaultAgentNamesIn(agents),
+    getUserAgentNames: () => getUserAgentNamesIn(agents),
+    isValidType: (type) => isValidTypeIn(agents, type),
+    getToolNamesForType: (type) => getToolNamesForTypeIn(agents, type),
+    getConfig: (type) => getConfigIn(agents, type),
+    resolveSpawnType: (requested) => resolveSpawnTypeIn(agents, requested, fallbackSubagent),
+  };
+}

--- a/src/enabled-models.ts
+++ b/src/enabled-models.ts
@@ -101,7 +101,7 @@ function hashOf(path: string): string {
 export function resolveEnabledModels(
   patterns: string[] | undefined,
   registry: ModelRegistryRef,
-  cwd: string = process.cwd(),
+  cwd: string,
 ): Set<string> | undefined {
   // Fast path: check cache (stat both project and global settings.json files)
   const patternsKey = JSON.stringify(patterns);

--- a/src/index.ts
+++ b/src/index.ts
@@ -11,14 +11,14 @@
  */
 
 import { existsSync, mkdirSync, readFileSync, unlinkSync } from "node:fs";
-import { join } from "node:path";
+import { join, resolve } from "node:path";
 import { defineTool, type ExtensionAPI, type ExtensionCommandContext, type ExtensionContext, getAgentDir, getSettingsListTheme } from "@earendil-works/pi-coding-agent";
 import { Container, Key, matchesKey, type SettingItem, SettingsList, Spacer, Text } from "@earendil-works/pi-tui";
 import { Type } from "@sinclair/typebox";
 import { abortable } from "./abortable.js";
 import { AgentManager } from "./agent-manager.js";
 import { getAgentConversation, getDefaultMaxTurns, getGraceTurns, normalizeMaxTurns, SUBAGENT_TOOL_NAMES, setDefaultMaxTurns, setGraceTurns, steerAgent } from "./agent-runner.js";
-import { BUILTIN_TOOL_NAMES, getAgentConfig, getAllTypes, getAvailableTypes, getFallbackSubagent, isDefaultsDisabled, NO_FALLBACK, registerAgents, resolveSpawnType, resolveType, setDefaultsDisabled, setFallbackSubagent } from "./agent-types.js";
+import { BUILTIN_TOOL_NAMES, buildAgentRegistry, createAgentTypeState, NO_FALLBACK } from "./agent-types.js";
 import { inChildSessionContext } from "./child-context.js";
 import { type RpcHandle, registerRpcHandlers } from "./cross-extension-rpc.js";
 import { loadCustomAgents } from "./custom-agents.js";
@@ -30,7 +30,7 @@ import { getMaxSubagentDepth, setMaxSubagentDepth } from "./nested-tools.js";
 import { createOutputFilePath, getOutputTranscriptDefault, setOutputTranscriptDefault, streamToOutputFile, writeInitialEntry } from "./output-file.js";
 import { SubagentScheduler } from "./schedule.js";
 import { resolveStorePath, ScheduleStore } from "./schedule-store.js";
-import { applyAndEmitLoaded, loadSettings, type SubagentsSettings, saveAndEmitChanged, type ToolDescriptionMode } from "./settings.js";
+import { applyAndEmitLoaded, applyDefaultSettings, loadSettings, type SettingsAppliers, type SubagentsSettings, saveAndEmitChanged, type ToolDescriptionMode } from "./settings.js";
 import { getForegroundOutcomeNote, getStatusNote, partialOutputSuffix } from "./status-note.js";
 import { type AgentConfig, type AgentInvocation, type AgentRecord, type JoinMode, type NotificationDetails, type SubagentType, type WidgetMode } from "./types.js";
 import {
@@ -278,15 +278,34 @@ export default function (pi: ExtensionAPI) {
     }
   );
 
+  // ---- Per-session agent-type state (#206) ----
+  // The registry and its settings live in this activation closure, never in
+  // module scope: activation is per-session, so an embedding host running
+  // several concurrent sessions (SDK) gives each its own registry instead of
+  // a process-wide one where per-session reloads would be last-writer-wins.
+  const agentTypes = createAgentTypeState();
+
+  // The session's working directory. Provisional `process.cwd()` until
+  // `session_start` delivers `ctx.cwd` — identical in the CLI, different in
+  // an embedding host whose process cwd is not the session's project (#206).
+  let sessionCwd = process.cwd();
+
   // Read directly rather than waiting for applyAndEmitLoaded below: this decides
   // the initial load, which happens hundreds of lines before settings are applied.
-  let strictAgentFiles = loadSettings(process.cwd()).strictAgentFiles === true;
+  let strictAgentFiles = loadSettings(sessionCwd).strictAgentFiles === true;
 
   /** Reload agents from project/global custom agent dirs and merge with defaults (called on init and each Agent invocation). */
   const reloadCustomAgents = (strict = false) => {
-    const userAgents = loadCustomAgents(process.cwd(), strict);
-    registerAgents(userAgents);
+    agentTypes.register(loadCustomAgents(sessionCwd, strict));
   };
+
+  /**
+   * Build a registry for an arbitrary config root with this session's registry
+   * settings (`disableDefaultAgents`). Nested delegation resolves its own
+   * config roots through this, so a nested branch honors the session's
+   * settings without touching the session's registry.
+   */
+  const buildRegistryFor = (root: string) => buildAgentRegistry(loadCustomAgents(root), agentTypes.isDefaultsDisabled());
 
   // Initial load — the only strict one. A bad edit mid-session must not kill the
   // session on the next unrelated spawn, so every later reload keeps warning.
@@ -495,8 +514,13 @@ export default function (pi: ExtensionAPI) {
     // envelopes at the RPC boundary. Reload first so an agent file added mid
     // session is spawnable here too, not only through the Agent tool.
     reloadCustomAgents();
-    const dispatch = resolveSpawnType(type);
+    const dispatch = agentTypes.resolveSpawnType(type);
     if (!dispatch.ok) throw new Error(dispatch.message);
+    // The registry is a capability, not an option: it decides which agent
+    // definitions the spawn resolves against, so external callers get the
+    // session's own — a forged one would smuggle in arbitrary definitions.
+    safeOptions.registry = agentTypes.registry();
+    safeOptions.buildRegistryFor = buildRegistryFor;
     return manager.spawn(piRef, ctxRef, dispatch.type, prompt, safeOptions);
   };
   const registryEntry = {
@@ -536,7 +560,7 @@ export default function (pi: ExtensionAPI) {
       if (!sessionId) return;  // sessionId not yet available — try again on next event
       const path = resolveStorePath(ctx.cwd, sessionId);
       const store = new ScheduleStore(path);
-      scheduler.start(pi, ctx, manager, store);
+      scheduler.start(pi, ctx, manager, store, agentTypes, buildRegistryFor);
       pi.events.emit("subagents:scheduler_ready", { sessionId, jobCount: store.list().length });
     } catch (err) {
       // Scheduling is non-essential — log and move on so the rest of the
@@ -550,6 +574,44 @@ export default function (pi: ExtensionAPI) {
   // bound session_start, so a filtered-out activation never advertises (#142).
   pi.on("session_start", async (_event, ctx) => {
     currentCtx = ctx;
+    manager.sessionCwd = ctx.cwd;
+    // Adopt the session's working directory (#206). The provisional value was
+    // `process.cwd()` — identical to `ctx.cwd` in the CLI, where this block
+    // never runs. In an embedding host (SDK) whose sessions live elsewhere,
+    // project settings, custom agents, and the Agent tool's advertised type
+    // list were all derived from the wrong tree — rebuild them from the
+    // session's own cwd, in dependency order: settings first (they decide
+    // strictness, disabled defaults, and the description mode), then the
+    // registry, then the tool registration that embeds both.
+    // resolve() both sides so a spelling difference (trailing slash, relative
+    // segment) can't make a genuinely-CLI session look adopted — adoption
+    // re-registers the tool and emits a second settings_loaded, and the CLI
+    // pin promises neither.
+    if (resolve(ctx.cwd) !== resolve(sessionCwd)) {
+      sessionCwd = ctx.cwd;
+      // Defaults first: appliers only fire for keys the merged settings name,
+      // so re-applying alone would let the provisional cwd's policy (e.g.
+      // disableDefaultAgents, fallbackSubagent) survive wherever the
+      // session's own tree is silent.
+      applyDefaultSettings(settingsAppliers);
+      applySettingsFromDisk();
+      // This is the session's startup load — the strict one (a broken
+      // checked-in agent file should fail loudly here, like CLI startup).
+      try {
+        reloadCustomAgents(strictAgentFiles);
+      } catch (err) {
+        // Strictness failed the load, but the settings are already the
+        // session's and every later reload is non-strict from the new cwd —
+        // keeping the provisional roster would leave the advertised type list
+        // and actual dispatch diverged for good. Converge on the session's
+        // tree (minus the broken file), then rethrow so the failure still
+        // surfaces as an extension error.
+        reloadCustomAgents();
+        registerAgentTool();
+        throw err;
+      }
+      registerAgentTool();
+    }
     manager.clearCompleted(true);
     // Guard mirrors the `!scheduler.isActive()` pattern below: session_start
     // fires once per activation, but a double-bind must not leak listeners.
@@ -607,11 +669,11 @@ export default function (pi: ExtensionAPI) {
   // everything else; "off" = hide the widget entirely. Read live at render time.
   let widgetMode: WidgetMode = "background";
   function getWidgetMode(): WidgetMode { return widgetMode; }
-  const widget = new AgentWidget(manager, agentActivity, getWidgetMode);
+  const widget = new AgentWidget(manager, agentActivity, agentTypes.registry(), getWidgetMode);
   function setWidgetMode(m: WidgetMode): void { widgetMode = m; widget.update(); }
 
   // Claude Code-style FleetView: navigable list of main + subagents below the editor.
-  const fleet = new FleetList(manager, agentActivity);
+  const fleet = new FleetList(manager, agentActivity, agentTypes.registry());
   let fleetViewEnabled = true;
   function isFleetViewEnabled(): boolean { return fleetViewEnabled; }
   function setFleetViewEnabled(b: boolean): void { fleetViewEnabled = b; fleet.setEnabled(b); }
@@ -644,7 +706,7 @@ export default function (pi: ExtensionAPI) {
   // State lives in agent-types.ts (isDefaultsDisabled) because registerAgents
   // needs it; this wrapper just re-registers after flipping it.
   function setDisableDefaultAgents(b: boolean): void {
-    setDefaultsDisabled(b);
+    agentTypes.setDefaultsDisabled(b);
     reloadCustomAgents(); // re-register with new setting
   }
 
@@ -718,10 +780,10 @@ export default function (pi: ExtensionAPI) {
 
   /** Build the full type list text dynamically from available agents only. */
   const buildTypeListText = () => {
-    const available = getAvailableTypes();
+    const available = agentTypes.getAvailableTypes();
 
     return available.map((name) => {
-      const cfg = getAgentConfig(name);
+      const cfg = agentTypes.getAgentConfig(name);
       const modelSuffix = cfg?.model ? ` (${getModelLabelFromConfig(cfg.model)})` : "";
       const toolsSuffix = ` (Tools: ${formatToolsSuffix(cfg)})`;
       return `- ${name}: ${cfg?.description ?? name}${modelSuffix}${toolsSuffix}`;
@@ -736,8 +798,8 @@ export default function (pi: ExtensionAPI) {
 
   /** Compact type list: one line per agent, first sentence only. */
   const buildCompactTypeListText = () =>
-    getAvailableTypes().map((name) => {
-      const cfg = getAgentConfig(name);
+    agentTypes.getAvailableTypes().map((name) => {
+      const cfg = agentTypes.getAgentConfig(name);
       return `- ${name}: ${firstSentence(cfg?.description ?? name)} (Tools: ${formatToolsSuffix(cfg)})`;
     }).join("\n");
 
@@ -751,26 +813,33 @@ export default function (pi: ExtensionAPI) {
 
   // Apply persisted settings on startup and emit `subagents:settings_loaded`.
   // Global + project merged; missing → defaults; corrupt file emits a warning
-  // to stderr and falls back to defaults.
-  applyAndEmitLoaded(
-    {
-      setMaxConcurrent: (n) => manager.setMaxConcurrent(n),
-      setDefaultMaxTurns,
-      setGraceTurns,
-      setDefaultJoinMode,
-      setSchedulingEnabled,
-      setScopeModels: setScopeModelsEnabled,
-      setStrictAgentFiles: (b) => { strictAgentFiles = b; },
-      setDisableDefaultAgents: setDisableDefaultAgents,
-      setToolDescriptionMode: setToolDescriptionMode,
-      setFleetView: setFleetViewEnabled,
-      setWidgetMode: setWidgetMode,
-      setOutputTranscript: setOutputTranscriptDefault,
-      setMaxSubagentDepth: setMaxSubagentDepth,
-      setFallbackSubagent: setFallbackSubagent,
-    },
+  // to stderr and falls back to defaults. Re-run when session_start adopts a
+  // diverging session cwd (#206), so the session's own project settings apply.
+  // Named (not inlined into applyAndEmitLoaded) because the session_start
+  // adoption also runs the defaults reset through the same appliers — one
+  // object so the two paths can never drift apart.
+  const settingsAppliers: SettingsAppliers = {
+    setMaxConcurrent: (n) => manager.setMaxConcurrent(n),
+    setDefaultMaxTurns,
+    setGraceTurns,
+    setDefaultJoinMode,
+    setSchedulingEnabled,
+    setScopeModels: setScopeModelsEnabled,
+    setStrictAgentFiles: (b) => { strictAgentFiles = b; },
+    setDisableDefaultAgents: setDisableDefaultAgents,
+    setToolDescriptionMode: setToolDescriptionMode,
+    setFleetView: setFleetViewEnabled,
+    setWidgetMode: setWidgetMode,
+    setOutputTranscript: setOutputTranscriptDefault,
+    setMaxSubagentDepth: setMaxSubagentDepth,
+    setFallbackSubagent: (v) => agentTypes.setFallbackSubagent(v),
+  };
+  const applySettingsFromDisk = () => applyAndEmitLoaded(
+    settingsAppliers,
     (event, payload) => pi.events.emit(event, payload),
+    sessionCwd,
   );
+  applySettingsFromDisk();
 
   // ---- Agent tool ----
 
@@ -789,17 +858,17 @@ export default function (pi: ExtensionAPI) {
       }),
     ),
   };
-  const scheduleParam: Partial<typeof scheduleParamShape> =
+  const scheduleParam = (): Partial<typeof scheduleParamShape> =>
     isSchedulingEnabled() ? scheduleParamShape : {};
 
-  const scheduleGuideline = isSchedulingEnabled()
+  const scheduleGuideline = () => isSchedulingEnabled()
     ? `\n- Use \`schedule\` only when the user explicitly asked for scheduled / recurring / delayed execution (e.g. "every Monday", "in an hour"). Don't auto-schedule from vague intent like "monitor X" — run once now or ask.`
     : "";
 
   // Compact Agent tool description (#91, `toolDescriptionMode: "compact"`) —
   // the same load-bearing facts as the full version at ~75% fewer tokens, for
   // small/local models. Per-option details live in the param descriptions.
-  const compactAgentToolDescription = `Launch an autonomous agent for complex, multi-step tasks. Agent types:
+  const compactAgentToolDescription = () => `Launch an autonomous agent for complex, multi-step tasks. Agent types:
 ${buildCompactTypeListText()}
 
 Custom agents: .pi/agents/<name>.md (project) or ${getAgentDir()}/agents/<name>.md (global).
@@ -811,7 +880,7 @@ Notes:
 - resume continues a previous agent by ID; steer_subagent messages a running one.
 - isolation: "worktree" runs the agent in an isolated git worktree; changes land on a branch.`;
 
-  const fullAgentToolDescription = `Launch a new agent to handle complex, multi-step tasks autonomously. Each agent type has specific capabilities and tools available to it.
+  const fullAgentToolDescription = () => `Launch a new agent to handle complex, multi-step tasks autonomously. Each agent type has specific capabilities and tools available to it.
 
 Available agent types and the tools they have access to:
 ${buildTypeListText()}
@@ -839,7 +908,7 @@ If the target is already known, use a direct tool — \`read\` for a known path,
 - Use model to specify a different model (as "provider/modelId", or fuzzy e.g. "haiku", "sonnet").
 - Use thinking to control extended thinking level.
 - Use inherit_context if the agent needs the parent conversation history.
-- Use isolation: "worktree" to run the agent in an isolated git worktree (safe parallel file modifications). The worktree is automatically cleaned up if the agent makes no changes; otherwise the path and branch are returned in the result.${scheduleGuideline}
+- Use isolation: "worktree" to run the agent in an isolated git worktree (safe parallel file modifications). The worktree is automatically cleaned up if the agent makes no changes; otherwise the path and branch are returned in the result.${scheduleGuideline()}
 
 ## Writing the prompt
 
@@ -863,7 +932,7 @@ Terse command-style prompts produce shallow, generic work.
       typeList: buildTypeListText,
       compactTypeList: buildCompactTypeListText,
       agentDir: getAgentDir,
-      scheduleGuideline: () => scheduleGuideline,
+      scheduleGuideline,
     };
     // Replacement callback (not a string) — agent descriptions may contain `$&` etc.
     return template.replace(/\{\{(\w+)\}\}/g, (raw, name: string) => {
@@ -875,7 +944,7 @@ Terse command-style prompts produce shallow, generic work.
 
   const loadCustomToolDescription = (): string | undefined => {
     for (const path of [
-      join(process.cwd(), ".pi", "agent-tool-description.md"),
+      join(sessionCwd, ".pi", "agent-tool-description.md"),
       join(getAgentDir(), "agent-tool-description.md"),
     ]) {
       try {
@@ -890,21 +959,30 @@ Terse command-style prompts produce shallow, generic work.
     return undefined;
   };
 
-  const agentToolDescription = (() => {
+  const agentToolDescription = () => {
     const mode = getToolDescriptionMode();
-    if (mode === "compact") return compactAgentToolDescription;
+    if (mode === "compact") return compactAgentToolDescription();
     if (mode === "custom") {
       const custom = loadCustomToolDescription();
       if (custom) return custom;
       console.warn('[pi-subagents] toolDescriptionMode is "custom" but no agent-tool-description.md found — using "full"');
     }
-    return fullAgentToolDescription;
-  })();
+    return fullAgentToolDescription();
+  };
 
+  /**
+   * Register the Agent tool. Everything session-dependent — the description
+   * (type list, custom description file, schedule gating) and the
+   * `subagent_type` schema text — is computed at call time, so re-registering
+   * after `session_start` adopts a diverging session cwd (#206) rebuilds the
+   * advertised surface from that session's registry and settings. pi's
+   * `registerTool` replaces by name; in the CLI this runs exactly once.
+   */
+  const registerAgentTool = () => {
   pi.registerTool(defineTool({
     name: SUBAGENT_TOOL_NAMES.AGENT,
     label: "Agent",
-    description: agentToolDescription,
+    description: agentToolDescription(),
     promptSnippet: "Launch autonomous sub-agents for complex multi-step tasks",
     promptGuidelines: [
       "Use Agent with specialized agents when the task matches an agent type's description. Subagents are valuable for parallelizing independent queries or for protecting the main context window from excessive results, but should not be used excessively when not needed. Importantly, avoid duplicating work that subagents are already doing — if you delegate research to a subagent, do not also perform the same searches yourself.",
@@ -920,7 +998,7 @@ Terse command-style prompts produce shallow, generic work.
         description: "A short (3-5 word) description of the task (shown in UI).",
       }),
       subagent_type: Type.String({
-        description: `The type of specialized agent to use. Available types: ${getAvailableTypes().join(", ")}. Custom agents from .pi/agents/*.md (project) or ${getAgentDir()}/agents/*.md (global) are also available.`,
+        description: `The type of specialized agent to use. Available types: ${agentTypes.getAvailableTypes().join(", ")}. Custom agents from .pi/agents/*.md (project) or ${getAgentDir()}/agents/*.md (global) are also available.`,
       }),
       model: Type.Optional(
         Type.String({
@@ -964,13 +1042,13 @@ Terse command-style prompts produce shallow, generic work.
           description: 'Set to "worktree" to run the agent in a temporary git worktree (isolated copy of the repo). Changes are saved to a branch on completion.',
         }),
       ),
-      ...scheduleParam,
+      ...scheduleParam(),
     }),
 
     // ---- Custom rendering: Claude Code style ----
 
     renderCall(args, theme) {
-      const displayName = args.subagent_type ? getDisplayName(args.subagent_type) : "Agent";
+      const displayName = args.subagent_type ? getDisplayName(agentTypes.registry(), args.subagent_type) : "Agent";
       const desc = args.description ?? "";
       return new Text("▸ " + theme.fg("toolTitle", theme.bold(displayName)) + (desc ? "  " + theme.fg("muted", desc) : ""), 0, 0);
     },
@@ -1079,7 +1157,7 @@ Terse command-style prompts produce shallow, generic work.
       // background or scheduled call can't start running the wrong agent while
       // the caller is still unaware. `fallbackSubagent` decides whether an
       // unresolvable type falls back or fails closed.
-      const dispatch = resolveSpawnType(rawType);
+      const dispatch = agentTypes.resolveSpawnType(rawType);
       // `resume` replays a stored session and ignores `subagent_type` entirely,
       // but the parameter is required by the schema — so gating it here would
       // make a live agent unresumable the moment its type is deleted, disabled,
@@ -1096,13 +1174,13 @@ Terse command-style prompts produce shallow, generic work.
       // session and ignores `subagent_type` entirely, so a note about type
       // substitution would be describing something that didn't happen.
       const fallbackNote = dispatch.ok && dispatch.fellBackFrom !== undefined
-        ? `Note: Unknown agent type "${dispatch.fellBackFrom}" — using ${resolveType(subagentType) ? subagentType : "the fallback agent config"}.\n\n`
+        ? `Note: Unknown agent type "${dispatch.fellBackFrom}" — using ${agentTypes.resolveType(subagentType) ? subagentType : "the fallback agent config"}.\n\n`
         : "";
 
-      const displayName = getDisplayName(subagentType);
+      const displayName = getDisplayName(agentTypes.registry(), subagentType);
 
       // Get agent config (if any)
-      const customConfig = getAgentConfig(subagentType);
+      const customConfig = agentTypes.getAgentConfig(subagentType);
 
       const resolvedConfig = resolveAgentInvocationConfig(customConfig, params);
 
@@ -1167,7 +1245,7 @@ Terse command-style prompts produce shallow, generic work.
         isolation,
       };
       // Tool-result render shows the mode label too; viewer's header already does.
-      const modeLabel = getPromptModeLabel(subagentType);
+      const modeLabel = getPromptModeLabel(agentTypes.registry(), subagentType);
       const { tags: invocationTags } = buildInvocationTags(agentInvocation);
       const agentTags = modeLabel ? [modeLabel, ...invocationTags] : invocationTags;
       const detailBase = {
@@ -1267,6 +1345,8 @@ Terse command-style prompts produce shallow, generic work.
         // reads to the model as a subagent that ran and reported this (#179).
         id = manager.spawn(pi, ctx, subagentType, params.prompt, {
           description: params.description,
+          registry: agentTypes.registry(),
+          buildRegistryFor,
           model,
           maxTurns: effectiveMaxTurns,
           isolated,
@@ -1391,6 +1471,8 @@ Terse command-style prompts produce shallow, generic work.
       try {
         const fgResult = await manager.spawnAndWait(pi, ctx, subagentType, params.prompt, {
           description: params.description,
+          registry: agentTypes.registry(),
+          buildRegistryFor,
           model,
           maxTurns: effectiveMaxTurns,
           isolated,
@@ -1440,6 +1522,8 @@ Terse command-style prompts produce shallow, generic work.
       );
     },
   }));
+  };
+  registerAgentTool();
 
   // ---- get_subagent_result tool ----
 
@@ -1485,7 +1569,7 @@ Terse command-style prompts produce shallow, generic work.
         if (record.promise) await abortable(record.promise, signal);
       }
 
-      const displayName = getDisplayName(record.type);
+      const displayName = getDisplayName(agentTypes.registry(), record.type);
       const duration = formatDuration(record.startedAt, record.completedAt);
       const tokens = formatLifetimeTokens(record);
       const contextPercent = getSessionContextPercent(record.session);
@@ -1581,8 +1665,8 @@ Terse command-style prompts produce shallow, generic work.
 
   // ---- /agents interactive menu ----
 
-  const projectAgentsDir = () => join(process.cwd(), ".pi", "agents");
-  const workspaceAgentsDir = () => join(process.cwd(), ".agents", "agents");
+  const projectAgentsDir = () => join(sessionCwd, ".pi", "agents");
+  const workspaceAgentsDir = () => join(sessionCwd, ".agents", "agents");
   const personalAgentsDir = () => join(getAgentDir(), "agents");
 
   /** Find the file path of a custom agent by name, in discovery-precedence order (project, workspace, then global). */
@@ -1597,7 +1681,7 @@ Terse command-style prompts produce shallow, generic work.
   }
 
   function getModelLabel(type: string, registry?: ModelRegistry): string {
-    const cfg = getAgentConfig(type);
+    const cfg = agentTypes.getAgentConfig(type);
     if (!cfg?.model) return "inherit"; // no model configured → really inherits parent
     const label = getModelLabelFromConfig(cfg.model);
     if (!registry) return label;
@@ -1616,7 +1700,7 @@ Terse command-style prompts produce shallow, generic work.
 
   async function showAgentsMenu(ctx: ExtensionCommandContext) {
     reloadCustomAgents();
-    const allNames = getAllTypes();
+    const allNames = agentTypes.getAllTypes();
 
     // Build select options
     const options: string[] = [];
@@ -1675,7 +1759,7 @@ Terse command-style prompts produce shallow, generic work.
   }
 
   async function showAllAgentsList(ctx: ExtensionCommandContext) {
-    const allNames = getAllTypes();
+    const allNames = agentTypes.getAllTypes();
     if (allNames.length === 0) {
       ctx.ui.notify("No agents.", "info");
       return;
@@ -1695,7 +1779,7 @@ Terse command-style prompts produce shallow, generic work.
     // full description renders below the highlighted row via SettingsList,
     // exactly like the Settings menu — so long descriptions never wrap the list.
     const items: SettingItem[] = allNames.map(name => {
-      const cfg = getAgentConfig(name);
+      const cfg = agentTypes.getAgentConfig(name);
       const disabled = cfg?.enabled === false;
       const model = getModelLabel(name, ctx.modelRegistry);
       return {
@@ -1709,8 +1793,8 @@ Terse command-style prompts produce shallow, generic work.
       };
     });
 
-    const hasCustom = allNames.some(n => { const c = getAgentConfig(n); return c && !c.isDefault && c.enabled !== false; });
-    const hasDisabled = allNames.some(n => getAgentConfig(n)?.enabled === false);
+    const hasCustom = allNames.some(n => { const c = agentTypes.getAgentConfig(n); return c && !c.isDefault && c.enabled !== false; });
+    const hasDisabled = allNames.some(n => agentTypes.getAgentConfig(n)?.enabled === false);
     const legendParts: string[] = [];
     if (hasCustom) legendParts.push("• = project  ◦ = global");
     if (hasDisabled) legendParts.push("✕ = disabled");
@@ -1736,7 +1820,7 @@ Terse command-style prompts produce shallow, generic work.
       };
     });
 
-    if (selected && getAgentConfig(selected)) {
+    if (selected && agentTypes.getAgentConfig(selected)) {
       await showAgentDetail(ctx, selected);
       await showAllAgentsList(ctx);
     }
@@ -1750,7 +1834,7 @@ Terse command-style prompts produce shallow, generic work.
     }
 
     const options = agents.map(a => {
-      const dn = getDisplayName(a.type);
+      const dn = getDisplayName(agentTypes.registry(), a.type);
       const dur = formatDuration(a.startedAt, a.completedAt);
       return `${dn} (${a.description}) · ${a.toolUses} tools · ${a.status} · ${dur}`;
     });
@@ -1780,7 +1864,7 @@ Terse command-style prompts produce shallow, generic work.
 
     await ctx.ui.custom<undefined>(
       (tui, theme, keybindings, done) => {
-        return new ConversationViewer(tui, session, record, activity, theme, done, () => {
+        return new ConversationViewer(tui, session, record, agentTypes.registry(), activity, theme, done, () => {
           if (manager.abort(record.id)) {
             ctx.ui.notify(`Stopped "${record.description}".`, "info");
           }
@@ -1794,7 +1878,7 @@ Terse command-style prompts produce shallow, generic work.
   }
 
   async function showAgentDetail(ctx: ExtensionCommandContext, name: string) {
-    const cfg = getAgentConfig(name);
+    const cfg = agentTypes.getAgentConfig(name);
     if (!cfg) {
       ctx.ui.notify(`Agent config not found for "${name}".`, "warning");
       return;
@@ -2046,6 +2130,8 @@ Write the file using the write tool. Only write the file, nothing else.`;
     const { record } = await manager.spawnAndWait(pi, ctx, "general-purpose", generatePrompt, {
       description: `Generate ${name} agent`,
       maxTurns: 5,
+      registry: agentTypes.registry(),
+      buildRegistryFor,
     });
 
     if (record.status === "error") {
@@ -2154,7 +2240,7 @@ ${systemPrompt}
       schedulingEnabled: isSchedulingEnabled(),
       scopeModels: isScopeModelsEnabled(),
       strictAgentFiles,
-      disableDefaultAgents: isDefaultsDisabled(),
+      disableDefaultAgents: agentTypes.isDefaultsDisabled(),
       toolDescriptionMode: getToolDescriptionMode(),
       fleetView: isFleetViewEnabled(),
       widgetMode: getWidgetMode(),
@@ -2164,7 +2250,7 @@ ${systemPrompt}
       // whole snapshot, and materializing the implicit default would turn it into
       // explicit configuration — which then fails loudly if general-purpose later
       // goes away. undefined is dropped by JSON.stringify.
-      fallbackSubagent: getFallbackSubagent(),
+      fallbackSubagent: agentTypes.getFallbackSubagent(),
     };
   }
 
@@ -2181,8 +2267,8 @@ ${systemPrompt}
       // there would advertise strict dispatch for the most permissive state.
       // `values` still offers only resolvable targets, so the user cannot
       // persist a fallback that would hard-error on every dispatch.
-      const fallbackValue = getFallbackSubagent() ?? "general-purpose";
-      const fallbackValues = [...new Set([...getAvailableTypes(), NO_FALLBACK])];
+      const fallbackValue = agentTypes.getFallbackSubagent() ?? "general-purpose";
+      const fallbackValues = [...new Set([...agentTypes.getAvailableTypes(), NO_FALLBACK])];
 
       return [
         {
@@ -2245,7 +2331,7 @@ ${systemPrompt}
           id: "disableDefaultAgents",
           label: "Disable defaults",
           description: "Hide built-in agents (general-purpose, Explore, Plan) — custom agents are unaffected",
-          currentValue: isDefaultsDisabled() ? "on" : "off",
+          currentValue: agentTypes.isDefaultsDisabled() ? "on" : "off",
           values: ["on", "off"],
         },
         {
@@ -2347,7 +2433,7 @@ ${systemPrompt}
         setDisableDefaultAgents(enabled);
         notifyApplied(ctx, `Default agents ${enabled ? "disabled" : "enabled"}. Tool spec change takes effect on next pi session.`);
       } else if (id === "fallbackSubagent") {
-        setFallbackSubagent(value);
+        agentTypes.setFallbackSubagent(value);
         notifyApplied(
           ctx,
           value === NO_FALLBACK
@@ -2459,6 +2545,7 @@ ${systemPrompt}
       snapshotSettings(),
       successMsg,
       (event, payload) => pi.events.emit(event, payload),
+      sessionCwd,
     );
     ctx.ui.notify(message, level);
   }

--- a/src/index.ts
+++ b/src/index.ts
@@ -979,549 +979,549 @@ Terse command-style prompts produce shallow, generic work.
    * `registerTool` replaces by name; in the CLI this runs exactly once.
    */
   const registerAgentTool = () => {
-  pi.registerTool(defineTool({
-    name: SUBAGENT_TOOL_NAMES.AGENT,
-    label: "Agent",
-    description: agentToolDescription(),
-    promptSnippet: "Launch autonomous sub-agents for complex multi-step tasks",
-    promptGuidelines: [
-      "Use Agent with specialized agents when the task matches an agent type's description. Subagents are valuable for parallelizing independent queries or for protecting the main context window from excessive results, but should not be used excessively when not needed. Importantly, avoid duplicating work that subagents are already doing — if you delegate research to a subagent, do not also perform the same searches yourself.",
-      "For broad codebase exploration or research, spawn Agent with an appropriate subagent_type (e.g. Explore). Otherwise use direct tools (read, grep, find) when the target is already known.",
-      "When an agent runs in the background, you will be notified on completion — do not poll or sleep waiting for it. Continue with other work instead.",
-      "Trust but verify: an agent's summary describes intent, not outcome. When an agent writes or edits code, check the actual changes before reporting work as done.",
-    ],
-    parameters: Type.Object({
-      prompt: Type.String({
-        description: "The task for the agent to perform.",
+    pi.registerTool(defineTool({
+      name: SUBAGENT_TOOL_NAMES.AGENT,
+      label: "Agent",
+      description: agentToolDescription(),
+      promptSnippet: "Launch autonomous sub-agents for complex multi-step tasks",
+      promptGuidelines: [
+        "Use Agent with specialized agents when the task matches an agent type's description. Subagents are valuable for parallelizing independent queries or for protecting the main context window from excessive results, but should not be used excessively when not needed. Importantly, avoid duplicating work that subagents are already doing — if you delegate research to a subagent, do not also perform the same searches yourself.",
+        "For broad codebase exploration or research, spawn Agent with an appropriate subagent_type (e.g. Explore). Otherwise use direct tools (read, grep, find) when the target is already known.",
+        "When an agent runs in the background, you will be notified on completion — do not poll or sleep waiting for it. Continue with other work instead.",
+        "Trust but verify: an agent's summary describes intent, not outcome. When an agent writes or edits code, check the actual changes before reporting work as done.",
+      ],
+      parameters: Type.Object({
+        prompt: Type.String({
+          description: "The task for the agent to perform.",
+        }),
+        description: Type.String({
+          description: "A short (3-5 word) description of the task (shown in UI).",
+        }),
+        subagent_type: Type.String({
+          description: `The type of specialized agent to use. Available types: ${agentTypes.getAvailableTypes().join(", ")}. Custom agents from .pi/agents/*.md (project) or ${getAgentDir()}/agents/*.md (global) are also available.`,
+        }),
+        model: Type.Optional(
+          Type.String({
+            description:
+              'Optional model override. Accepts "provider/modelId" or fuzzy name (e.g. "haiku", "sonnet"). Omit to use the agent type\'s default.',
+          }),
+        ),
+        thinking: Type.Optional(
+          Type.String({
+            description: `Thinking level: ${THINKING_LEVELS.join(", ")}. Overrides agent default.`,
+          }),
+        ),
+        max_turns: Type.Optional(
+          Type.Number({
+            description: "Maximum number of agentic turns before stopping. Omit for unlimited (default).",
+            minimum: 1,
+          }),
+        ),
+        run_in_background: Type.Optional(
+          Type.Boolean({
+            description: "Set to true to run in background. Returns agent ID immediately. You will be notified on completion.",
+          }),
+        ),
+        resume: Type.Optional(
+          Type.String({
+            description: "Optional agent ID to resume from. Continues from previous context.",
+          }),
+        ),
+        isolated: Type.Optional(
+          Type.Boolean({
+            description: "If true, agent gets no extension/MCP tools — only built-in tools.",
+          }),
+        ),
+        inherit_context: Type.Optional(
+          Type.Boolean({
+            description: "If true, fork parent conversation into the agent. Default: false (fresh context).",
+          }),
+        ),
+        isolation: Type.Optional(
+          Type.Literal("worktree", {
+            description: 'Set to "worktree" to run the agent in a temporary git worktree (isolated copy of the repo). Changes are saved to a branch on completion.',
+          }),
+        ),
+        ...scheduleParam(),
       }),
-      description: Type.String({
-        description: "A short (3-5 word) description of the task (shown in UI).",
-      }),
-      subagent_type: Type.String({
-        description: `The type of specialized agent to use. Available types: ${agentTypes.getAvailableTypes().join(", ")}. Custom agents from .pi/agents/*.md (project) or ${getAgentDir()}/agents/*.md (global) are also available.`,
-      }),
-      model: Type.Optional(
-        Type.String({
-          description:
-            'Optional model override. Accepts "provider/modelId" or fuzzy name (e.g. "haiku", "sonnet"). Omit to use the agent type\'s default.',
-        }),
-      ),
-      thinking: Type.Optional(
-        Type.String({
-          description: `Thinking level: ${THINKING_LEVELS.join(", ")}. Overrides agent default.`,
-        }),
-      ),
-      max_turns: Type.Optional(
-        Type.Number({
-          description: "Maximum number of agentic turns before stopping. Omit for unlimited (default).",
-          minimum: 1,
-        }),
-      ),
-      run_in_background: Type.Optional(
-        Type.Boolean({
-          description: "Set to true to run in background. Returns agent ID immediately. You will be notified on completion.",
-        }),
-      ),
-      resume: Type.Optional(
-        Type.String({
-          description: "Optional agent ID to resume from. Continues from previous context.",
-        }),
-      ),
-      isolated: Type.Optional(
-        Type.Boolean({
-          description: "If true, agent gets no extension/MCP tools — only built-in tools.",
-        }),
-      ),
-      inherit_context: Type.Optional(
-        Type.Boolean({
-          description: "If true, fork parent conversation into the agent. Default: false (fresh context).",
-        }),
-      ),
-      isolation: Type.Optional(
-        Type.Literal("worktree", {
-          description: 'Set to "worktree" to run the agent in a temporary git worktree (isolated copy of the repo). Changes are saved to a branch on completion.',
-        }),
-      ),
-      ...scheduleParam(),
-    }),
 
-    // ---- Custom rendering: Claude Code style ----
+      // ---- Custom rendering: Claude Code style ----
 
-    renderCall(args, theme) {
-      const displayName = args.subagent_type ? getDisplayName(agentTypes.registry(), args.subagent_type) : "Agent";
-      const desc = args.description ?? "";
-      return new Text("▸ " + theme.fg("toolTitle", theme.bold(displayName)) + (desc ? "  " + theme.fg("muted", desc) : ""), 0, 0);
-    },
+      renderCall(args, theme) {
+        const displayName = args.subagent_type ? getDisplayName(agentTypes.registry(), args.subagent_type) : "Agent";
+        const desc = args.description ?? "";
+        return new Text("▸ " + theme.fg("toolTitle", theme.bold(displayName)) + (desc ? "  " + theme.fg("muted", desc) : ""), 0, 0);
+      },
 
-    renderResult(result, { expanded, isPartial }, theme, renderContext) {
-      const details = result.details as AgentDetails | undefined;
-      const text = result.content[0]?.type === "text" ? result.content[0].text : "";
-      // Pi reports pre-execution failures (extension block, abort, argument
-      // validation) as `{ content: [reason], details: {} }` with isError set —
-      // no status to render, so show the reason instead of inventing one (#199).
-      if (renderContext.isError || !details?.status) {
-        return new Text(text, 0, 0);
-      }
-
-      // Helper: build "haiku · thinking: high · ↻5≤30 · 3 tool uses · 33.8k tokens" stats string
-      const stats = (d: AgentDetails) => {
-        const parts: string[] = [];
-        if (d.modelName) parts.push(d.modelName);
-        if (d.tags) parts.push(...d.tags);
-        if (d.turnCount != null && d.turnCount > 0) {
-          parts.push(formatTurns(d.turnCount, d.maxTurns));
+      renderResult(result, { expanded, isPartial }, theme, renderContext) {
+        const details = result.details as AgentDetails | undefined;
+        const text = result.content[0]?.type === "text" ? result.content[0].text : "";
+        // Pi reports pre-execution failures (extension block, abort, argument
+        // validation) as `{ content: [reason], details: {} }` with isError set —
+        // no status to render, so show the reason instead of inventing one (#199).
+        if (renderContext.isError || !details?.status) {
+          return new Text(text, 0, 0);
         }
-        if (d.toolUses > 0) parts.push(`${d.toolUses} tool use${d.toolUses === 1 ? "" : "s"}`);
-        if (d.tokens) parts.push(d.tokens);
-        return parts.map(p => fgPreservingNestedStyles(theme, "dim", p)).join(" " + theme.fg("dim", "·") + " ");
-      };
 
-      // ---- While running (streaming) ----
-      if (isPartial || details.status === "running") {
-        const frame = SPINNER[details.spinnerFrame ?? 0];
-        const s = stats(details);
-        return renderRunningAgentStatus(frame, s, details.activity ?? "thinking…", theme);
-      }
-
-      // ---- Background agent launched ----
-      if (details.status === "background") {
-        return new Text(theme.fg("dim", `  ⎿  Running in background (ID: ${details.agentId})`), 0, 0);
-      }
-
-      // ---- Completed / Steered ----
-      if (details.status === "completed" || details.status === "steered") {
-        const duration = formatMs(details.durationMs);
-        const isSteered = details.status === "steered";
-        const icon = isSteered ? theme.fg("warning", "✓") : theme.fg("success", "✓");
-        const s = stats(details);
-        let line = icon + (s ? " " + s : "");
-        line += " " + theme.fg("dim", "·") + " " + theme.fg("dim", duration);
-
-        if (expanded) {
-          const resultText = result.content[0]?.type === "text" ? result.content[0].text : "";
-          if (resultText) {
-            const lines = resultText.split("\n").slice(0, 50);
-            for (const l of lines) {
-              line += "\n" + theme.fg("dim", `  ${l}`);
-            }
-            if (resultText.split("\n").length > 50) {
-              line += "\n" + theme.fg("muted", "  ... (use get_subagent_result with verbose for full output)");
-            }
+        // Helper: build "haiku · thinking: high · ↻5≤30 · 3 tool uses · 33.8k tokens" stats string
+        const stats = (d: AgentDetails) => {
+          const parts: string[] = [];
+          if (d.modelName) parts.push(d.modelName);
+          if (d.tags) parts.push(...d.tags);
+          if (d.turnCount != null && d.turnCount > 0) {
+            parts.push(formatTurns(d.turnCount, d.maxTurns));
           }
-        } else {
-          const doneText = isSteered ? "Wrapped up (turn limit)" : "Done";
-          line += "\n" + theme.fg("dim", `  ⎿  ${doneText}`);
-        }
-        return new Text(line, 0, 0);
-      }
+          if (d.toolUses > 0) parts.push(`${d.toolUses} tool use${d.toolUses === 1 ? "" : "s"}`);
+          if (d.tokens) parts.push(d.tokens);
+          return parts.map(p => fgPreservingNestedStyles(theme, "dim", p)).join(" " + theme.fg("dim", "·") + " ");
+        };
 
-      // ---- Stopped (user-initiated abort) ----
-      if (details.status === "stopped") {
+        // ---- While running (streaming) ----
+        if (isPartial || details.status === "running") {
+          const frame = SPINNER[details.spinnerFrame ?? 0];
+          const s = stats(details);
+          return renderRunningAgentStatus(frame, s, details.activity ?? "thinking…", theme);
+        }
+
+        // ---- Background agent launched ----
+        if (details.status === "background") {
+          return new Text(theme.fg("dim", `  ⎿  Running in background (ID: ${details.agentId})`), 0, 0);
+        }
+
+        // ---- Completed / Steered ----
+        if (details.status === "completed" || details.status === "steered") {
+          const duration = formatMs(details.durationMs);
+          const isSteered = details.status === "steered";
+          const icon = isSteered ? theme.fg("warning", "✓") : theme.fg("success", "✓");
+          const s = stats(details);
+          let line = icon + (s ? " " + s : "");
+          line += " " + theme.fg("dim", "·") + " " + theme.fg("dim", duration);
+
+          if (expanded) {
+            const resultText = result.content[0]?.type === "text" ? result.content[0].text : "";
+            if (resultText) {
+              const lines = resultText.split("\n").slice(0, 50);
+              for (const l of lines) {
+                line += "\n" + theme.fg("dim", `  ${l}`);
+              }
+              if (resultText.split("\n").length > 50) {
+                line += "\n" + theme.fg("muted", "  ... (use get_subagent_result with verbose for full output)");
+              }
+            }
+          } else {
+            const doneText = isSteered ? "Wrapped up (turn limit)" : "Done";
+            line += "\n" + theme.fg("dim", `  ⎿  ${doneText}`);
+          }
+          return new Text(line, 0, 0);
+        }
+
+        // ---- Stopped (user-initiated abort) ----
+        if (details.status === "stopped") {
+          const s = stats(details);
+          let line = theme.fg("dim", "■") + (s ? " " + s : "");
+          line += "\n" + theme.fg("dim", "  ⎿  Stopped");
+          return new Text(line, 0, 0);
+        }
+
+        // Anything left ("queued", or a status added later) has no rendering of
+        // its own — the turn-limit wording below must not be the catch-all.
+        if (details.status !== "error" && details.status !== "aborted") {
+          return new Text(text, 0, 0);
+        }
+
+        // ---- Error / Aborted (hard max_turns) ----
         const s = stats(details);
-        let line = theme.fg("dim", "■") + (s ? " " + s : "");
-        line += "\n" + theme.fg("dim", "  ⎿  Stopped");
-        return new Text(line, 0, 0);
-      }
+        let line = theme.fg("error", "✗") + (s ? " " + s : "");
 
-      // Anything left ("queued", or a status added later) has no rendering of
-      // its own — the turn-limit wording below must not be the catch-all.
-      if (details.status !== "error" && details.status !== "aborted") {
-        return new Text(text, 0, 0);
-      }
-
-      // ---- Error / Aborted (hard max_turns) ----
-      const s = stats(details);
-      let line = theme.fg("error", "✗") + (s ? " " + s : "");
-
-      if (details.status === "error") {
-        line += "\n" + theme.fg("error", `  ⎿  Error: ${details.error ?? "unknown"}`);
-      } else {
-        line += "\n" + theme.fg("warning", "  ⎿  Aborted (max turns exceeded)");
-      }
-
-      return new Text(line, 0, 0);
-    },
-
-    // ---- Execute ----
-
-    execute: async (toolCallId, params, signal, onUpdate, ctx) => {
-      // Ensure we have UI context for widget rendering
-      widget.setUICtx(ctx.ui as UICtx);
-
-      // Reload custom agents so new project/global .md files are picked up without restart
-      reloadCustomAgents();
-
-      const rawType = params.subagent_type as SubagentType;
-      // Single decision point for dispatch (#183): unknown, disabled and
-      // case-ambiguous types are refused here, BEFORE anything spawns, so a
-      // background or scheduled call can't start running the wrong agent while
-      // the caller is still unaware. `fallbackSubagent` decides whether an
-      // unresolvable type falls back or fails closed.
-      const dispatch = agentTypes.resolveSpawnType(rawType);
-      // `resume` replays a stored session and ignores `subagent_type` entirely,
-      // but the parameter is required by the schema — so gating it here would
-      // make a live agent unresumable the moment its type is deleted, disabled,
-      // or gains a case-clashing sibling. Only a real spawn is gated.
-      if (!dispatch.ok && !params.resume) return textResult(dispatch.message);
-      const subagentType = dispatch.ok ? dispatch.type : rawType;
-      // What the caller actually asked for, named once: `fellBackFrom` is "" for
-      // a blank request, so reading it inline invites the `??`-vs-`||` slip that
-      // once persisted an empty type into a scheduled job.
-      const requestedType = (dispatch.ok && dispatch.fellBackFrom) || subagentType;
-      // Computed at resolution rather than after the run, so the background and
-      // schedule branches carry it too — previously it existed only on the
-      // foreground path. Resume deliberately doesn't: it replays the stored
-      // session and ignores `subagent_type` entirely, so a note about type
-      // substitution would be describing something that didn't happen.
-      const fallbackNote = dispatch.ok && dispatch.fellBackFrom !== undefined
-        ? `Note: Unknown agent type "${dispatch.fellBackFrom}" — using ${agentTypes.resolveType(subagentType) ? subagentType : "the fallback agent config"}.\n\n`
-        : "";
-
-      const displayName = getDisplayName(agentTypes.registry(), subagentType);
-
-      // Get agent config (if any)
-      const customConfig = agentTypes.getAgentConfig(subagentType);
-
-      const resolvedConfig = resolveAgentInvocationConfig(customConfig, params);
-
-      // Resolve model from agent config first; tool-call params only fill gaps.
-      let model = ctx.model;
-      if (resolvedConfig.modelInput) {
-        const resolved = resolveModel(resolvedConfig.modelInput, ctx.modelRegistry);
-        if (typeof resolved === "string") {
-          if (resolvedConfig.modelFromParams) return textResult(resolved);
-          // config-specified: silent fallback to parent
+        if (details.status === "error") {
+          line += "\n" + theme.fg("error", `  ⎿  Error: ${details.error ?? "unknown"}`);
         } else {
-          model = resolved;
+          line += "\n" + theme.fg("warning", "  ⎿  Aborted (max turns exceeded)");
         }
-      }
 
-      // Scope validation: the effective resolved model is checked against the
-      // user's enabledModels list. Policy (hard error vs warn-and-proceed) lives
-      // in model-scope.ts so the nested delegation tools apply the same rule.
-      const scopeVerdict = checkModelScope({
-        model,
-        cwd: ctx.cwd,
-        modelRegistry: ctx.modelRegistry,
-        callerSupplied: resolvedConfig.modelFromParams,
-        agentLabel: customConfig?.displayName ?? subagentType,
-        modelInput: resolvedConfig.modelInput,
-      });
-      if (scopeVerdict.kind === "error") return textResult(scopeVerdict.message);
-      if (scopeVerdict.kind === "warn") ctx.ui.notify(scopeVerdict.message, "warning");
+        return new Text(line, 0, 0);
+      },
 
-      const thinking = resolvedConfig.thinking;
-      const inheritContext = resolvedConfig.inheritContext;
-      const runInBackground = resolvedConfig.runInBackground;
-      const isolated = resolvedConfig.isolated;
-      const isolation = resolvedConfig.isolation;
-      // Whether this spawn writes its .output transcript. Per-agent
-      // frontmatter (`output_transcript`) wins; otherwise the project/global
-      // default applies. `attachTranscript` below is the SOLE gate — every
-      // downstream consumer keys off record.outputFile being set, so no spawn
-      // path can re-enable the transcript by accident.
-      const outputTranscript = customConfig?.outputTranscript ?? getOutputTranscriptDefault();
-      const attachTranscript = (rec: AgentRecord | undefined, agentId: string): void => {
-        if (!rec || !outputTranscript) return;
-        rec.outputFile = createOutputFilePath(ctx.cwd, agentId, ctx.sessionManager.getSessionId());
-        writeInitialEntry(rec.outputFile, agentId, params.prompt, ctx.cwd);
-      };
+      // ---- Execute ----
 
-      const parentModelId = ctx.model?.id;
-      const effectiveModelId = model?.id;
-      const modelName = effectiveModelId && effectiveModelId !== parentModelId
-        ? (model?.name ?? effectiveModelId).replace(/^Claude\s+/i, "").toLowerCase()
-        : undefined;
-      const effectiveMaxTurns = normalizeMaxTurns(resolvedConfig.maxTurns ?? getDefaultMaxTurns());
-      const agentInvocation: AgentInvocation = {
-        modelName,
-        thinking,
-        // Explicit value only — the default fallback would just add noise.
-        // Normalize so `0` (unlimited) doesn't surface as a misleading "max turns: 0".
-        maxTurns: normalizeMaxTurns(resolvedConfig.maxTurns),
-        isolated,
-        inheritContext,
-        runInBackground,
-        isolation,
-      };
-      // Tool-result render shows the mode label too; viewer's header already does.
-      const modeLabel = getPromptModeLabel(agentTypes.registry(), subagentType);
-      const { tags: invocationTags } = buildInvocationTags(agentInvocation);
-      const agentTags = modeLabel ? [modeLabel, ...invocationTags] : invocationTags;
-      const detailBase = {
-        displayName,
-        description: params.description,
-        subagentType,
-        modelName,
-        tags: agentTags.length > 0 ? agentTags : undefined,
-      };
+      execute: async (toolCallId, params, signal, onUpdate, ctx) => {
+        // Ensure we have UI context for widget rendering
+        widget.setUICtx(ctx.ui as UICtx);
 
-      // ---- Schedule: register a job, don't spawn now ----
-      if (params.schedule) {
-        if (!isSchedulingEnabled()) {
-          return textResult("Scheduling is disabled in this project. Enable via /agents → Settings → Scheduling.");
+        // Reload custom agents so new project/global .md files are picked up without restart
+        reloadCustomAgents();
+
+        const rawType = params.subagent_type as SubagentType;
+        // Single decision point for dispatch (#183): unknown, disabled and
+        // case-ambiguous types are refused here, BEFORE anything spawns, so a
+        // background or scheduled call can't start running the wrong agent while
+        // the caller is still unaware. `fallbackSubagent` decides whether an
+        // unresolvable type falls back or fails closed.
+        const dispatch = agentTypes.resolveSpawnType(rawType);
+        // `resume` replays a stored session and ignores `subagent_type` entirely,
+        // but the parameter is required by the schema — so gating it here would
+        // make a live agent unresumable the moment its type is deleted, disabled,
+        // or gains a case-clashing sibling. Only a real spawn is gated.
+        if (!dispatch.ok && !params.resume) return textResult(dispatch.message);
+        const subagentType = dispatch.ok ? dispatch.type : rawType;
+        // What the caller actually asked for, named once: `fellBackFrom` is "" for
+        // a blank request, so reading it inline invites the `??`-vs-`||` slip that
+        // once persisted an empty type into a scheduled job.
+        const requestedType = (dispatch.ok && dispatch.fellBackFrom) || subagentType;
+        // Computed at resolution rather than after the run, so the background and
+        // schedule branches carry it too — previously it existed only on the
+        // foreground path. Resume deliberately doesn't: it replays the stored
+        // session and ignores `subagent_type` entirely, so a note about type
+        // substitution would be describing something that didn't happen.
+        const fallbackNote = dispatch.ok && dispatch.fellBackFrom !== undefined
+          ? `Note: Unknown agent type "${dispatch.fellBackFrom}" — using ${agentTypes.resolveType(subagentType) ? subagentType : "the fallback agent config"}.\n\n`
+          : "";
+
+        const displayName = getDisplayName(agentTypes.registry(), subagentType);
+
+        // Get agent config (if any)
+        const customConfig = agentTypes.getAgentConfig(subagentType);
+
+        const resolvedConfig = resolveAgentInvocationConfig(customConfig, params);
+
+        // Resolve model from agent config first; tool-call params only fill gaps.
+        let model = ctx.model;
+        if (resolvedConfig.modelInput) {
+          const resolved = resolveModel(resolvedConfig.modelInput, ctx.modelRegistry);
+          if (typeof resolved === "string") {
+            if (resolvedConfig.modelFromParams) return textResult(resolved);
+            // config-specified: silent fallback to parent
+          } else {
+            model = resolved;
+          }
         }
+
+        // Scope validation: the effective resolved model is checked against the
+        // user's enabledModels list. Policy (hard error vs warn-and-proceed) lives
+        // in model-scope.ts so the nested delegation tools apply the same rule.
+        const scopeVerdict = checkModelScope({
+          model,
+          cwd: ctx.cwd,
+          modelRegistry: ctx.modelRegistry,
+          callerSupplied: resolvedConfig.modelFromParams,
+          agentLabel: customConfig?.displayName ?? subagentType,
+          modelInput: resolvedConfig.modelInput,
+        });
+        if (scopeVerdict.kind === "error") return textResult(scopeVerdict.message);
+        if (scopeVerdict.kind === "warn") ctx.ui.notify(scopeVerdict.message, "warning");
+
+        const thinking = resolvedConfig.thinking;
+        const inheritContext = resolvedConfig.inheritContext;
+        const runInBackground = resolvedConfig.runInBackground;
+        const isolated = resolvedConfig.isolated;
+        const isolation = resolvedConfig.isolation;
+        // Whether this spawn writes its .output transcript. Per-agent
+        // frontmatter (`output_transcript`) wins; otherwise the project/global
+        // default applies. `attachTranscript` below is the SOLE gate — every
+        // downstream consumer keys off record.outputFile being set, so no spawn
+        // path can re-enable the transcript by accident.
+        const outputTranscript = customConfig?.outputTranscript ?? getOutputTranscriptDefault();
+        const attachTranscript = (rec: AgentRecord | undefined, agentId: string): void => {
+          if (!rec || !outputTranscript) return;
+          rec.outputFile = createOutputFilePath(ctx.cwd, agentId, ctx.sessionManager.getSessionId());
+          writeInitialEntry(rec.outputFile, agentId, params.prompt, ctx.cwd);
+        };
+
+        const parentModelId = ctx.model?.id;
+        const effectiveModelId = model?.id;
+        const modelName = effectiveModelId && effectiveModelId !== parentModelId
+          ? (model?.name ?? effectiveModelId).replace(/^Claude\s+/i, "").toLowerCase()
+          : undefined;
+        const effectiveMaxTurns = normalizeMaxTurns(resolvedConfig.maxTurns ?? getDefaultMaxTurns());
+        const agentInvocation: AgentInvocation = {
+          modelName,
+          thinking,
+          // Explicit value only — the default fallback would just add noise.
+          // Normalize so `0` (unlimited) doesn't surface as a misleading "max turns: 0".
+          maxTurns: normalizeMaxTurns(resolvedConfig.maxTurns),
+          isolated,
+          inheritContext,
+          runInBackground,
+          isolation,
+        };
+        // Tool-result render shows the mode label too; viewer's header already does.
+        const modeLabel = getPromptModeLabel(agentTypes.registry(), subagentType);
+        const { tags: invocationTags } = buildInvocationTags(agentInvocation);
+        const agentTags = modeLabel ? [modeLabel, ...invocationTags] : invocationTags;
+        const detailBase = {
+          displayName,
+          description: params.description,
+          subagentType,
+          modelName,
+          tags: agentTags.length > 0 ? agentTags : undefined,
+        };
+
+        // ---- Schedule: register a job, don't spawn now ----
+        if (params.schedule) {
+          if (!isSchedulingEnabled()) {
+            return textResult("Scheduling is disabled in this project. Enable via /agents → Settings → Scheduling.");
+          }
+          if (params.resume) {
+            return textResult("Cannot combine `schedule` with `resume` — schedules create fresh agents.");
+          }
+          if (params.inherit_context) {
+            return textResult("Cannot combine `schedule` with `inherit_context` — there is no parent conversation at fire time.");
+          }
+          if (params.run_in_background === false) {
+            return textResult("Cannot combine `schedule` with `run_in_background: false` — scheduled jobs always run in background.");
+          }
+          if (!scheduler.isActive()) {
+            return textResult("Scheduler is not active in this session yet. Try again after the session has fully started.");
+          }
+          try {
+            const job = scheduler.addJob({
+              name: params.description as string,
+              description: params.description as string,
+              schedule: params.schedule as string,
+              // The caller's own name, not the substitute — the scheduler re-resolves
+              // at fire time, and the original is what a user edits.
+              subagent_type: requestedType,
+              prompt: params.prompt as string,
+              model: params.model as string | undefined,
+              thinking: thinking,
+              max_turns: effectiveMaxTurns,
+              isolated: isolated,
+              isolation: isolation,
+            });
+            const next = scheduler.getNextRun(job.id);
+            return textResult(
+              `${fallbackNote}Scheduled "${job.name}" (id: ${job.id}, type: ${job.scheduleType}). ` +
+              `Next run: ${next ?? "(unknown)"}. ` +
+              `Manage via /agents → Scheduled jobs.`,
+            );
+          } catch (err) {
+            return textResult(err instanceof Error ? err.message : String(err));
+          }
+        }
+
+        // Resume existing agent
         if (params.resume) {
-          return textResult("Cannot combine `schedule` with `resume` — schedules create fresh agents.");
-        }
-        if (params.inherit_context) {
-          return textResult("Cannot combine `schedule` with `inherit_context` — there is no parent conversation at fire time.");
-        }
-        if (params.run_in_background === false) {
-          return textResult("Cannot combine `schedule` with `run_in_background: false` — scheduled jobs always run in background.");
-        }
-        if (!scheduler.isActive()) {
-          return textResult("Scheduler is not active in this session yet. Try again after the session has fully started.");
-        }
-        try {
-          const job = scheduler.addJob({
-            name: params.description as string,
-            description: params.description as string,
-            schedule: params.schedule as string,
-            // The caller's own name, not the substitute — the scheduler re-resolves
-            // at fire time, and the original is what a user edits.
-            subagent_type: requestedType,
-            prompt: params.prompt as string,
-            model: params.model as string | undefined,
-            thinking: thinking,
-            max_turns: effectiveMaxTurns,
-            isolated: isolated,
-            isolation: isolation,
-          });
-          const next = scheduler.getNextRun(job.id);
+          const existing = manager.getRecord(params.resume);
+          if (!existing || existing.parentAgentId) {
+            return textResult(`Agent not found: "${params.resume}". It may have been cleaned up.`);
+          }
+          if (!existing.session) {
+            return textResult(`Agent "${params.resume}" has no active session to resume.`);
+          }
+          const record = await manager.resume(params.resume, params.prompt, signal);
+          if (!record) {
+            return textResult(`Failed to resume agent "${params.resume}".`);
+          }
+          // A failed resume surfaces the error, plus any partial output THIS
+          // resume produced (never the previous turn's answer, #144).
+          if (record.status === "error") {
+            return textResult(`Agent failed: ${record.error}${partialOutputSuffix(record)}`, buildDetails(detailBase, record));
+          }
           return textResult(
-            `${fallbackNote}Scheduled "${job.name}" (id: ${job.id}, type: ${job.scheduleType}). ` +
-            `Next run: ${next ?? "(unknown)"}. ` +
-            `Manage via /agents → Scheduled jobs.`,
+            record.result?.trim() || "No output.",
+            buildDetails(detailBase, record),
           );
-        } catch (err) {
-          return textResult(err instanceof Error ? err.message : String(err));
         }
-      }
 
-      // Resume existing agent
-      if (params.resume) {
-        const existing = manager.getRecord(params.resume);
-        if (!existing || existing.parentAgentId) {
-          return textResult(`Agent not found: "${params.resume}". It may have been cleaned up.`);
-        }
-        if (!existing.session) {
-          return textResult(`Agent "${params.resume}" has no active session to resume.`);
-        }
-        const record = await manager.resume(params.resume, params.prompt, signal);
-        if (!record) {
-          return textResult(`Failed to resume agent "${params.resume}".`);
-        }
-        // A failed resume surfaces the error, plus any partial output THIS
-        // resume produced (never the previous turn's answer, #144).
-        if (record.status === "error") {
-          return textResult(`Agent failed: ${record.error}${partialOutputSuffix(record)}`, buildDetails(detailBase, record));
-        }
-        return textResult(
-          record.result?.trim() || "No output.",
-          buildDetails(detailBase, record),
-        );
-      }
+        // Background execution
+        if (runInBackground) {
+          const { state: bgState, callbacks: bgCallbacks } = createActivityTracker(effectiveMaxTurns);
 
-      // Background execution
-      if (runInBackground) {
-        const { state: bgState, callbacks: bgCallbacks } = createActivityTracker(effectiveMaxTurns);
+          // Wrap onSessionCreated to wire output file streaming.
+          // The callback lazily reads record.outputFile (set right after spawn)
+          // rather than closing over a value that doesn't exist yet.
+          let id: string;
+          const origBgOnSession = bgCallbacks.onSessionCreated;
+          bgCallbacks.onSessionCreated = (session: any) => {
+            origBgOnSession(session);
+            const rec = manager.getRecord(id);
+            if (rec?.outputFile) {
+              rec.outputCleanup = streamToOutputFile(session, rec.outputFile, id, ctx.cwd);
+            }
+          };
 
-        // Wrap onSessionCreated to wire output file streaming.
-        // The callback lazily reads record.outputFile (set right after spawn)
-        // rather than closing over a value that doesn't exist yet.
-        let id: string;
-        const origBgOnSession = bgCallbacks.onSessionCreated;
-        bgCallbacks.onSessionCreated = (session: any) => {
-          origBgOnSession(session);
-          const rec = manager.getRecord(id);
-          if (rec?.outputFile) {
-            rec.outputCleanup = streamToOutputFile(session, rec.outputFile, id, ctx.cwd);
+          // A throw here means the agent never started. Let it out: pi marks a
+          // tool call failed only when execute throws, and a returned message
+          // reads to the model as a subagent that ran and reported this (#179).
+          id = manager.spawn(pi, ctx, subagentType, params.prompt, {
+            description: params.description,
+            registry: agentTypes.registry(),
+            buildRegistryFor,
+            model,
+            maxTurns: effectiveMaxTurns,
+            isolated,
+            inheritContext,
+            thinkingLevel: thinking,
+            isBackground: true,
+            isolation,
+            invocation: agentInvocation,
+            rootSessionId: ctx.sessionManager.getSessionId(),
+            ...bgCallbacks,
+          });
+
+          // Set output file + join mode synchronously after spawn, before the
+          // event loop yields — onSessionCreated is async so this is safe.
+          const joinMode = resolveJoinMode(defaultJoinMode, true);
+          const record = manager.getRecord(id);
+          if (record && joinMode) {
+            record.joinMode = joinMode;
+            record.toolCallId = toolCallId;
+            attachTranscript(record, id);
+          }
+
+          if (joinMode == null || joinMode === 'async') {
+            // Foreground/no join mode or explicit async — not part of any batch
+          } else {
+            // smart or group — add to current batch
+            currentBatchAgents.push({ id, joinMode });
+            // Debounce: reset timer on each new agent so parallel tool calls
+            // dispatched across multiple event loop ticks are captured together
+            if (batchFinalizeTimer) clearTimeout(batchFinalizeTimer);
+            batchFinalizeTimer = setTimeout(finalizeBatch, 100);
+          }
+
+          agentActivity.set(id, bgState);
+          widget.ensureTimer();
+          widget.update();
+          fleet.ensureTimer();
+          fleet.update();
+
+          // Emit created event
+          pi.events.emit("subagents:created", {
+            id,
+            type: subagentType,
+            description: params.description,
+            isBackground: true,
+          });
+
+          const isQueued = record?.status === "queued";
+          return textResult(
+            `${fallbackNote}Agent ${isQueued ? "queued" : "started"} in background.\n` +
+            `Agent ID: ${id}\n` +
+            `Type: ${displayName}\n` +
+            `Description: ${params.description}\n` +
+            (record?.outputFile ? `Output file: ${record.outputFile}\n` : "") +
+            (isQueued ? `Position: queued (max ${manager.getMaxConcurrent()} concurrent)\n` : "") +
+            `\nYou will be notified when this agent completes.\n` +
+            `Use get_subagent_result to retrieve full results, or steer_subagent to send it messages.\n` +
+            `Do not duplicate this agent's work.`,
+            { ...detailBase, toolUses: 0, tokens: "", durationMs: 0, status: "background" as const, agentId: id },
+          );
+        }
+
+        // Foreground (synchronous) execution — stream progress via onUpdate
+        let spinnerFrame = 0;
+        const startedAt = Date.now();
+        let fgId: string | undefined;
+
+        const streamUpdate = () => {
+          const details: AgentDetails = {
+            ...detailBase,
+            toolUses: fgState.toolUses,
+            tokens: formatLifetimeTokens(fgState),
+            turnCount: fgState.turnCount,
+            maxTurns: fgState.maxTurns,
+            durationMs: Date.now() - startedAt,
+            status: "running",
+            activity: describeActivity(fgState.activeTools, fgState.responseText),
+            spinnerFrame: spinnerFrame % SPINNER.length,
+          };
+          onUpdate?.({
+            content: [{ type: "text", text: `${fgState.toolUses} tool uses...` }],
+            details: details as any,
+          });
+        };
+
+        const { state: fgState, callbacks: fgCallbacks } = createActivityTracker(effectiveMaxTurns, streamUpdate);
+
+        // Wire session creation: register in widget + stream to output file.
+        // The output file path is set synchronously after spawn (below),
+        // before onSessionCreated fires — same pattern as background agents.
+        const origOnSession = fgCallbacks.onSessionCreated;
+        fgCallbacks.onSessionCreated = (session: any) => {
+          origOnSession(session);
+          for (const a of manager.listAgents()) {
+            if (a.session === session) {
+              fgId = a.id;
+              agentActivity.set(a.id, fgState);
+              widget.ensureTimer();
+              fleet.ensureTimer();
+              fleet.update();
+              break;
+            }
+          }
+          // Stream conversation to output file (foreground agent logging)
+          if (fgId) {
+            const rec = manager.getRecord(fgId);
+            if (rec?.outputFile) {
+              rec.outputCleanup = streamToOutputFile(session, rec.outputFile, fgId, ctx.cwd);
+            }
           }
         };
 
-        // A throw here means the agent never started. Let it out: pi marks a
-        // tool call failed only when execute throws, and a returned message
-        // reads to the model as a subagent that ran and reported this (#179).
-        id = manager.spawn(pi, ctx, subagentType, params.prompt, {
-          description: params.description,
-          registry: agentTypes.registry(),
-          buildRegistryFor,
-          model,
-          maxTurns: effectiveMaxTurns,
-          isolated,
-          inheritContext,
-          thinkingLevel: thinking,
-          isBackground: true,
-          isolation,
-          invocation: agentInvocation,
-          rootSessionId: ctx.sessionManager.getSessionId(),
-          ...bgCallbacks,
-        });
+        // Animate spinner at ~80ms (smooth rotation through 10 braille frames)
+        const spinnerInterval = setInterval(() => {
+          spinnerFrame++;
+          streamUpdate();
+        }, 80);
 
-        // Set output file + join mode synchronously after spawn, before the
-        // event loop yields — onSessionCreated is async so this is safe.
-        const joinMode = resolveJoinMode(defaultJoinMode, true);
-        const record = manager.getRecord(id);
-        if (record && joinMode) {
-          record.joinMode = joinMode;
-          record.toolCallId = toolCallId;
-          attachTranscript(record, id);
-        }
-
-        if (joinMode == null || joinMode === 'async') {
-          // Foreground/no join mode or explicit async — not part of any batch
-        } else {
-          // smart or group — add to current batch
-          currentBatchAgents.push({ id, joinMode });
-          // Debounce: reset timer on each new agent so parallel tool calls
-          // dispatched across multiple event loop ticks are captured together
-          if (batchFinalizeTimer) clearTimeout(batchFinalizeTimer);
-          batchFinalizeTimer = setTimeout(finalizeBatch, 100);
-        }
-
-        agentActivity.set(id, bgState);
-        widget.ensureTimer();
-        widget.update();
-        fleet.ensureTimer();
-        fleet.update();
-
-        // Emit created event
-        pi.events.emit("subagents:created", {
-          id,
-          type: subagentType,
-          description: params.description,
-          isBackground: true,
-        });
-
-        const isQueued = record?.status === "queued";
-        return textResult(
-          `${fallbackNote}Agent ${isQueued ? "queued" : "started"} in background.\n` +
-          `Agent ID: ${id}\n` +
-          `Type: ${displayName}\n` +
-          `Description: ${params.description}\n` +
-          (record?.outputFile ? `Output file: ${record.outputFile}\n` : "") +
-          (isQueued ? `Position: queued (max ${manager.getMaxConcurrent()} concurrent)\n` : "") +
-          `\nYou will be notified when this agent completes.\n` +
-          `Use get_subagent_result to retrieve full results, or steer_subagent to send it messages.\n` +
-          `Do not duplicate this agent's work.`,
-          { ...detailBase, toolUses: 0, tokens: "", durationMs: 0, status: "background" as const, agentId: id },
-        );
-      }
-
-      // Foreground (synchronous) execution — stream progress via onUpdate
-      let spinnerFrame = 0;
-      const startedAt = Date.now();
-      let fgId: string | undefined;
-
-      const streamUpdate = () => {
-        const details: AgentDetails = {
-          ...detailBase,
-          toolUses: fgState.toolUses,
-          tokens: formatLifetimeTokens(fgState),
-          turnCount: fgState.turnCount,
-          maxTurns: fgState.maxTurns,
-          durationMs: Date.now() - startedAt,
-          status: "running",
-          activity: describeActivity(fgState.activeTools, fgState.responseText),
-          spinnerFrame: spinnerFrame % SPINNER.length,
-        };
-        onUpdate?.({
-          content: [{ type: "text", text: `${fgState.toolUses} tool uses...` }],
-          details: details as any,
-        });
-      };
-
-      const { state: fgState, callbacks: fgCallbacks } = createActivityTracker(effectiveMaxTurns, streamUpdate);
-
-      // Wire session creation: register in widget + stream to output file.
-      // The output file path is set synchronously after spawn (below),
-      // before onSessionCreated fires — same pattern as background agents.
-      const origOnSession = fgCallbacks.onSessionCreated;
-      fgCallbacks.onSessionCreated = (session: any) => {
-        origOnSession(session);
-        for (const a of manager.listAgents()) {
-          if (a.session === session) {
-            fgId = a.id;
-            agentActivity.set(a.id, fgState);
-            widget.ensureTimer();
-            fleet.ensureTimer();
-            fleet.update();
-            break;
-          }
-        }
-        // Stream conversation to output file (foreground agent logging)
-        if (fgId) {
-          const rec = manager.getRecord(fgId);
-          if (rec?.outputFile) {
-            rec.outputCleanup = streamToOutputFile(session, rec.outputFile, fgId, ctx.cwd);
-          }
-        }
-      };
-
-      // Animate spinner at ~80ms (smooth rotation through 10 braille frames)
-      const spinnerInterval = setInterval(() => {
-        spinnerFrame++;
         streamUpdate();
-      }, 80);
 
-      streamUpdate();
-
-      let record: AgentRecord;
-      try {
-        const fgResult = await manager.spawnAndWait(pi, ctx, subagentType, params.prompt, {
-          description: params.description,
-          registry: agentTypes.registry(),
-          buildRegistryFor,
-          model,
-          maxTurns: effectiveMaxTurns,
-          isolated,
-          inheritContext,
-          thinkingLevel: thinking,
-          isolation,
-          invocation: agentInvocation,
-          signal,
-          rootSessionId: ctx.sessionManager.getSessionId(),
-          ...fgCallbacks,
-        }, (fgAgentId) => {
-          // onSpawned: called synchronously after spawn, before onSessionCreated fires.
-          // Set up the output file so streamToOutputFile can pick it up.
-          const fgRec = manager.getRecord(fgAgentId);
-          attachTranscript(fgRec, fgAgentId);
-        });
-        record = fgResult.record;
-      } finally {
-        // Runs on both paths, so a startup throw — which now propagates, see
-        // the background spawn above (#179) — no longer leaves the spinner
-        // ticking or a finished agent on the widget.
-        clearInterval(spinnerInterval);
-        if (fgId) {
-          agentActivity.delete(fgId);
-          widget.markFinished(fgId);
-          fleet.onAgentFinished(fgId);
+        let record: AgentRecord;
+        try {
+          const fgResult = await manager.spawnAndWait(pi, ctx, subagentType, params.prompt, {
+            description: params.description,
+            registry: agentTypes.registry(),
+            buildRegistryFor,
+            model,
+            maxTurns: effectiveMaxTurns,
+            isolated,
+            inheritContext,
+            thinkingLevel: thinking,
+            isolation,
+            invocation: agentInvocation,
+            signal,
+            rootSessionId: ctx.sessionManager.getSessionId(),
+            ...fgCallbacks,
+          }, (fgAgentId) => {
+            // onSpawned: called synchronously after spawn, before onSessionCreated fires.
+            // Set up the output file so streamToOutputFile can pick it up.
+            const fgRec = manager.getRecord(fgAgentId);
+            attachTranscript(fgRec, fgAgentId);
+          });
+          record = fgResult.record;
+        } finally {
+          // Runs on both paths, so a startup throw — which now propagates, see
+          // the background spawn above (#179) — no longer leaves the spinner
+          // ticking or a finished agent on the widget.
+          clearInterval(spinnerInterval);
+          if (fgId) {
+            agentActivity.delete(fgId);
+            widget.markFinished(fgId);
+            fleet.onAgentFinished(fgId);
+          }
         }
-      }
 
-      // Get final token count
-      const tokenText = formatLifetimeTokens(fgState);
+        // Get final token count
+        const tokenText = formatLifetimeTokens(fgState);
 
-      const details = buildDetails(detailBase, record, fgState, { tokens: tokenText });
+        const details = buildDetails(detailBase, record, fgState, { tokens: tokenText });
 
-      if (record.status === "error") {
-        // Error headline + any partial output the run produced before failing.
-        return textResult(`${fallbackNote}Agent failed: ${record.error}${partialOutputSuffix(record)}`, details);
-      }
+        if (record.status === "error") {
+          // Error headline + any partial output the run produced before failing.
+          return textResult(`${fallbackNote}Agent failed: ${record.error}${partialOutputSuffix(record)}`, details);
+        }
 
-      const durationMs = (record.completedAt ?? Date.now()) - record.startedAt;
-      const statsParts = [`${record.toolUses} tool uses`];
-      if (tokenText) statsParts.push(tokenText);
-      return textResult(
-        `${fallbackNote}Agent completed in ${formatMs(durationMs)} (${statsParts.join(", ")})${getForegroundOutcomeNote(record.status)}.\n\n` +
-        (record.result?.trim() || "No output."),
-        details,
-      );
-    },
-  }));
+        const durationMs = (record.completedAt ?? Date.now()) - record.startedAt;
+        const statsParts = [`${record.toolUses} tool uses`];
+        if (tokenText) statsParts.push(tokenText);
+        return textResult(
+          `${fallbackNote}Agent completed in ${formatMs(durationMs)} (${statsParts.join(", ")})${getForegroundOutcomeNote(record.status)}.\n\n` +
+          (record.result?.trim() || "No output."),
+          details,
+        );
+      },
+    }));
   };
   registerAgentTool();
 

--- a/src/nested-tools.ts
+++ b/src/nested-tools.ts
@@ -9,13 +9,11 @@ import {
 import { Type } from "@sinclair/typebox";
 import { abortable } from "./abortable.js";
 import {
-  buildAgentRegistry,
   getAgentConfigIn,
   getAvailableTypesIn,
   resolveEnabledTypeIn,
   resolveTypeIn,
 } from "./agent-types.js";
-import { loadCustomAgents } from "./custom-agents.js";
 import { resolveAgentInvocationConfig } from "./invocation-config.js";
 import { resolveModel } from "./model-resolver.js";
 import { checkModelScope } from "./model-scope.js";
@@ -66,6 +64,10 @@ interface NestedSpawnOptions {
   maxSubagentDepth: number;
   configCwd?: string;
   rootSessionId?: string;
+  /** Registry the spawned agent's config resolves from (this branch's root). */
+  registry: Map<string, AgentConfig>;
+  /** Registry builder threaded to this child's own nested delegation. */
+  buildRegistryFor?: (configCwd: string) => Map<string, AgentConfig>;
 }
 
 export interface NestedAgentManager {
@@ -99,6 +101,12 @@ export interface NestedToolContext {
   allowedSubagents: "all" | string[];
   /** Root used for agent/config discovery; may differ from the agent's working directory. */
   configCwd: string;
+  /**
+   * Build a registry for a config root, applying the owning session's registry
+   * settings (`disableDefaultAgents`). Provided by the session (index.ts) and
+   * threaded down every nesting level.
+   */
+  buildRegistryFor: (configCwd: string) => Map<string, AgentConfig>;
 }
 
 function textResult(text: string, isError = false) {
@@ -142,9 +150,9 @@ function formatRecord(record: AgentRecord, position: ResultPosition): string {
 /** Build child-safe orchestration tools scoped to one parent agent instance. */
 export function createNestedSubagentTools(context: NestedToolContext): ToolDefinition[] {
   // Agents resolve from a registry built for THIS branch's config root (under
-  // worktree isolation, the copy). Never via registerAgents — that is
-  // process-global state shared with the main session and every other agent.
-  const loadRegistry = () => buildAgentRegistry(loadCustomAgents(context.configCwd));
+  // worktree isolation, the copy) — never from the owning session's registry,
+  // which is shared with the main conversation and every other agent.
+  const loadRegistry = () => context.buildRegistryFor(context.configCwd);
   const allowedTypesIn = (registry: Map<string, AgentConfig>): Set<string> | undefined =>
     context.allowedSubagents === "all"
       ? undefined
@@ -281,6 +289,10 @@ export function createNestedSubagentTools(context: NestedToolContext): ToolDefin
         maxSubagentDepth: context.maxSubagentDepth,
         configCwd: context.configCwd,
         rootSessionId,
+        // The child's config resolves from this branch's own root registry —
+        // the same one the allowlist and dispatch above resolved against.
+        registry,
+        buildRegistryFor: context.buildRegistryFor,
       };
 
       // Transcript wiring, same gate as the top-level path: the child's

--- a/src/schedule.ts
+++ b/src/schedule.ts
@@ -19,10 +19,10 @@ import type { ExtensionAPI, ExtensionContext } from "@earendil-works/pi-coding-a
 import { Cron } from "croner";
 import { nanoid } from "nanoid";
 import type { AgentManager } from "./agent-manager.js";
-import { resolveSpawnType } from "./agent-types.js";
+import type { AgentTypeState } from "./agent-types.js";
 import { resolveModel } from "./model-resolver.js";
 import type { ScheduleStore } from "./schedule-store.js";
-import type { IsolationMode, ScheduledSubagent, SubagentType, ThinkingLevel } from "./types.js";
+import type { AgentConfig, IsolationMode, ScheduledSubagent, SubagentType, ThinkingLevel } from "./types.js";
 
 /** Event emitted on `pi.events` for cross-extension consumers. */
 export type ScheduleChangeEvent =
@@ -53,13 +53,24 @@ export class SubagentScheduler {
   private pi: ExtensionAPI | undefined;
   private ctx: ExtensionContext | undefined;
   private manager: AgentManager | undefined;
+  private agentTypes: AgentTypeState | undefined;
+  private buildRegistryFor: ((root: string) => Map<string, AgentConfig>) | undefined;
 
   /** Start the scheduler: bind to a session's store and arm enabled jobs. */
-  start(pi: ExtensionAPI, ctx: ExtensionContext, manager: AgentManager, store: ScheduleStore): void {
+  start(
+    pi: ExtensionAPI,
+    ctx: ExtensionContext,
+    manager: AgentManager,
+    store: ScheduleStore,
+    agentTypes: AgentTypeState,
+    buildRegistryFor: (root: string) => Map<string, AgentConfig>,
+  ): void {
     this.pi = pi;
     this.ctx = ctx;
     this.manager = manager;
     this.store = store;
+    this.agentTypes = agentTypes;
+    this.buildRegistryFor = buildRegistryFor;
 
     for (const job of store.list()) {
       if (job.enabled) this.scheduleJob(job);
@@ -76,6 +87,8 @@ export class SubagentScheduler {
     this.pi = undefined;
     this.ctx = undefined;
     this.manager = undefined;
+    this.agentTypes = undefined;
+    this.buildRegistryFor = undefined;
   }
 
   /** True if start() has bound a store and the scheduler is active. */
@@ -222,7 +235,8 @@ export class SubagentScheduler {
     const pi = this.pi;
     const ctx = this.ctx;
     const manager = this.manager;
-    if (!store || !pi || !ctx || !manager) return;
+    const agentTypes = this.agentTypes;
+    if (!store || !pi || !ctx || !manager || !agentTypes) return;
     const job = store.get(id);
     if (!job?.enabled) return;
 
@@ -239,18 +253,20 @@ export class SubagentScheduler {
 
     let agentId: string;
     try {
-      // Re-resolve at fire time against the registry as it stands. This does not
-      // reload from disk (the scheduler has no reason to rebuild process-global
-      // state from a timer), so it catches changes that went through /agents or
+      // Re-resolve at fire time against the session's registry as it stands.
+      // This does not reload from disk (the scheduler has no reason to rebuild
+      // the registry from a timer), so it catches changes that went through /agents or
       // an Agent call — not a file deleted directly from a shell. The catch below turns
       // this into lastStatus: "error" plus an error event, like any other
       // fire-time failure.
-      const dispatch = resolveSpawnType(job.subagent_type);
+      const dispatch = agentTypes.resolveSpawnType(job.subagent_type);
       if (!dispatch.ok) throw new Error(dispatch.message);
       agentId = manager.spawn(pi, ctx, dispatch.type, job.prompt, {
         description: job.description,
         isBackground: true,
         bypassQueue: true,
+        registry: agentTypes.registry(),
+        buildRegistryFor: this.buildRegistryFor,
         model: resolvedModel,
         maxTurns: job.max_turns,
         isolated: job.isolated,

--- a/src/settings.ts
+++ b/src/settings.ts
@@ -263,8 +263,14 @@ function readSettingsFile(path: string): SubagentsSettings {
   }
 }
 
-/** Load merged settings: global provides defaults, project overrides. */
-export function loadSettings(cwd: string = process.cwd()): SubagentsSettings {
+/**
+ * Load merged settings: global provides defaults, project overrides.
+ *
+ * `cwd` is the session's working directory — required, no `process.cwd()`
+ * default: in an embedding host the process cwd is not the session's project
+ * (#206), and a defaulted parameter is exactly how that class of bug hides.
+ */
+export function loadSettings(cwd: string): SubagentsSettings {
   return { ...readSettingsFile(globalPath()), ...readSettingsFile(projectPath(cwd)) };
 }
 
@@ -273,7 +279,7 @@ export function loadSettings(cwd: string = process.cwd()): SubagentsSettings {
  * Returns `true` on success, `false` if the write (or mkdir) failed so the
  * caller can surface a warning — persistence isn't fatal but isn't silent.
  */
-export function saveSettings(s: SubagentsSettings, cwd: string = process.cwd()): boolean {
+export function saveSettings(s: SubagentsSettings, cwd: string): boolean {
   const path = projectPath(cwd);
   try {
     mkdirSync(dirname(path), { recursive: true });
@@ -303,6 +309,46 @@ export function applySettings(s: SubagentsSettings, appliers: SettingsAppliers):
 }
 
 /**
+ * Built-in defaults for every settings key — the value in effect when no
+ * settings file names it. Mirrors the initializers that live next to each
+ * setter (and the defaults the `SubagentsSettings` docs promise); `Required`
+ * so a new settings key can't ship without declaring its default here.
+ * `fallbackSubagent` is excluded: its default is `undefined` (the historical
+ * general-purpose fallback), which an optional field can't distinguish from
+ * "absent" — `applyDefaultSettings` resets it explicitly instead.
+ */
+export const DEFAULT_SETTINGS: Required<Omit<SubagentsSettings, "fallbackSubagent">> = {
+  maxConcurrent: 4,
+  defaultMaxTurns: 0, // 0 = unlimited — the convention normalizeMaxTurns understands
+  graceTurns: 5,
+  defaultJoinMode: "smart",
+  schedulingEnabled: true,
+  scopeModels: false,
+  strictAgentFiles: false,
+  disableDefaultAgents: false,
+  toolDescriptionMode: "full",
+  fleetView: true,
+  widgetMode: "background",
+  outputTranscript: true,
+  maxSubagentDepth: 2,
+};
+
+/**
+ * Reset in-memory state to the built-in defaults. `applySettings` fires
+ * appliers only for keys present in the settings it's given — right for
+ * layering a file over current state, but when that state was built for a
+ * *different* directory (session_start adopting the session cwd, #206), the
+ * previous directory's policy would survive wherever the new tree's settings
+ * are silent. Run this first, then apply the new tree's settings on top.
+ */
+export function applyDefaultSettings(appliers: SettingsAppliers): void {
+  applySettings(DEFAULT_SETTINGS, appliers);
+  // The one reset applySettings can't express: `undefined` restores the
+  // historical general-purpose fallback.
+  appliers.setFallbackSubagent(undefined);
+}
+
+/**
  * Format the user-facing toast for a settings mutation. Pure function —
  * routes the success/failure of `saveSettings` into the right message + level
  * so the UI layer (index.ts) stays a thin wire between input and notification.
@@ -324,7 +370,7 @@ export function persistToastFor(
 export function applyAndEmitLoaded(
   appliers: SettingsAppliers,
   emit: SettingsEmit,
-  cwd: string = process.cwd(),
+  cwd: string,
 ): SubagentsSettings {
   const settings = loadSettings(cwd);
   applySettings(settings, appliers);
@@ -342,7 +388,7 @@ export function saveAndEmitChanged(
   snapshot: SubagentsSettings,
   successMsg: string,
   emit: SettingsEmit,
-  cwd: string = process.cwd(),
+  cwd: string,
 ): { message: string; level: "info" | "warning" } {
   const persisted = saveSettings(snapshot, cwd);
   emit("subagents:settings_changed", { settings: snapshot, persisted });

--- a/src/ui/agent-widget.ts
+++ b/src/ui/agent-widget.ts
@@ -7,8 +7,8 @@
 
 import { truncateToWidth } from "@earendil-works/pi-tui";
 import type { AgentManager } from "../agent-manager.js";
-import { getConfig } from "../agent-types.js";
-import type { AgentInvocation, SubagentType, WidgetMode } from "../types.js";
+import { getConfigIn } from "../agent-types.js";
+import type { AgentConfig, AgentInvocation, SubagentType, WidgetMode } from "../types.js";
 import { getLifetimeTotal, getSessionContextPercent, type LifetimeUsage, type SessionLike } from "../usage.js";
 
 // ---- Constants ----
@@ -149,14 +149,14 @@ export function formatDuration(startedAt: number, completedAt?: number): string 
   return `${formatMs(Date.now() - startedAt)} (running)`;
 }
 
-/** Get display name for any agent type (built-in or custom). */
-export function getDisplayName(type: SubagentType): string {
-  return getConfig(type).displayName;
+/** Get display name for any agent type (built-in or custom) from a registry. */
+export function getDisplayName(registry: Map<string, AgentConfig>, type: SubagentType): string {
+  return getConfigIn(registry, type).displayName;
 }
 
 /** Short label for prompt mode: "twin" for append, nothing for replace (the default). */
-export function getPromptModeLabel(type: SubagentType): string | undefined {
-  const config = getConfig(type);
+export function getPromptModeLabel(registry: Map<string, AgentConfig>, type: SubagentType): string | undefined {
+  const config = getConfigIn(registry, type);
   return config.promptMode === "append" ? "twin" : undefined;
 }
 
@@ -231,6 +231,8 @@ export class AgentWidget {
   constructor(
     private manager: AgentManager,
     private agentActivity: Map<string, AgentActivity>,
+    /** The owning session's live agent registry — display names resolve here. */
+    private registry: Map<string, AgentConfig>,
     /**
      * Read live at render time. Selects which agents the widget shows — see
      * `WidgetMode`. Defaults to `"all"` when a caller supplies no policy; the
@@ -307,8 +309,8 @@ export class AgentWidget {
 
   /** Render a finished agent line. */
   private renderFinishedLine(a: { id: string; type: SubagentType; status: string; description: string; toolUses: number; startedAt: number; completedAt?: number; error?: string }, theme: Theme): string {
-    const name = getDisplayName(a.type);
-    const modeLabel = getPromptModeLabel(a.type);
+    const name = getDisplayName(this.registry, a.type);
+    const modeLabel = getPromptModeLabel(this.registry, a.type);
     const duration = formatMs((a.completedAt ?? Date.now()) - a.startedAt);
 
     let icon: string;
@@ -377,8 +379,8 @@ export class AgentWidget {
 
     const runningLines: string[][] = []; // each entry is [header, activity]
     for (const a of running) {
-      const name = getDisplayName(a.type);
-      const modeLabel = getPromptModeLabel(a.type);
+      const name = getDisplayName(this.registry, a.type);
+      const modeLabel = getPromptModeLabel(this.registry, a.type);
       const modeTag = modeLabel ? ` ${theme.fg("dim", `(${modeLabel})`)}` : "";
       const elapsed = formatMs(Date.now() - a.startedAt);
 

--- a/src/ui/conversation-viewer.ts
+++ b/src/ui/conversation-viewer.ts
@@ -8,7 +8,7 @@
 import type { AgentSession } from "@earendil-works/pi-coding-agent";
 import { type Component, Input, matchesKey, type TUI, truncateToWidth, visibleWidth, wrapTextWithAnsi } from "@earendil-works/pi-tui";
 import { extractText } from "../context.js";
-import type { AgentRecord } from "../types.js";
+import type { AgentConfig, AgentRecord } from "../types.js";
 import { getLifetimeTotal, getSessionContextPercent } from "../usage.js";
 import type { Theme } from "./agent-widget.js";
 import { type AgentActivity, buildInvocationTags, describeActivity, fgPreservingNestedStyles, formatDuration, formatSessionTokens, getDisplayName, getPromptModeLabel } from "./agent-widget.js";
@@ -36,6 +36,8 @@ export class ConversationViewer implements Component {
     private tui: TUI,
     private session: AgentSession,
     private record: AgentRecord,
+    /** The owning session's live agent registry — display names resolve here. */
+    private registry: Map<string, AgentConfig>,
     private activity: AgentActivity | undefined,
     private theme: Theme,
     private done: (result: undefined) => void,
@@ -137,8 +139,8 @@ export class ConversationViewer implements Component {
 
     // Header
     lines.push(hrTop);
-    const name = getDisplayName(this.record.type);
-    const modeLabel = getPromptModeLabel(this.record.type);
+    const name = getDisplayName(this.registry, this.record.type);
+    const modeLabel = getPromptModeLabel(this.registry, this.record.type);
     const modeTag = modeLabel ? ` ${th.fg("dim", `(${modeLabel})`)}` : "";
     const statusIcon = this.record.status === "running"
       ? th.fg("accent", "●")

--- a/src/ui/fleet-list.ts
+++ b/src/ui/fleet-list.ts
@@ -13,7 +13,7 @@
 
 import { Editor, isKeyRelease, Key, matchesKey, truncateToWidth, visibleWidth } from "@earendil-works/pi-tui";
 import type { AgentManager } from "../agent-manager.js";
-import type { AgentRecord } from "../types.js";
+import type { AgentConfig, AgentRecord } from "../types.js";
 import { getLifetimeTotal } from "../usage.js";
 import { type AgentActivity, getDisplayName, type Theme } from "./agent-widget.js";
 import { ConversationViewer, VIEWPORT_HEIGHT_PCT } from "./conversation-viewer.js";
@@ -93,6 +93,8 @@ export class FleetList {
   constructor(
     private manager: AgentManager,
     private agentActivity: Map<string, AgentActivity>,
+    /** The owning session's live agent registry — display names resolve here. */
+    private registry: Map<string, AgentConfig>,
   ) {}
 
   // ---- Lifecycle ----
@@ -302,6 +304,7 @@ export class FleetList {
           tui,
           session,
           record,
+          this.registry,
           activity,
           theme,
           done,
@@ -371,7 +374,7 @@ export class FleetList {
   }
 
   private renderAgentRow(rosterIndex: number, sel: number, record: AgentRecord, width: number, theme: Theme): string {
-    const left = `  ${this.bullet(rosterIndex, sel, theme)} ${theme.fg("muted", getDisplayName(record.type))}  ${record.description}`;
+    const left = `  ${this.bullet(rosterIndex, sel, theme)} ${theme.fg("muted", getDisplayName(this.registry, record.type))}  ${record.description}`;
     const tokens = getLifetimeTotal(this.agentActivity.get(record.id)?.lifetimeUsage ?? record.lifetimeUsage);
     const elapsedMs = (record.completedAt ?? Date.now()) - record.startedAt; // freezes once finished
     const right = theme.fg("dim", `${formatFleetElapsed(elapsedMs)} · ${formatFleetTokens(tokens)}`);

--- a/test/agent-runner-e2e.test.ts
+++ b/test/agent-runner-e2e.test.ts
@@ -29,7 +29,7 @@ import { join, resolve } from "node:path";
 import { fileURLToPath } from "node:url";
 import { afterEach, beforeEach, describe, expect, it, vi } from "vitest";
 import { extensionCanonicalName, runAgent } from "../src/agent-runner.js";
-import { registerAgents } from "../src/agent-types.js";
+import { buildAgentRegistry } from "../src/agent-types.js";
 import type { AgentConfig } from "../src/types.js";
 import { registerFauxProvider } from "./helpers/pi-ai.js";
 
@@ -69,7 +69,7 @@ describe("agent-runner end-to-end (real pi-mono session + real extension)", () =
    * return the real session's active tool names captured at construction time.
    */
   async function activeToolsFor(cfg: Partial<AgentConfig>): Promise<string[]> {
-    registerAgents(
+    const registry = buildAgentRegistry(
       new Map([
         [
           "e2e",
@@ -105,6 +105,7 @@ describe("agent-runner end-to-end (real pi-mono session + real extension)", () =
     try {
       await runAgent(ctx, "e2e", "go", {
         pi: makePi(),
+        registry,
         model,
         onSessionCreated: (s) => {
           active = s.getActiveToolNames();

--- a/test/agent-runner.test.ts
+++ b/test/agent-runner.test.ts
@@ -63,17 +63,16 @@ vi.mock("@earendil-works/pi-coding-agent", () => ({
   SettingsManager: { create: settingsManagerCreate },
 }));
 
-vi.mock("../src/agent-types.js", () => ({
-  BUILTIN_TOOL_NAMES: ["read", "bash", "edit", "write", "grep", "find", "ls"],
-  getConfig: vi.fn(() => ({
+vi.mock("../src/agent-types.js", () => {
+  const getConfig = vi.fn(() => ({
     displayName: "Explore",
     description: "Explore",
     builtinToolNames: ["read"],
     extensions: false,
     skills: false,
     promptMode: "replace",
-  })),
-  getAgentConfig: vi.fn(() => ({
+  }));
+  const getAgentConfig = vi.fn(() => ({
     name: "Explore",
     description: "Explore",
     builtinToolNames: ["read"],
@@ -84,11 +83,25 @@ vi.mock("../src/agent-types.js", () => ({
     inheritContext: false,
     runInBackground: false,
     isolated: false,
-  })),
-  getMemoryToolNames: vi.fn(() => []),
-  getReadOnlyMemoryToolNames: vi.fn(() => []),
-  getToolNamesForType: vi.fn(() => ["read"]),
-}));
+  }));
+  const getToolNamesForType = vi.fn(() => ["read"]);
+  return {
+    BUILTIN_TOOL_NAMES: ["read", "bash", "edit", "write", "grep", "find", "ls"],
+    // The runner reads the registry-parameterized `*In` variants now (#206);
+    // the mocks ignore the registry argument, so the same fn objects serve
+    // both names and the per-test `vi.mocked(getConfig)…` steering below
+    // keeps working unchanged.
+    getConfig,
+    getConfigIn: getConfig,
+    getAgentConfig,
+    getAgentConfigIn: getAgentConfig,
+    getToolNamesForType,
+    getToolNamesForTypeIn: getToolNamesForType,
+    getMemoryToolNames: vi.fn(() => []),
+    getReadOnlyMemoryToolNames: vi.fn(() => []),
+    buildAgentRegistry: vi.fn((userAgents: Map<string, unknown>) => userAgents),
+  };
+});
 
 vi.mock("../src/env.js", () => ({
   detectEnv: vi.fn(async () => ({ isGitRepo: false, branch: "", platform: "linux" })),
@@ -122,10 +135,23 @@ import {
   getAgentConversation,
   parseExtensionsSpec,
   parseExtSelectors,
+  type RunOptions,
   resumeAgent,
-  runAgent,
+  runAgent as runAgentActual,
   SUBAGENT_TOOL_NAMES,
 } from "../src/agent-runner.js";
+
+/**
+ * `runAgent` with the now-required per-session `registry` defaulted (#206) —
+ * the mocked config lookups above ignore it, so an empty Map serves every
+ * test here without touching each call site.
+ */
+const runAgent = (
+  ctx: Parameters<typeof runAgentActual>[0],
+  type: Parameters<typeof runAgentActual>[1],
+  prompt: string,
+  options: Omit<RunOptions, "registry"> & Partial<Pick<RunOptions, "registry">>,
+) => runAgentActual(ctx, type, prompt, { registry: new Map(), ...options });
 
 /** The most recent session built by `createSession` — read by `lastToolsPassed()`. */
 let lastSession: ReturnType<typeof createSession>["session"] | undefined;

--- a/test/agent-types.test.ts
+++ b/test/agent-types.test.ts
@@ -1,27 +1,37 @@
 import { afterEach, beforeEach, describe, expect, it } from "vitest";
 import {
+  type AgentTypeState,
   BUILTIN_TOOL_NAMES,
-  getAgentConfig,
-  getAvailableTypes,
-  getConfig,
-  getDefaultAgentNames,
+  createAgentTypeState,
   getMemoryToolNames,
   getReadOnlyMemoryToolNames,
-  getToolNamesForType,
-  getUserAgentNames,
-  isDefaultsDisabled,
-  isValidType,
   NO_FALLBACK,
-  registerAgents,
   resolveEnabledTypeIn,
-  resolveSpawnType,
   resolveSpawnTypeIn,
-  resolveType,
-  setDefaultsDisabled,
-  setFallbackSubagent,
 } from "../src/agent-types.js";
 import { DEFAULT_AGENTS } from "../src/default-agents.js";
 import type { AgentConfig } from "../src/types.js";
+
+// The registry moved from module scope into per-session state (#206). The API
+// surface is unchanged — rebind the old names to one state instance so the
+// test bodies below stay as they were; `registerAgents` refills that
+// instance's registry in place, exactly like the old module-global one (and,
+// like it, leaves disableDefaults/fallbackSubagent alone — the afterEach
+// resets below still matter).
+const state: AgentTypeState = createAgentTypeState();
+const registerAgents = (userAgents: Map<string, AgentConfig>) => state.register(userAgents);
+const getAgentConfig = (name: string) => state.getAgentConfig(name);
+const getAvailableTypes = () => state.getAvailableTypes();
+const getConfig = (type: string) => state.getConfig(type);
+const getDefaultAgentNames = () => state.getDefaultAgentNames();
+const getToolNamesForType = (type: string) => state.getToolNamesForType(type);
+const getUserAgentNames = () => state.getUserAgentNames();
+const isDefaultsDisabled = () => state.isDefaultsDisabled();
+const isValidType = (type: string) => state.isValidType(type);
+const resolveSpawnType = (requested: unknown) => state.resolveSpawnType(requested);
+const resolveType = (name: string) => state.resolveType(name);
+const setDefaultsDisabled = (b: boolean) => state.setDefaultsDisabled(b);
+const setFallbackSubagent = (v: string | undefined) => state.setFallbackSubagent(v);
 
 function makeAgentConfig(overrides: Partial<AgentConfig> = {}): AgentConfig {
   return {
@@ -138,7 +148,7 @@ describe("agent type registry", () => {
   });
 
   describe("disable defaults", () => {
-    // Module-level flag — always reset so later describes see the default roster.
+    // Instance flag — always reset so later describes see the default roster.
     afterEach(() => {
       setDefaultsDisabled(false);
       registerAgents(new Map());
@@ -481,13 +491,55 @@ describe("resolveSpawnType — fail-closed dispatch (#183)", () => {
     // Nested delegation uses this seam so a project-level fallback can't hand a
     // nested caller an agent its allowlist never named.
     const registry = roster();
-    setFallbackSubagent("router");
     expect(resolveEnabledTypeIn(registry, "typoo")).toBeUndefined();
     expect(resolveEnabledTypeIn(registry, "retired")).toBeUndefined();
     expect(resolveEnabledTypeIn(registry, " SCOUT ")).toBe("scout");
-    // ...while the policy layer still honors it.
-    expect(resolveSpawnTypeIn(registry, "typoo")).toEqual({
+    // ...while the policy layer still honors a fallback — passed explicitly,
+    // since resolveSpawnTypeIn is pure over both the registry and the policy
+    // (the ambient module state it used to read is per-session now, #206).
+    expect(resolveSpawnTypeIn(registry, "typoo", "router")).toEqual({
       ok: true, type: "router", fellBackFrom: "typoo",
     });
+  });
+});
+
+describe("per-session agent-type state (#206)", () => {
+  it("two states register different rosters without interfering", () => {
+    // The embedding-host shape: two live sessions in different projects, each
+    // reloading its own definitions. With module-scope state this was
+    // last-writer-wins; with per-session instances both resolve their own.
+    const sessionA = createAgentTypeState();
+    const sessionB = createAgentTypeState();
+    sessionA.register(new Map([["alpha", makeAgentConfig({ name: "alpha" })]]));
+    sessionB.register(new Map([["beta", makeAgentConfig({ name: "beta" })]]));
+
+    expect(sessionA.isValidType("alpha")).toBe(true);
+    expect(sessionA.isValidType("beta")).toBe(false);
+    expect(sessionB.isValidType("beta")).toBe(true);
+    expect(sessionB.isValidType("alpha")).toBe(false);
+  });
+
+  it("registry settings are per-state too", () => {
+    const strict = createAgentTypeState();
+    const lax = createAgentTypeState();
+    strict.setFallbackSubagent(NO_FALLBACK);
+    strict.setDefaultsDisabled(true);
+    strict.register(new Map());
+    lax.register(new Map());
+
+    expect(strict.resolveSpawnType("nope").ok).toBe(false);
+    expect(lax.resolveSpawnType("nope")).toEqual({ ok: true, type: "general-purpose", fellBackFrom: "nope" });
+    expect(strict.getAvailableTypes()).toEqual([]);
+    expect(lax.isValidType("Explore")).toBe(true);
+  });
+
+  it("registry() is a stable reference that register() refills in place", () => {
+    // A spawn queued with this reference must observe mid-session reloads —
+    // the same live semantics the process-wide registry had.
+    const session = createAgentTypeState();
+    const ref = session.registry();
+    session.register(new Map([["late", makeAgentConfig({ name: "late" })]]));
+    expect(session.registry()).toBe(ref);
+    expect(ref.has("late")).toBe(true);
   });
 });

--- a/test/agent-widget.test.ts
+++ b/test/agent-widget.test.ts
@@ -1,4 +1,5 @@
 import { describe, expect, it } from "vitest";
+import { buildAgentRegistry } from "../src/agent-types.js";
 import { renderRunningAgentStatus } from "../src/index.js";
 import type { WidgetMode } from "../src/types.js";
 import { type AgentActivity, AgentWidget, fgPreservingNestedStyles, formatSessionTokens } from "../src/ui/agent-widget.js";
@@ -87,6 +88,7 @@ describe("AgentWidget", () => {
     const widget = new AgentWidget(
       manager as any,
       new Map([[activityId, makeActivity()]]),
+      buildAgentRegistry(new Map()),
       mode,
     );
     let factory: any;

--- a/test/conversation-viewer-keybindings.test.ts
+++ b/test/conversation-viewer-keybindings.test.ts
@@ -1,5 +1,6 @@
 import { KeybindingsManager, TUI_KEYBINDINGS } from "@earendil-works/pi-tui";
 import { describe, expect, it, vi } from "vitest";
+import { buildAgentRegistry } from "../src/agent-types.js";
 import type { AgentRecord } from "../src/types.js";
 import { ConversationViewer } from "../src/ui/conversation-viewer.js";
 import type { ViewerKeybindings } from "../src/ui/viewer-keys.js";
@@ -46,7 +47,7 @@ function createViewer(keybindings?: ViewerKeybindings) {
     fg: (_color: string, text: string) => text,
     bold: (text: string) => text,
   } as any;
-  const viewer = new ConversationViewer(tui, session, record, undefined, theme, vi.fn(), undefined, keybindings);
+  const viewer = new ConversationViewer(tui, session, record, buildAgentRegistry(new Map()), undefined, theme, vi.fn(), undefined, keybindings);
   viewer.render(80); // sets lastInnerW and scrolls to bottom (autoScroll)
   return viewer;
 }

--- a/test/conversation-viewer.test.ts
+++ b/test/conversation-viewer.test.ts
@@ -1,4 +1,5 @@
 import { beforeEach, describe, expect, it, vi } from "vitest";
+import { buildAgentRegistry } from "../src/agent-types.js";
 import type { AgentRecord } from "../src/types.js";
 
 // ── Mock wrapTextWithAnsi ──────────────────────────────────────────────
@@ -26,6 +27,9 @@ const { visibleWidth } = await import("@earendil-works/pi-tui");
 const { ConversationViewer } = await import("../src/ui/conversation-viewer.js");
 
 // ── Helpers ────────────────────────────────────────────────────────────
+
+/** Default-agents registry — display names resolve from it (#206). */
+const registry = buildAgentRegistry(new Map());
 
 function mockTui(rows = 40, columns = 80) {
   return {
@@ -82,7 +86,7 @@ describe("ConversationViewer", () => {
     it("no line exceeds width with empty messages", () => {
       for (const w of widths) {
         const viewer = new ConversationViewer(
-          mockTui(30, w), mockSession([]), mockRecord(), undefined, ansiTheme(), vi.fn(),
+          mockTui(30, w), mockSession([]), mockRecord(), registry, undefined, ansiTheme(), vi.fn(),
         );
         assertAllLinesFit(viewer.render(w), w);
       }
@@ -95,7 +99,7 @@ describe("ConversationViewer", () => {
       ];
       for (const w of widths) {
         const viewer = new ConversationViewer(
-          mockTui(30, w), mockSession(messages), mockRecord(), undefined, ansiTheme(), vi.fn(),
+          mockTui(30, w), mockSession(messages), mockRecord(), registry, undefined, ansiTheme(), vi.fn(),
         );
         assertAllLinesFit(viewer.render(w), w);
       }
@@ -108,6 +112,7 @@ describe("ConversationViewer", () => {
           mockTui(30, width),
           mockSession([]),
           mockRecord({ description: `${"a".repeat(prefixLength)}界more` }),
+          registry,
           undefined,
           ansiTheme(),
           vi.fn(),
@@ -131,7 +136,7 @@ describe("ConversationViewer", () => {
       ];
       for (const w of widths) {
         const viewer = new ConversationViewer(
-          mockTui(30, w), mockSession(messages), mockRecord(), undefined, ansiTheme(), vi.fn(),
+          mockTui(30, w), mockSession(messages), mockRecord(), registry, undefined, ansiTheme(), vi.fn(),
         );
         assertAllLinesFit(viewer.render(w), w);
       }
@@ -144,7 +149,7 @@ describe("ConversationViewer", () => {
       ];
       for (const w of widths) {
         const viewer = new ConversationViewer(
-          mockTui(30, w), mockSession(messages), mockRecord(), undefined, ansiTheme(), vi.fn(),
+          mockTui(30, w), mockSession(messages), mockRecord(), registry, undefined, ansiTheme(), vi.fn(),
         );
         assertAllLinesFit(viewer.render(w), w);
       }
@@ -157,7 +162,7 @@ describe("ConversationViewer", () => {
       ];
       for (const w of widths) {
         const viewer = new ConversationViewer(
-          mockTui(30, w), mockSession(messages), mockRecord(), undefined, ansiTheme(), vi.fn(),
+          mockTui(30, w), mockSession(messages), mockRecord(), registry, undefined, ansiTheme(), vi.fn(),
         );
         assertAllLinesFit(viewer.render(w), w);
       }
@@ -172,7 +177,7 @@ describe("ConversationViewer", () => {
       ];
       for (const w of widths) {
         const viewer = new ConversationViewer(
-          mockTui(30, w), mockSession(messages), mockRecord(), undefined, ansiTheme(), vi.fn(),
+          mockTui(30, w), mockSession(messages), mockRecord(), registry, undefined, ansiTheme(), vi.fn(),
         );
         assertAllLinesFit(viewer.render(w), w);
       }
@@ -188,7 +193,7 @@ describe("ConversationViewer", () => {
       ];
       for (const w of widths) {
         const viewer = new ConversationViewer(
-          mockTui(30, w), mockSession(messages), mockRecord(), undefined, ansiTheme(), vi.fn(),
+          mockTui(30, w), mockSession(messages), mockRecord(), registry, undefined, ansiTheme(), vi.fn(),
         );
         assertAllLinesFit(viewer.render(w), w);
       }
@@ -206,7 +211,7 @@ describe("ConversationViewer", () => {
       ];
       for (const w of widths) {
         const viewer = new ConversationViewer(
-          mockTui(30, w), mockSession(messages), mockRecord({ status: "running" }), activity as any, ansiTheme(), vi.fn(),
+          mockTui(30, w), mockSession(messages), mockRecord({ status: "running" }), registry, activity as any, ansiTheme(), vi.fn(),
         );
         assertAllLinesFit(viewer.render(w), w);
       }
@@ -224,7 +229,7 @@ describe("ConversationViewer", () => {
       ];
       for (const w of widths) {
         const viewer = new ConversationViewer(
-          mockTui(30, w), mockSession(messages), mockRecord(), undefined, ansiTheme(), vi.fn(),
+          mockTui(30, w), mockSession(messages), mockRecord(), registry, undefined, ansiTheme(), vi.fn(),
         );
         assertAllLinesFit(viewer.render(w), w);
       }
@@ -237,7 +242,7 @@ describe("ConversationViewer", () => {
       ];
       for (const w of [8, 10, 15, 20]) {
         const viewer = new ConversationViewer(
-          mockTui(30, w), mockSession(messages), mockRecord(), undefined, ansiTheme(), vi.fn(),
+          mockTui(30, w), mockSession(messages), mockRecord(), registry, undefined, ansiTheme(), vi.fn(),
         );
         assertAllLinesFit(viewer.render(w), w);
       }
@@ -250,7 +255,7 @@ describe("ConversationViewer", () => {
       ];
       for (const w of widths) {
         const viewer = new ConversationViewer(
-          mockTui(30, w), mockSession(messages), mockRecord(), undefined, ansiTheme(), vi.fn(),
+          mockTui(30, w), mockSession(messages), mockRecord(), registry, undefined, ansiTheme(), vi.fn(),
         );
         assertAllLinesFit(viewer.render(w), w);
       }
@@ -283,7 +288,7 @@ describe("ConversationViewer", () => {
         { role: "toolResult", toolUseId: "t1", content: [{ type: "text", text: "output" }] },
       ];
       const viewer = new ConversationViewer(
-        mockTui(30, w), mockSession(messages), mockRecord(), undefined, ansiTheme(), vi.fn(),
+        mockTui(30, w), mockSession(messages), mockRecord(), registry, undefined, ansiTheme(), vi.fn(),
       );
       assertAllLinesFit(callBuildContentLines(viewer, w), w);
     });
@@ -294,7 +299,7 @@ describe("ConversationViewer", () => {
 
       const messages = [{ role: "user", content: "hello" }];
       const viewer = new ConversationViewer(
-        mockTui(30, w), mockSession(messages), mockRecord(), undefined, ansiTheme(), vi.fn(),
+        mockTui(30, w), mockSession(messages), mockRecord(), registry, undefined, ansiTheme(), vi.fn(),
       );
       assertAllLinesFit(callBuildContentLines(viewer, w), w);
     });
@@ -307,7 +312,7 @@ describe("ConversationViewer", () => {
         { role: "assistant", content: [{ type: "text", text: "response" }] },
       ];
       const viewer = new ConversationViewer(
-        mockTui(30, w), mockSession(messages), mockRecord(), undefined, ansiTheme(), vi.fn(),
+        mockTui(30, w), mockSession(messages), mockRecord(), registry, undefined, ansiTheme(), vi.fn(),
       );
       assertAllLinesFit(callBuildContentLines(viewer, w), w);
     });
@@ -323,7 +328,7 @@ describe("ConversationViewer", () => {
         },
       ];
       const viewer = new ConversationViewer(
-        mockTui(30, w), mockSession(messages), mockRecord(), undefined, ansiTheme(), vi.fn(),
+        mockTui(30, w), mockSession(messages), mockRecord(), registry, undefined, ansiTheme(), vi.fn(),
       );
       assertAllLinesFit(callBuildContentLines(viewer, w), w);
     });
@@ -336,7 +341,7 @@ describe("ConversationViewer", () => {
         { role: "toolResult", toolUseId: "t1", content: [{ type: "text", text: "output" }] },
       ];
       const viewer = new ConversationViewer(
-        mockTui(30, w), mockSession(messages), mockRecord(), undefined, ansiTheme(), vi.fn(),
+        mockTui(30, w), mockSession(messages), mockRecord(), registry, undefined, ansiTheme(), vi.fn(),
       );
       assertAllLinesFit(callBuildContentLines(viewer, w), w);
     });
@@ -349,7 +354,7 @@ describe("ConversationViewer", () => {
       const onStop = vi.fn();
       const tui = mockTui(30, W);
       const viewer = new ConversationViewer(
-        tui, mockSession(), mockRecord({ status: "running" }), undefined, ansiTheme(), vi.fn(), onStop,
+        tui, mockSession(), mockRecord({ status: "running" }), registry, undefined, ansiTheme(), vi.fn(), onStop,
       );
 
       // Idle footer offers the stop affordance.
@@ -369,7 +374,7 @@ describe("ConversationViewer", () => {
     it("any other key disarms the confirm", () => {
       const onStop = vi.fn();
       const viewer = new ConversationViewer(
-        mockTui(30, W), mockSession(), mockRecord({ status: "running" }), undefined, ansiTheme(), vi.fn(), onStop,
+        mockTui(30, W), mockSession(), mockRecord({ status: "running" }), registry, undefined, ansiTheme(), vi.fn(), onStop,
       );
 
       viewer.handleInput("x");                       // arm
@@ -384,7 +389,7 @@ describe("ConversationViewer", () => {
     it("does not offer or perform stop once the agent is no longer running", () => {
       const onStop = vi.fn();
       const viewer = new ConversationViewer(
-        mockTui(30, W), mockSession(), mockRecord({ status: "completed" }), undefined, ansiTheme(), vi.fn(), onStop,
+        mockTui(30, W), mockSession(), mockRecord({ status: "completed" }), registry, undefined, ansiTheme(), vi.fn(), onStop,
       );
 
       expect(viewer.render(W).join("\n")).not.toContain("x stop");
@@ -395,7 +400,7 @@ describe("ConversationViewer", () => {
 
     it("no stop affordance when no onStop handler is provided (read-only history)", () => {
       const viewer = new ConversationViewer(
-        mockTui(30, W), mockSession(), mockRecord({ status: "running" }), undefined, ansiTheme(), vi.fn(),
+        mockTui(30, W), mockSession(), mockRecord({ status: "running" }), registry, undefined, ansiTheme(), vi.fn(),
       );
       expect(viewer.render(W).join("\n")).not.toContain("x stop");
       expect(() => { viewer.handleInput("x"); viewer.handleInput("x"); }).not.toThrow();
@@ -409,7 +414,7 @@ describe("ConversationViewer", () => {
       const onSteer = opts.onSteer ?? vi.fn();
       const tui = mockTui(30, W);
       const viewer = new ConversationViewer(
-        tui, mockSession(), mockRecord({ status: opts.status ?? "running" }),
+        tui, mockSession(), mockRecord({ status: opts.status ?? "running" }), registry,
         undefined, ansiTheme(), vi.fn(), undefined, undefined, onSteer,
       );
       return { viewer, tui, onSteer };
@@ -472,7 +477,7 @@ describe("ConversationViewer", () => {
 
     it("no steer affordance when no onSteer handler is provided", () => {
       const viewer = new ConversationViewer(
-        mockTui(30, W), mockSession(), mockRecord({ status: "running" }), undefined, ansiTheme(), vi.fn(),
+        mockTui(30, W), mockSession(), mockRecord({ status: "running" }), registry, undefined, ansiTheme(), vi.fn(),
       );
       expect(viewer.render(W).join("\n")).not.toContain("Enter steer");
       expect(() => viewer.handleInput("\r")).not.toThrow();
@@ -482,7 +487,7 @@ describe("ConversationViewer", () => {
       for (const w of [40, 80, 120]) {
         const tui = mockTui(30, w);
         const viewer = new ConversationViewer(
-          tui, mockSession(), mockRecord({ status: "running" }),
+          tui, mockSession(), mockRecord({ status: "running" }), registry,
           undefined, ansiTheme(), vi.fn(), undefined, undefined, vi.fn(),
         );
         viewer.handleInput("\r"); // open composer

--- a/test/e2e/tool-veto-reachability.e2e.test.ts
+++ b/test/e2e/tool-veto-reachability.e2e.test.ts
@@ -41,7 +41,7 @@ import { join, resolve } from "node:path";
 import { fileURLToPath } from "node:url";
 import { afterEach, beforeEach, describe, expect, it, vi } from "vitest";
 import { runAgent } from "../../src/agent-runner.js";
-import { registerAgents } from "../../src/agent-types.js";
+import { buildAgentRegistry } from "../../src/agent-types.js";
 import type { AgentConfig } from "../../src/types.js";
 import { registerFauxProvider } from "../helpers/pi-ai.js";
 
@@ -74,7 +74,7 @@ describe("tool veto reachability against real pi-mono", () => {
   });
 
   it("pi installs a chainable beforeToolCall, and runAgent's veto blocks out-of-scope tools", async () => {
-    registerAgents(
+    const registry = buildAgentRegistry(
       new Map([
         [
           "veto",
@@ -113,6 +113,7 @@ describe("tool veto reachability against real pi-mono", () => {
     let session: any;
     try {
       await runAgent(ctx, "veto", "go", {
+        registry,
         pi: makePi(),
         model,
         onSessionCreated: (s: any) => {

--- a/test/enabled-models.test.ts
+++ b/test/enabled-models.test.ts
@@ -2,7 +2,19 @@ import { mkdirSync, mkdtempSync, rmSync, writeFileSync } from "node:fs";
 import { tmpdir } from "node:os";
 import { join } from "node:path";
 import { afterEach, beforeEach, describe, expect, it } from "vitest";
-import { type ModelRegistryRef, readEnabledModels, resolveEnabledModels } from "../src/enabled-models.js";
+import { type ModelRegistryRef, readEnabledModels, resolveEnabledModels as resolveEnabledModelsActual } from "../src/enabled-models.js";
+
+/**
+ * `resolveEnabledModels` now requires the session cwd (#206 — no
+ * `process.cwd()` parameter default). These tests exercise pattern
+ * resolution, not settings discovery, so a directory with no settings
+ * files serves them all.
+ */
+const resolveEnabledModels = (
+  patterns: string[] | undefined,
+  registry: ModelRegistryRef,
+  cwd: string = join(tmpdir(), "pi-subagents-enabled-models-no-settings"),
+) => resolveEnabledModelsActual(patterns, registry, cwd);
 
 /** Mock models matching typical registry shape. */
 const MODELS = [

--- a/test/ext-templates-e2e.test.ts
+++ b/test/ext-templates-e2e.test.ts
@@ -7,7 +7,7 @@
  *
  *   test/fixtures/.pi/agents/*.md         (pre-configured agent templates)
  *     → real loadCustomAgents()           (frontmatter → parseToolsField/ext:)
- *     → registerAgents()                  (real registry)
+ *     → buildAgentRegistry()              (real registry, passed to runAgent)
  *     → real runAgent() [headless]        (real DefaultResourceLoader loads the
  *                                          real .mjs extension fixtures)
  *     → real createAgentSession()         (real pi-mono tool gating)
@@ -30,9 +30,10 @@ import { fileURLToPath } from "node:url";
 import { parseFrontmatter } from "@earendil-works/pi-coding-agent";
 import { afterAll, beforeAll, describe, expect, it, vi } from "vitest";
 import { runAgent } from "../src/agent-runner.js";
-import { getAgentConfig, registerAgents } from "../src/agent-types.js";
+import { buildAgentRegistry, getAgentConfigIn } from "../src/agent-types.js";
 import { loadCustomAgents } from "../src/custom-agents.js";
 import { resolveAgentInvocationConfig } from "../src/invocation-config.js";
+import type { AgentConfig } from "../src/types.js";
 import { registerFauxProvider } from "./helpers/pi-ai.js";
 
 // Real pi-mono (loader + dynamic extension import + session construction) — a
@@ -70,6 +71,8 @@ describe("ext: / tools: scoping — template-driven e2e (real pi-mono, headless)
   let prevHome: string | undefined;
   let hermeticDir: string;
   let faux: ReturnType<typeof registerFauxProvider>;
+  /** The registry runAgent resolves against — per-session state (#206). */
+  let registry: Map<string, AgentConfig>;
 
   beforeAll(() => {
     // Isolate global discovery (getAgentDir / ~/.pi) so the dev's real agents
@@ -83,9 +86,9 @@ describe("ext: / tools: scoping — template-driven e2e (real pi-mono, headless)
     faux = registerFauxProvider({ provider: "faux", models: [{ id: "faux-1", contextWindow: 200_000 }] });
 
     // Load the templates through the REAL loader (project agents come from
-    // <cwd>/.pi/agents → FIXTURES_DIR/.pi/agents) and install them in the
-    // registry runAgent reads from.
-    registerAgents(loadCustomAgents(FIXTURES_DIR));
+    // <cwd>/.pi/agents → FIXTURES_DIR/.pi/agents) and build the registry
+    // runAgent reads from (passed per run — per-session state, #206).
+    registry = buildAgentRegistry(loadCustomAgents(FIXTURES_DIR));
   });
 
   afterAll(() => {
@@ -118,12 +121,13 @@ describe("ext: / tools: scoping — template-driven e2e (real pi-mono, headless)
     // Mirror production: the caller resolves frontmatter-locked fields (isolated,
     // inherit_context, …) into runAgent options via resolveAgentInvocationConfig.
     // isolated is the one that affects tool gating (forces extensions:false + drops ext:).
-    const resolved = resolveAgentInvocationConfig(getAgentConfig(agentName), { modelFromParams: false } as any);
+    const resolved = resolveAgentInvocationConfig(getAgentConfigIn(registry, agentName), { modelFromParams: false } as any);
 
     let active: string[] = [];
     let prompt = "";
     try {
       await runAgent(ctx, agentName, "go", {
+        registry,
         pi,
         model,
         cwd: FIXTURES_DIR,
@@ -154,7 +158,7 @@ describe("ext: / tools: scoping — template-driven e2e (real pi-mono, headless)
       expect(s.present.length + s.promptContains.length + s.promptAbsent.length).toBeGreaterThan(0);
       // Each loaded as ITS OWN agent — guards against runAgent silently falling
       // back to general-purpose when a template fails to parse/register.
-      const cfg = getAgentConfig(s.name);
+      const cfg = getAgentConfigIn(registry, s.name);
       expect(cfg, `template "${s.name}" did not register (parse error or name mismatch?)`).toBeDefined();
       expect(cfg?.name).toBe(s.name);
     }

--- a/test/fallback-subagent-wiring.test.ts
+++ b/test/fallback-subagent-wiring.test.ts
@@ -20,7 +20,8 @@ vi.mock("../src/agent-runner.js", async () => {
 });
 
 import { runAgent } from "../src/agent-runner.js";
-import { getAllTypes, getAvailableTypes, NO_FALLBACK, registerAgents, setFallbackSubagent } from "../src/agent-types.js";
+import { buildAgentRegistry, getAllTypesIn, getAvailableTypesIn } from "../src/agent-types.js";
+import { loadCustomAgents } from "../src/custom-agents.js";
 import subagentsExtension from "../src/index.js";
 
 function makePi() {
@@ -54,6 +55,16 @@ function writeAgents(): void {
   writeFileSync(join(dir, "retired.md"), "---\ndescription: Retired\ntools: read\nenabled: false\n---\nRetired.\n");
 }
 
+/**
+ * Configure `fallbackSubagent: none` the way production receives it: through
+ * `<cwd>/.pi/subagents.json`, applied at activation (the per-session state is
+ * closure-internal now, #206 — there is no module-level setter to poke).
+ * Must run before boot().
+ */
+function writeStrictDispatchSettings(): void {
+  writeFileSync(join(cwd, ".pi", "subagents.json"), JSON.stringify({ fallbackSubagent: "none" }));
+}
+
 function ctx() {
   return {
     hasUI: false,
@@ -84,14 +95,12 @@ describe("fallbackSubagent gates dispatch through the real Agent tool", () => {
   });
 
   afterEach(() => {
-    setFallbackSubagent(undefined);
     delete (globalThis as any)[Symbol.for("pi-subagents:manager")];
     process.chdir(originalCwd);
     if (originalAgentDir == null) delete process.env.PI_CODING_AGENT_DIR;
     else process.env.PI_CODING_AGENT_DIR = originalAgentDir;
     if (originalHome == null) delete process.env.HOME;
     else process.env.HOME = originalHome;
-    registerAgents(new Map());
     rmSync(cwd, { recursive: true, force: true });
   });
 
@@ -103,8 +112,8 @@ describe("fallbackSubagent gates dispatch through the real Agent tool", () => {
 
   for (const background of [false, true]) {
     it(`refuses an unknown type without spawning (run_in_background: ${background})`, async () => {
+      writeStrictDispatchSettings();
       const { tools } = boot();
-      setFallbackSubagent(NO_FALLBACK);
 
       const result = await tools.get("Agent").execute(
         "tc-1",
@@ -165,12 +174,14 @@ describe("fallbackSubagent gates dispatch through the real Agent tool", () => {
   });
 
   it("refuses a disabled type, which used to dispatch with a mixed identity", async () => {
+    writeStrictDispatchSettings();
     const { tools } = boot();
-    setFallbackSubagent(NO_FALLBACK);
     // Pin the fixture: without this the test passes identically if retired.md
     // stopped loading, since "unknown" and "disabled" share one message.
-    expect(getAllTypes()).toContain("retired");
-    expect(getAvailableTypes()).not.toContain("retired");
+    // Loaded through the same real loader the extension uses.
+    const fixtureRegistry = buildAgentRegistry(loadCustomAgents(cwd));
+    expect(getAllTypesIn(fixtureRegistry)).toContain("retired");
+    expect(getAvailableTypesIn(fixtureRegistry)).not.toContain("retired");
 
     const result = await tools.get("Agent").execute(
       "tc-4",
@@ -207,6 +218,7 @@ describe("fallbackSubagent gates dispatch through the real Agent tool", () => {
     // resume replays a stored session; the type is required by the schema but
     // unused. Gating it would make a live agent unresumable the moment its type
     // is deleted or disabled — the opposite of what strict dispatch is for.
+    writeStrictDispatchSettings();
     const { tools } = boot();
     vi.mocked(runAgent).mockResolvedValue({
       responseText: "first", session: { dispose: vi.fn() } as any, aborted: false, steered: false,
@@ -220,7 +232,6 @@ describe("fallbackSubagent gates dispatch through the real Agent tool", () => {
       ?? (spawned as any).details?.agentId;
     expect(id).toBeTruthy();
 
-    setFallbackSubagent(NO_FALLBACK);
     const resumed = await tools.get("Agent").execute(
       "tc-7",
       { resume: id, prompt: "keep going", description: "resume", subagent_type: "deleted-since" },
@@ -233,8 +244,8 @@ describe("fallbackSubagent gates dispatch through the real Agent tool", () => {
   it("applies the same contract to cross-extension spawns", async () => {
     // The registry entry is what RPC callers reach; it must not be a way around
     // the setting. A throw here becomes an error envelope at the RPC boundary.
+    writeStrictDispatchSettings();
     boot();
-    setFallbackSubagent(NO_FALLBACK);
     const registry = (globalThis as any)[Symbol.for("pi-subagents:manager")];
 
     expect(() => registry.spawn({}, ctx(), "definitely-missing", "do it", { description: "rpc" }))

--- a/test/fleet-list.test.ts
+++ b/test/fleet-list.test.ts
@@ -1,9 +1,13 @@
 import { Editor, visibleWidth } from "@earendil-works/pi-tui";
 import { describe, expect, it, vi } from "vitest";
 import type { AgentManager } from "../src/agent-manager.js";
+import { buildAgentRegistry } from "../src/agent-types.js";
 import type { AgentRecord } from "../src/types.js";
 import { getDisplayName } from "../src/ui/agent-widget.js";
 import { FleetList, type FleetUICtx, formatFleetElapsed, formatFleetTokens } from "../src/ui/fleet-list.js";
+
+/** Default-agents registry — display names resolve from it (#206). */
+const registry = buildAgentRegistry(new Map());
 
 // ---- Key sequences (see node_modules/@earendil-works/pi-tui/dist/keys.js) ----
 const DOWN = "\x1b[B";
@@ -93,7 +97,7 @@ function harness(agents: AgentRecord[]): Harness {
   };
 
   const manager = fakeManager(agents);
-  const fleet = new FleetList(manager, new Map());
+  const fleet = new FleetList(manager, new Map(), registry);
   fleet.setUICtx(ui);
   fleet.update();
 
@@ -231,7 +235,7 @@ describe("FleetList navigation", () => {
       const agents = [makeRecord({ id: "a1" })];
       const listAgents = vi.fn(() => agents);
       const manager = { listAgents, abort: () => true } as unknown as AgentManager;
-      const fleet = new FleetList(manager, new Map());
+      const fleet = new FleetList(manager, new Map(), registry);
       fleet.setUICtx({
         setWidget: () => {}, onTerminalInput: () => () => {}, getEditorText: () => "",
         notify: () => {}, custom: (() => new Promise<undefined>(() => {})) as FleetUICtx["custom"],
@@ -310,7 +314,7 @@ describe("FleetList rendering", () => {
     expect(lines.find(l => l.includes("main"))).toContain("●"); // main selected by default
     const agentLine = lines.find(l => l.includes("Sleep then report 1"))!;
     expect(agentLine).toContain("○");
-    expect(agentLine).toContain(getDisplayName("general-purpose"));
+    expect(agentLine).toContain(getDisplayName(registry, "general-purpose"));
     expect(agentLine).toContain("↓ 13.1k tokens");
     expect(agentLine).toMatch(/\d+s · ↓/); // "<seconds>s · ↓ ..." (timing-agnostic)
   });

--- a/test/helpers/print-mode-runner.ts
+++ b/test/helpers/print-mode-runner.ts
@@ -117,8 +117,9 @@ export interface RunPrintModeOptions {
    */
   hold?: boolean;
   /**
-   * Run before the parent turn, after globals are isolated — e.g.
-   * `registerAgents(loadCustomAgents(cwd))` to install frontmatter agents.
+   * Run before the parent turn, after globals are isolated. Custom agents in
+   * `<cwd>/.pi/agents` need no registration here — the extension discovers
+   * them from its session cwd itself (per-session state, #206).
    */
   beforeRun?: () => void | Promise<void>;
   /**
@@ -257,9 +258,9 @@ export async function runPrintMode(options: RunPrintModeOptions): Promise<PrintM
   const ownsCwd = options.cwd == null;
   const cwd = options.cwd ?? mkdtempSync(join(tmpdir(), "subagents-print-"));
 
-  // chdir into cwd: the extension discovers project custom agents from process.cwd()
-  // (not ctx.cwd), and re-reads them on every Agent invocation — so a custom agent
-  // is only spawnable if process.cwd() points at the dir holding it. Restored on
+  // chdir into cwd: matches the CLI, where the process cwd IS the session cwd.
+  // (Discovery itself keys off the session cwd since #206 — the chdir keeps the
+  // provisional pre-session_start value identical too.) Restored on
   // dispose. (Vitest isolates test files per process, so this doesn't race.)
   const prevCwd = process.cwd();
   process.chdir(cwd);

--- a/test/nested-delegation-e2e.test.ts
+++ b/test/nested-delegation-e2e.test.ts
@@ -21,8 +21,6 @@ import { tmpdir } from "node:os";
 import { join } from "node:path";
 import { type Context, fauxToolCall } from "@earendil-works/pi-ai";
 import { afterEach, describe, expect, it, vi } from "vitest";
-import { registerAgents } from "../src/agent-types.js";
-import { loadCustomAgents } from "../src/custom-agents.js";
 import { encodeCwd } from "../src/output-file.js";
 import {
   agentCall,
@@ -159,7 +157,6 @@ describe("nested delegation e2e (real pi-mono, faux model)", () => {
       cwd,
       respond,
       live: false,
-      beforeRun: () => { registerAgents(loadCustomAgents(cwd)); },
     });
 
     // pi admitted the injected nested tools into the opted-in child's active set,
@@ -223,7 +220,6 @@ describe("nested delegation e2e (real pi-mono, faux model)", () => {
         cwd,
         respond,
         live: false,
-        beforeRun: () => { registerAgents(loadCustomAgents(cwd)); },
       });
 
       // The background child ran and its output came back through the id the

--- a/test/nested-tools.test.ts
+++ b/test/nested-tools.test.ts
@@ -2,13 +2,19 @@ import { mkdirSync, mkdtempSync, rmSync, writeFileSync } from "node:fs";
 import { tmpdir } from "node:os";
 import { join } from "node:path";
 import { afterEach, beforeEach, describe, expect, it, vi } from "vitest";
-import { getAvailableTypes, registerAgents, setFallbackSubagent } from "../src/agent-types.js";
+import { type AgentTypeState, buildAgentRegistry, createAgentTypeState } from "../src/agent-types.js";
 import { loadCustomAgents } from "../src/custom-agents.js";
 import { setScopeModelsEnabled } from "../src/model-scope.js";
 import { createNestedSubagentTools, type NestedAgentManager } from "../src/nested-tools.js";
 import { encodeCwd } from "../src/output-file.js";
 
 let cwd: string;
+/**
+ * Stand-in for the owning session's per-session registry state (#206). Nested
+ * tools never receive it — they resolve from their own config root via
+ * `buildRegistryFor` — so tests assert it stays untouched.
+ */
+let sessionState: AgentTypeState;
 let manager: NestedAgentManager;
 let records: Map<string, any>;
 let spawn: ReturnType<typeof vi.fn>;
@@ -51,6 +57,7 @@ function tools(
     maxSubagentDepth,
     allowedSubagents,
     configCwd,
+    buildRegistryFor: (root) => buildAgentRegistry(loadCustomAgents(root)),
   });
 }
 
@@ -62,7 +69,8 @@ beforeEach(() => {
   cwd = mkdtempSync(join(tmpdir(), "nested-tools-test-"));
   writeAgent("scout");
   writeAgent("reviewer");
-  registerAgents(loadCustomAgents(cwd));
+  sessionState = createAgentTypeState();
+  sessionState.register(loadCustomAgents(cwd));
   records = new Map();
   spawn = vi.fn((_pi, _ctx, type, _prompt, options) => {
     const id = `child-${records.size + 1}`;
@@ -152,14 +160,14 @@ describe("child-safe nested Agent tools", () => {
     expect(spawnAndWait).toHaveBeenCalledTimes(1);
   });
 
-  it("resolves nested types without touching the process-global registry", async () => {
+  it("resolves nested types without touching the session's registry", async () => {
     // A worktree-isolated parent hands its own config root down. Resolving from
-    // it must not swap the registry the main session and every other agent read.
+    // it must not swap the registry the owning session and every other agent read.
     const otherCwd = mkdtempSync(join(tmpdir(), "nested-tools-config-"));
     const otherAgentDir = join(otherCwd, ".pi", "agents");
     mkdirSync(otherAgentDir, { recursive: true });
     writeFileSync(join(otherAgentDir, "branch-only.md"), "---\ndescription: branch-only\n---\nbranch-only\n");
-    const before = getAvailableTypes();
+    const before = sessionState.getAvailableTypes();
 
     try {
       const [agent] = tools("all", 1, 2, otherCwd);
@@ -172,8 +180,8 @@ describe("child-safe nested Agent tools", () => {
       // Resolved from the inherited root...
       expect(result.isError).toBe(false);
       // ...without leaking it into the shared registry.
-      expect(getAvailableTypes()).toEqual(before);
-      expect(getAvailableTypes()).not.toContain("branch-only");
+      expect(sessionState.getAvailableTypes()).toEqual(before);
+      expect(sessionState.getAvailableTypes()).not.toContain("branch-only");
     } finally {
       rmSync(otherCwd, { recursive: true, force: true });
     }
@@ -236,7 +244,7 @@ describe("child-safe nested Agent tools", () => {
 
   it("rejects unknown or disabled nested agent types instead of falling back", async () => {
     writeAgent("disabled", "enabled: false\n");
-    registerAgents(loadCustomAgents(cwd));
+    sessionState.register(loadCustomAgents(cwd));
     const [agent] = tools();
 
     for (const subagentType of ["missing", "disabled"]) {
@@ -340,21 +348,20 @@ describe("child-safe nested Agent tools", () => {
     // The contract nested delegation documents is "rejected rather than falling
     // back" — a top-level fallback must not hand a nested caller an agent its
     // allowlist never named.
-    setFallbackSubagent("scout");
-    try {
-      const [agent] = tools(["scout"]);
-      const result = await execute(agent, {
-        subagent_type: "definitely-missing",
-        description: "typo",
-        prompt: "Do work",
-      });
+    // The fallback policy lives in the owning session's state (#206), which
+    // nested tools never receive — so even a session configured to fall back
+    // cannot make a nested dispatch substitute an agent.
+    sessionState.setFallbackSubagent("scout");
+    const [agent] = tools(["scout"]);
+    const result = await execute(agent, {
+      subagent_type: "definitely-missing",
+      description: "typo",
+      prompt: "Do work",
+    });
 
-      expect(result.isError).toBe(true);
-      expect(result.content[0].text).toContain("Unknown or disabled nested agent type");
-      expect(spawnAndWait).not.toHaveBeenCalled();
-    } finally {
-      setFallbackSubagent(undefined);
-    }
+    expect(result.isError).toBe(true);
+    expect(result.content[0].text).toContain("Unknown or disabled nested agent type");
+    expect(spawnAndWait).not.toHaveBeenCalled();
   });
 
   it("hands the branch cap down to the child it spawns", async () => {
@@ -490,7 +497,7 @@ describe("child-safe nested Agent tools", () => {
 
       // The child's own frontmatter still wins.
       writeAgent("quiet", "output_transcript: false\n");
-      registerAgents(loadCustomAgents(cwd));
+      sessionState.register(loadCustomAgents(cwd));
       records.delete("child-1");
       await execute(agent, { subagent_type: "quiet", description: "untraced", prompt: "Do work" });
       expect(records.get("child-1").outputFile).toBeUndefined();

--- a/test/prompts.test.ts
+++ b/test/prompts.test.ts
@@ -1,5 +1,5 @@
 import { beforeEach, describe, expect, it } from "vitest";
-import { getAgentConfig, registerAgents } from "../src/agent-types.js";
+import { type AgentTypeState, createAgentTypeState } from "../src/agent-types.js";
 import { buildAgentPrompt } from "../src/prompts.js";
 import type { AgentConfig, EnvInfo } from "../src/types.js";
 
@@ -15,13 +15,15 @@ const envNoGit: EnvInfo = {
   platform: "linux",
 };
 
-// Initialize default agents
+// Initialize default agents — in a per-test state instance (#206)
+let state: AgentTypeState;
 beforeEach(() => {
-  registerAgents(new Map());
+  state = createAgentTypeState();
+  state.register(new Map());
 });
 
 function getDefaultConfig(name: string): AgentConfig {
-  return getAgentConfig(name)!;
+  return state.getAgentConfig(name)!;
 }
 
 describe("buildAgentPrompt", () => {

--- a/test/schedule-e2e.test.ts
+++ b/test/schedule-e2e.test.ts
@@ -15,8 +15,16 @@ import { mkdtempSync, readFileSync, rmSync } from "node:fs";
 import { tmpdir } from "node:os";
 import { join } from "node:path";
 import { afterEach, beforeEach, describe, expect, it, vi } from "vitest";
+import { createAgentTypeState } from "../src/agent-types.js";
 import { SubagentScheduler } from "../src/schedule.js";
 import { ScheduleStore } from "../src/schedule-store.js";
+
+/** Per-session registry state (#206), default agents registered. */
+const makeAgentTypes = () => {
+  const agentTypes = createAgentTypeState();
+  agentTypes.register(new Map());
+  return agentTypes;
+};
 
 type FakeRecord = { status: string; promise: Promise<string>; resolve: () => void };
 
@@ -87,7 +95,7 @@ describe("SubagentScheduler — end-to-end with real timers", () => {
   it("one-shot job: real setTimeout fires, agent runs, store reflects success", async () => {
     const manager = makeFaithfulManager("completed");
     const pi = makePi();
-    scheduler.start(pi, makeCtx(), manager, store);
+    scheduler.start(pi, makeCtx(), manager, store, makeAgentTypes(), () => new Map());
 
     // Fire ~100ms in the future. detectSchedule normalizes "+100ms" — but our
     // parser only accepts s/m/h/d, so use a near-future ISO timestamp instead.
@@ -116,7 +124,7 @@ describe("SubagentScheduler — end-to-end with real timers", () => {
   it("one-shot job that errors: store records lastStatus error (regression — bug #1)", async () => {
     const manager = makeFaithfulManager("error");  // Agent terminates with error status
     const pi = makePi();
-    scheduler.start(pi, makeCtx(), manager, store);
+    scheduler.start(pi, makeCtx(), manager, store, makeAgentTypes(), () => new Map());
 
     const future = new Date(Date.now() + 100).toISOString();
     const job = scheduler.addJob({
@@ -137,7 +145,7 @@ describe("SubagentScheduler — end-to-end with real timers", () => {
   it("interval job: fires repeatedly, runCount grows", async () => {
     const manager = makeFaithfulManager("completed");
     const pi = makePi();
-    scheduler.start(pi, makeCtx(), manager, store);
+    scheduler.start(pi, makeCtx(), manager, store, makeAgentTypes(), () => new Map());
 
     // 100ms interval — wait for ~3 fires
     const job = scheduler.addJob({
@@ -164,7 +172,7 @@ describe("SubagentScheduler — end-to-end with real timers", () => {
   it("persistence: schedules survive re-instantiating the store on the same file", async () => {
     const manager = makeFaithfulManager("completed");
     const pi = makePi();
-    scheduler.start(pi, makeCtx(), manager, store);
+    scheduler.start(pi, makeCtx(), manager, store, makeAgentTypes(), () => new Map());
 
     const future = new Date(Date.now() + 60_000).toISOString();  // far enough not to fire
     const job = scheduler.addJob({
@@ -186,7 +194,7 @@ describe("SubagentScheduler — end-to-end with real timers", () => {
   it("on-disk file shape: version=1 plus jobs array", async () => {
     const manager = makeFaithfulManager("completed");
     const pi = makePi();
-    scheduler.start(pi, makeCtx(), manager, store);
+    scheduler.start(pi, makeCtx(), manager, store, makeAgentTypes(), () => new Map());
 
     scheduler.addJob({
       name: "shape-test",
@@ -211,7 +219,7 @@ describe("SubagentScheduler — end-to-end with real timers", () => {
   it("subagents:scheduled events fire across the lifecycle", async () => {
     const manager = makeFaithfulManager("completed");
     const pi = makePi();
-    scheduler.start(pi, makeCtx(), manager, store);
+    scheduler.start(pi, makeCtx(), manager, store, makeAgentTypes(), () => new Map());
 
     const future = new Date(Date.now() + 100).toISOString();
     const job = scheduler.addJob({

--- a/test/schedule.test.ts
+++ b/test/schedule.test.ts
@@ -14,9 +14,19 @@ import { mkdtempSync, rmSync } from "node:fs";
 import { tmpdir } from "node:os";
 import { join } from "node:path";
 import { afterEach, beforeEach, describe, expect, it, vi } from "vitest";
-import { NO_FALLBACK, registerAgents, setFallbackSubagent } from "../src/agent-types.js";
+import { type AgentTypeState, createAgentTypeState, NO_FALLBACK } from "../src/agent-types.js";
+
 import { SubagentScheduler } from "../src/schedule.js";
 import { ScheduleStore } from "../src/schedule-store.js";
+
+// Per-session registry state (#206): the scheduler resolves fire-time types
+// against the owning session's state, handed to start().
+let agentTypes: AgentTypeState;
+const startScheduler = (scheduler: SubagentScheduler, pi: any, ctx: any, manager: any, store: any) => {
+  agentTypes = createAgentTypeState();
+  agentTypes.register(new Map());
+  scheduler.start(pi, ctx, manager, store, agentTypes, () => new Map());
+};
 
 function makeMockManager() {
   const spawnFn = vi.fn(() => "agent-" + Math.random().toString(36).slice(2, 10));
@@ -107,7 +117,7 @@ describe("SubagentScheduler — lifecycle", () => {
     manager = makeMockManager();
     pi = makeMockPi();
     ctx = makeMockCtx();
-    scheduler.start(pi, ctx, manager, store);
+    startScheduler(scheduler, pi, ctx, manager, store);
   });
 
   afterEach(() => {
@@ -216,7 +226,7 @@ describe("SubagentScheduler — lifecycle", () => {
     // Re-arm: stop drops timers, start re-reads store.list() and calls scheduleJob
     // for every enabled job → the past-branch fires for our seeded record.
     scheduler.stop();
-    scheduler.start(pi, ctx, manager, store);
+    startScheduler(scheduler, pi, ctx, manager, store);
 
     const reloaded = scheduler.list().find(j => j.id === "reload-test");
     expect(reloaded?.enabled).toBe(false);
@@ -243,16 +253,12 @@ describe("SubagentScheduler — fire path", () => {
     manager = makeMockManager();
     pi = makeMockPi();
     ctx = makeMockCtx();
-    scheduler.start(pi, ctx, manager, store);
+    startScheduler(scheduler, pi, ctx, manager, store);
   });
 
   afterEach(() => {
     scheduler.stop();
     vi.useRealTimers();
-    // Module-global: restore here, not at the end of a test body, so a failing
-    // assertion can't leak strict dispatch into every test that follows.
-    setFallbackSubagent(undefined);
-    registerAgents(new Map());
     rmSync(tmp, { recursive: true, force: true });
   });
 
@@ -272,8 +278,8 @@ describe("SubagentScheduler — fire path", () => {
   it("refuses at fire time when the job's agent type no longer resolves", () => {
     // The registry is what production populates at activation; a job outliving
     // its agent must not silently run something else (#183).
-    registerAgents(new Map());
-    setFallbackSubagent(NO_FALLBACK);
+    agentTypes.register(new Map());
+    agentTypes.setFallbackSubagent(NO_FALLBACK);
     const job = scheduler.addJob({
       name: "gone", description: "vanished agent", schedule: "+1s",
       subagent_type: "deleted-since", prompt: "run",

--- a/test/session-cwd-wiring.test.ts
+++ b/test/session-cwd-wiring.test.ts
@@ -1,0 +1,247 @@
+/**
+ * session-cwd-wiring.test.ts — proves per-session config discovery (#206)
+ * through the real extension, not just through the units.
+ *
+ * The bug: custom agents, `subagents.json`, and the Agent tool's advertised
+ * type list were derived from `process.cwd()`. In the CLI that IS the session
+ * cwd, but an embedding host (SDK) creates sessions whose workspace is not the
+ * directory the process started in — and can run several such sessions
+ * concurrently, where any process-wide registry is last-writer-wins.
+ *
+ * Three pins:
+ *   1. `session_start` with a diverging `ctx.cwd` rebuilds settings, agents,
+ *      and the Agent tool schema from the session's own tree.
+ *   2. In the CLI shape (ctx.cwd === process.cwd()) nothing re-runs — no
+ *      second tool registration, no second settings_loaded emit.
+ *   3. Two activations with different session cwds resolve their own agents,
+ *      concurrently, without one reload clobbering the other.
+ */
+import { mkdirSync, mkdtempSync, rmSync, writeFileSync } from "node:fs";
+import { tmpdir } from "node:os";
+import { join } from "node:path";
+import { afterEach, beforeEach, describe, expect, it, vi } from "vitest";
+
+vi.mock("../src/agent-runner.js", async () => {
+  const actual = await vi.importActual<typeof import("../src/agent-runner.js")>("../src/agent-runner.js");
+  return { ...actual, runAgent: vi.fn() };
+});
+
+import { runAgent } from "../src/agent-runner.js";
+import subagentsExtension from "../src/index.js";
+
+function makePi() {
+  const tools = new Map<string, any>();
+  const lifecycle = new Map<string, any>();
+  const pi = {
+    registerMessageRenderer: vi.fn(),
+    registerTool: vi.fn((t: any) => tools.set(t.name, t)),
+    registerCommand: vi.fn(),
+    on: vi.fn((event: string, handler: any) => lifecycle.set(event, handler)),
+    events: { emit: vi.fn(), on: vi.fn(() => vi.fn()) },
+    appendEntry: vi.fn(),
+    sendMessage: vi.fn(),
+  } as any;
+  return { pi, tools, lifecycle };
+}
+
+function makeCtx(cwd: string) {
+  return {
+    hasUI: false,
+    ui: { setStatus: vi.fn(), setWidget: vi.fn(), notify: vi.fn() },
+    cwd,
+    model: undefined,
+    modelRegistry: { find: vi.fn(), getAvailable: vi.fn(() => []) },
+    sessionManager: { getSessionId: vi.fn(() => "s1"), getBranch: vi.fn(() => []) },
+    getSystemPrompt: vi.fn(() => "parent"),
+  } as any;
+}
+
+function writeAgent(root: string, name: string): void {
+  const dir = join(root, ".pi", "agents");
+  mkdirSync(dir, { recursive: true });
+  writeFileSync(join(dir, `${name}.md`), `---\ndescription: ${name}\ntools: read\n---\n${name}.\n`);
+}
+
+const typeListOf = (tools: Map<string, any>): string =>
+  tools.get("Agent").parameters.properties.subagent_type.description;
+
+const settingsLoadedEmits = (pi: any): number =>
+  pi.events.emit.mock.calls.filter(([event]: [string]) => event === "subagents:settings_loaded").length;
+
+const agentRegistrations = (pi: any): number =>
+  pi.registerTool.mock.calls.filter(([t]: [any]) => t.name === "Agent").length;
+
+let dirA: string;
+let dirB: string;
+let originalCwd: string;
+let originalAgentDir: string | undefined;
+let originalHome: string | undefined;
+
+describe("per-session config discovery through the real extension (#206)", () => {
+  beforeEach(() => {
+    originalCwd = process.cwd();
+    dirA = mkdtempSync(join(tmpdir(), "session-cwd-a-"));
+    dirB = mkdtempSync(join(tmpdir(), "session-cwd-b-"));
+    writeAgent(dirA, "alpha");
+    writeAgent(dirB, "beta");
+    // dirB's own project settings — proves settings re-read from the session
+    // cwd: strict dispatch there refuses what its tree doesn't define.
+    mkdirSync(join(dirB, ".pi"), { recursive: true });
+    writeFileSync(join(dirB, ".pi", "subagents.json"), JSON.stringify({ fallbackSubagent: "none" }));
+    // Isolate global discovery so the dev's real agents/settings can't bleed in.
+    originalAgentDir = process.env.PI_CODING_AGENT_DIR;
+    originalHome = process.env.HOME;
+    process.env.PI_CODING_AGENT_DIR = join(dirA, "agent-dir");
+    process.env.HOME = dirA;
+    // The embedding-host shape: the process sits somewhere unrelated (dirA
+    // stands in for "the host's own directory"), sessions live elsewhere.
+    process.chdir(dirA);
+    vi.mocked(runAgent).mockReset();
+    vi.mocked(runAgent).mockResolvedValue({
+      responseText: "done", session: { dispose: vi.fn() } as any, aborted: false, steered: false,
+    } as any);
+  });
+
+  afterEach(() => {
+    delete (globalThis as any)[Symbol.for("pi-subagents:manager")];
+    process.chdir(originalCwd);
+    if (originalAgentDir == null) delete process.env.PI_CODING_AGENT_DIR;
+    else process.env.PI_CODING_AGENT_DIR = originalAgentDir;
+    if (originalHome == null) delete process.env.HOME;
+    else process.env.HOME = originalHome;
+    rmSync(dirA, { recursive: true, force: true });
+    rmSync(dirB, { recursive: true, force: true });
+  });
+
+  it("adopts a diverging session cwd: settings, agents, and the Agent tool schema rebuild from it", async () => {
+    const { pi, tools, lifecycle } = makePi();
+    subagentsExtension(pi);
+
+    // Activation ran with the provisional process cwd — dirA's roster.
+    expect(typeListOf(tools)).toContain("alpha");
+    expect(typeListOf(tools)).not.toContain("beta");
+
+    await lifecycle.get("session_start")({}, makeCtx(dirB));
+
+    // The tool was re-registered with the session's own roster...
+    expect(agentRegistrations(pi)).toBe(2);
+    expect(typeListOf(tools)).toContain("beta");
+    expect(typeListOf(tools)).not.toContain("alpha");
+
+    // ...its agents dispatch...
+    const ok = await tools.get("Agent").execute(
+      "tc-1",
+      { prompt: "go", description: "session agent", subagent_type: "beta" },
+      undefined, undefined, makeCtx(dirB),
+    );
+    expect(ok.isError).not.toBe(true);
+    expect(runAgent).toHaveBeenCalledWith(expect.anything(), "beta", "go", expect.anything());
+
+    // ...and the OTHER tree's agent does not — refused, not fallen back,
+    // because dirB's own subagents.json (fallbackSubagent: none) was applied.
+    vi.mocked(runAgent).mockClear();
+    const refused = await tools.get("Agent").execute(
+      "tc-2",
+      { prompt: "go", description: "foreign agent", subagent_type: "alpha" },
+      undefined, undefined, makeCtx(dirB),
+    );
+    expect(refused.content[0].text).toContain('Unknown or disabled agent type: "alpha"');
+    expect(runAgent).not.toHaveBeenCalled();
+  });
+
+  it("resets provisional-cwd policy at adoption: keys the session's tree omits return to defaults", async () => {
+    // The host's own directory carries policy the session's tree never named —
+    // both registry-shaping keys, since they are what this fix isolates.
+    writeFileSync(
+      join(dirA, ".pi", "subagents.json"),
+      JSON.stringify({ disableDefaultAgents: true, fallbackSubagent: "none" }),
+    );
+    writeFileSync(join(dirB, ".pi", "subagents.json"), JSON.stringify({}));
+    const { pi, tools, lifecycle } = makePi();
+    subagentsExtension(pi);
+
+    // Activation applied the provisional policy: no built-ins advertised.
+    expect(typeListOf(tools)).not.toContain("general-purpose");
+
+    await lifecycle.get("session_start")({}, makeCtx(dirB));
+
+    // Adoption reset the policy before re-applying: the built-ins are back...
+    expect(typeListOf(tools)).toContain("general-purpose");
+    // ...and dispatch falls back permissively (the historical default) instead
+    // of keeping the provisional cwd's fail-closed fallbackSubagent.
+    const fromUnknown = await tools.get("Agent").execute(
+      "tc-1",
+      { prompt: "go", description: "unknown type", subagent_type: "no-such-agent" },
+      undefined, undefined, makeCtx(dirB),
+    );
+    expect(fromUnknown.isError).not.toBe(true);
+    expect(runAgent).toHaveBeenCalledWith(expect.anything(), "general-purpose", "go", expect.anything());
+  });
+
+  it("surfaces a strict-load failure at adoption and still converges on the session's tree", async () => {
+    // The session's tree opts into strictness and carries a broken agent file
+    // (the unquoted second colon makes the frontmatter unparseable).
+    writeFileSync(join(dirB, ".pi", "subagents.json"), JSON.stringify({ strictAgentFiles: true }));
+    writeFileSync(join(dirB, ".pi", "agents", "broken.md"), "---\nname: broken\ndescription: Use this: that\n---\nBroken.\n");
+    const warn = vi.spyOn(console, "warn").mockImplementation(() => {});
+    const { pi, tools, lifecycle } = makePi();
+    subagentsExtension(pi);
+
+    // The strict startup load fails loudly (pi surfaces the handler's throw
+    // as an extension error)...
+    await expect(lifecycle.get("session_start")({}, makeCtx(dirB))).rejects.toThrow(/broken\.md/);
+
+    // ...but the adopted state stays self-consistent: every later reload is
+    // non-strict from the session cwd, so the advertised schema must already
+    // be the session's tree (minus the broken file), not the provisional
+    // roster dispatch could never reach again.
+    expect(typeListOf(tools)).toContain("beta");
+    expect(typeListOf(tools)).not.toContain("alpha");
+    warn.mockRestore();
+  });
+
+  it("is a no-op in the CLI shape: session_start with the process cwd re-registers nothing", async () => {
+    const { pi, lifecycle } = makePi();
+    subagentsExtension(pi);
+
+    const registrationsAtActivation = agentRegistrations(pi);
+    const settingsEmitsAtActivation = settingsLoadedEmits(pi);
+    expect(registrationsAtActivation).toBe(1);
+
+    await lifecycle.get("session_start")({}, makeCtx(process.cwd()));
+
+    expect(agentRegistrations(pi)).toBe(registrationsAtActivation);
+    expect(settingsLoadedEmits(pi)).toBe(settingsEmitsAtActivation);
+  });
+
+  it("two concurrent sessions resolve their own agents — no last-writer-wins", async () => {
+    // Two activations in one process, one per session, different projects.
+    const a = makePi();
+    subagentsExtension(a.pi);
+    await a.lifecycle.get("session_start")({}, makeCtx(dirA));
+
+    const b = makePi();
+    subagentsExtension(b.pi);
+    await b.lifecycle.get("session_start")({}, makeCtx(dirB));
+
+    // Each session advertises its own roster...
+    expect(typeListOf(a.tools)).toContain("alpha");
+    expect(typeListOf(a.tools)).not.toContain("beta");
+    expect(typeListOf(b.tools)).toContain("beta");
+    expect(typeListOf(b.tools)).not.toContain("alpha");
+
+    // ...and B's per-invocation reload does not clobber A's registry: A still
+    // dispatches alpha AFTER B has reloaded and dispatched beta.
+    await b.tools.get("Agent").execute(
+      "tc-b", { prompt: "go", description: "b", subagent_type: "beta" },
+      undefined, undefined, makeCtx(dirB),
+    );
+    vi.mocked(runAgent).mockClear();
+    const fromA = await a.tools.get("Agent").execute(
+      "tc-a", { prompt: "go", description: "a", subagent_type: "alpha" },
+      undefined, undefined, makeCtx(dirA),
+    );
+    expect(fromA.isError).not.toBe(true);
+    expect(runAgent).toHaveBeenCalledWith(expect.anything(), "alpha", "go", expect.anything());
+  });
+});

--- a/test/strict-agent-files-wiring.test.ts
+++ b/test/strict-agent-files-wiring.test.ts
@@ -12,7 +12,6 @@ import { mkdirSync, mkdtempSync, rmSync, writeFileSync } from "node:fs";
 import { tmpdir } from "node:os";
 import { join } from "node:path";
 import { afterEach, beforeEach, describe, expect, it, vi } from "vitest";
-import { registerAgents } from "../src/agent-types.js";
 import subagentsExtension from "../src/index.js";
 
 function makePi() {
@@ -73,7 +72,6 @@ describe("strictAgentFiles gates extension activation", () => {
     else process.env.PI_CODING_AGENT_DIR = originalAgentDir;
     if (originalHome == null) delete process.env.HOME;
     else process.env.HOME = originalHome;
-    registerAgents(new Map());
     rmSync(cwd, { recursive: true, force: true });
   });
 


### PR DESCRIPTION
Fixes #206 (thanks @adameq — this threads exactly the call sites you listed). Beyond
cwd-threading: an SDK host runs sessions concurrently, so per-session reloads into the
module-level registry would be last-writer-wins, and the `Agent` tool schema — built once per
activation — would advertise whichever directory loaded last. The fix moves the state, not just
the parameter, generalizing the registry pattern nested delegation already uses
(`buildAgentRegistry` + `*In`) to the main session.

## What changes

- **`agent-types.ts`** — the module singletons (`agents` map, `disableDefaults`,
  `fallbackSubagent`) become `createAgentTypeState()`: one instance per activation closure, same
  API surface, bound wrappers over the existing pure `*In` functions.
- **`index.ts`** — `sessionCwd` starts as `process.cwd()` and is adopted from `ctx.cwd` at
  `session_start` when they differ (compared `resolve()`d). Adoption resets settings to
  defaults, re-applies from the session tree, reloads agents, and re-registers the `Agent` tool
  so its description + `subagent_type` list rebuild from the session's registry. A strict-load
  failure during adoption converges registry + schema on the session tree before rethrowing.
- **`agent-runner.ts`** — dequeue-time config reads go through the registry the spawn was
  created with (live Map reference: queued spawns still observe mid-session reloads).
- **`schedule.ts`** — fire-time type resolution reads the owning session's state.
- **`settings.ts` / `enabled-models.ts`** — the `cwd: string = process.cwd()` parameter defaults
  are removed; cwd is required.
- **Bonus fix** — a nested spawn's runner read the *global* registry for its config while
  dispatch resolved from the branch root; nested spawns now carry their branch registry end to
  end.

Unchanged: discovery roots + precedence, frontmatter parsing, defaults handling, and all
CLI-observable behavior (the cwds never differ there — one registration, one `settings_loaded`,
byte-identical).

## Review

Commit 1 is the logic; commit 2 is a whitespace-only re-indent of the wrapped Agent-tool
registration (empty under `git diff -w`).

## Tests

New `test/session-cwd-wiring.test.ts`: ① adoption rebuilds settings + agents + schema from the
session tree; ② the CLI shape re-registers nothing and emits no second `settings_loaded`;
③ two concurrent activations don't clobber each other (fails on master by construction).
Per-state pins added to `agent-types.test.ts`. The old nested-isolation assertion in
`nested-tools.test.ts` is now near-tautological (its hazard is unrepresentable by design) —
kept as documentation.

## Known limitations (out of scope, disclosed)

- The `Symbol.for("pi-subagents:manager")` globalThis slot stays first-activation-wins across
  concurrent sessions (the events-bus RPC is per-session and unaffected).
- Remaining module-level settings state (settings bleed only, no definition injection):
  `defaultMaxTurns`/`graceTurns`, `scopeModelsEnabled`, `maxSubagentDepth`,
  `outputTranscriptDefault`, warn-dedup sets, enabled-models cache.
- The embedded path emits `subagents:settings_loaded` twice (provisional, then adoption); the
  CLI sees exactly one, as before.
- `SpawnOptions.registry` is required but `buildRegistryFor` is optional with a behavior-bearing
  default; all production paths pass both — happy to require the pair if preferred.

## Verification

`lint` 0 errors · `typecheck` clean · `npm test` 854 passed / 5 skipped (master baseline 846) ·
`build` OK — plus a two-session SDK harness: stock build reproduces #206; patched build resolves
each session's own tree, no cross-session bleed; a real delegation to a project-local agent
round-trips.

CHANGELOG untouched per CONTRIBUTING.
