### PR TITLE
fix: fire session_shutdown before disposing child sessions

### DIFF
--- a/src/agent-manager.ts
+++ b/src/agent-manager.ts
@@ -147,6 +147,41 @@ interface ResumeOptions {
   onStarted?: () => void;
 }
 
+/**
+ * Fire session_shutdown on a child session's extension runner, then dispose it.
+ *
+ * WHY (hack, not a pi-core fix): pi's `AgentSession.dispose()` invalidates the
+ * extension runner WITHOUT emitting `session_shutdown` — the lifecycle stop
+ * event extensions use to close session-scoped resources (heartbeats, open
+ * connections). `AgentSessionRuntime.dispose()` emits it before disposing;
+ * `AgentSession.dispose()` does not. Extensions that keep touching their ctx
+ * after invalidation throw "This extension ctx is stale after session
+ * replacement or reload", surfacing as an uncaughtException that can take the
+ * whole process down (seen with @4fu/pi-pwsh). Emitting the event ourselves via
+ * the public `session.extensionRunner` getter reproduces what
+ * `AgentSessionRuntime.dispose()` does, without a pi-core change.
+ *
+ * Order matters: the emit must resolve BEFORE dispose(), so a shutdown handler
+ * finishes (stopping its heartbeat) before the runner is invalidated. A handler
+ * that hangs blocks disposal — the same behavior as AgentSessionRuntime.dispose().
+ */
+async function disposeSession(session: AgentSession | undefined): Promise<void> {
+  if (!session) return;
+  const runner = session.extensionRunner;
+  if (runner) {
+    try {
+      await runner.emit({ type: "session_shutdown", reason: "quit" });
+    } catch {
+      // A throwing handler must not block disposal or crash the parent.
+    }
+  }
+  try {
+    session.dispose();
+  } catch {
+    // dispose() is best-effort cleanup.
+  }
+}
+
 export class AgentManager {
   private agents = new Map<string, AgentRecord>();
   private cleanupInterval: ReturnType<typeof setInterval>;
@@ -759,11 +794,13 @@ export class AgentManager {
     return true;
   }
 
-  /** Dispose a record's session and remove it from the map. */
+  /** Dispose a record's session (firing session_shutdown first) and remove it from the map. */
   private removeRecord(id: string, record: AgentRecord): void {
-    record.session?.dispose?.();
+    const session = record.session;
+    // Eager detach: a second removeRecord/dispose must not re-emit on this session.
     record.session = undefined;
     this.agents.delete(id);
+    void disposeSession(session);
   }
 
   private cleanup() {
@@ -840,10 +877,13 @@ export class AgentManager {
     clearInterval(this.cleanupInterval);
     // Clear queue
     this.queue = [];
-    for (const record of this.agents.values()) {
-      record.session?.dispose();
-    }
+    const sessions = [...this.agents.values()]
+      .map(record => record.session)
+      .filter((session): session is AgentSession => session !== undefined);
+    // Eager detach before the async emit so a concurrent removeRecord can't re-emit.
+    for (const record of this.agents.values()) record.session = undefined;
     this.agents.clear();
+    void Promise.all(sessions.map(disposeSession));
     // Prune any orphaned git worktrees (crash recovery)
     try { pruneWorktrees(process.cwd()); } catch { /* ignore */ }
     // Also prune repos that caller-supplied cwds created worktrees in — a clean

--- a/test/agent-manager.test.ts
+++ b/test/agent-manager.test.ts
@@ -484,6 +484,37 @@ describe("AgentManager — Bug 3 clearCompleted", () => {
     expect(disposeSpy).toHaveBeenCalledOnce();
   });
 
+  it("fires session_shutdown before disposing a session with extensions", async () => {
+    manager = new AgentManager();
+    const order: string[] = [];
+    const sess = {
+      extensionRunner: {
+        emit: vi.fn(async () => {
+          order.push("shutdown");
+        }),
+      },
+      dispose: vi.fn(() => {
+        order.push("dispose");
+      }),
+    };
+    vi.mocked(runAgent).mockResolvedValue({
+      responseText: "done",
+      session: sess as any,
+      aborted: false,
+      steered: false,
+    });
+
+    const id = manager.spawn(mockPi, mockCtx, "general-purpose", "test", {
+      description: "test",
+      isBackground: true,
+    });
+    await manager.getRecord(id)!.promise;
+
+    manager.clearCompleted();
+    // clearCompleted is sync; the emit/dispose chain runs on a microtask.
+    await vi.waitFor(() => expect(order).toEqual(["shutdown", "dispose"]));
+  });
+
   it("clearCompleted removes error and stopped records", async () => {
     manager = new AgentManager();
     vi.mocked(runAgent).mockRejectedValue(new Error("boom"));


### PR DESCRIPTION
## Problem

Disposing an in-process child `AgentSession` can crash the whole pi process with
an uncaught `This extension ctx is stale after session replacement or reload`.
Reproduced with `@4fu/pi-pwsh`: it keeps a session-scoped heartbeat that touches
its ctx, and the throw lands after the subagent is done with the session, so
nothing catches it.

## Root cause

pi's `AgentSessionRuntime.dispose()` emits `session_shutdown` before invalidating
the extension runner; plain `AgentSession.dispose()` does not. Subagents build
child sessions via `createAgentSession` directly, so their extensions never get
the stop event and keep touching a stale ctx.

## Fix

Emit `session_shutdown` (reason `quit`) on the child's extension runner before
disposing, mirroring `AgentSessionRuntime.dispose()`:

- await the emit so shutdown handlers finish (stop heartbeats) before the runner
  is invalidated
- detach the session from the record before the async emit so a concurrent
  remove/dispose can't double-fire
- swallow handler/dispose errors so they can't block disposal or escape as
  unhandled rejections

## Caveat

This relies on the undocumented `session.extensionRunner.emit` seam. The durable
fix is pi-core exposing `AgentSession.shutdown()`; tracked separately.

## Tests

`test/agent-manager.test.ts` — "fires session_shutdown before disposing a
session with extensions" pins the `shutdown` → `dispose` ordering.
