### PR TITLE
feat: send foreground agents to background

### DIFF
--- a/README.md
+++ b/README.md
@@ -16,7 +16,7 @@ https://github.com/user-attachments/assets/8685261b-9338-4fea-8dfe-1c590d5df543
 - **Parallel background agents** — spawn multiple agents that run concurrently with automatic queuing (configurable concurrency limit, default 4) and smart group join (consolidated notifications)
 - **Live widget UI** — persistent above-editor widget with animated spinners, live tool activity, token counts, and colored status icons. Configurable via `/agents → Settings → Widget`: `all` (every agent), `background` (default — hides foreground runs, which already render inline as the `Agent` tool result), or `off`
 - **FleetView** — Claude Code-style navigable list of `main` + every running subagent rendered below the editor (earliest-launched first). Press `↓` (or `←`) at an empty prompt to jump in, `↑`/`↓` to move the selection, `Enter` to open the selected agent's live, auto-updating conversation, `Esc` to return. Finished agents linger briefly before dropping out, and a viewer stays open through completion so you can read the final output. Toggle via `/agents → Settings → Fleet view`
-- **Conversation viewer** — select any agent in `/agents` to open a live-scrolling overlay of its full conversation (auto-follows new content, scroll up to pause). Steer a running agent inline by pressing `Enter` to open a composer, typing, then `Enter` to send (`Esc` or an empty submit returns) — the message appears as a user message and redirects the agent after its current tool. Stop a still-running agent by pressing `x` (then `x` again to confirm) — both work for background agents too
+- **Conversation viewer** — select any agent in `/agents` to open a live-scrolling overlay of its full conversation (auto-follows new content, scroll up to pause). Steer a running agent inline by pressing `Enter` to open a composer, typing, then `Enter` to send (`Esc` or an empty submit returns) — the message appears as a user message and redirects the agent after its current tool. Press `b` on a live foreground run to send that same session and in-flight work to the background, or stop a still-running agent by pressing `x` (then `x` again to confirm)
 - **Custom agent types** — define agents in `.pi/agents/<name>.md` or `.agents/agents/<name>.md` (project) or globally, with YAML frontmatter: custom system prompts, model selection, thinking levels, tool restrictions, and Claude Code-compatible colored name badges
 - **Nested subagents** — opt-in, default-off delegation: a custom agent that sets `allowed_subagents` gets its own ownership-scoped `Agent`, `get_subagent_result`, and `steer_subagent` tools, depth-capped from the main session (default 2). It can control only its own children, they are stopped when it finishes, and their transcripts and token spend roll up to it. The allowlist is a privilege boundary — a child runs with its own tools, so pick it as carefully as `tools:` itself
 - **Agent mentions** — subagents are first-class: type `@explore also check the RPC path` at the prompt and it goes to that agent instead of the main model, without a word of it entering the chat. One syntax covers the whole lifecycle — message it while it runs, resume it once it has finished, reopen its session from disk long after that, or start it if it never ran. Mentioning an agent that isn't running spawns it through an off-screen clone of the conversation, so it gets Claude Code's context-written prompt and a real `Agent` tool call without a word of it reaching the chat; `direct` mode starts it here from your text instead, with no model call at all. The orchestrator can `name` an agent so you address it as `@auth-audit`, and handles work in `steer_subagent`/`get_subagent_result` too. `@` completes live agents, resumable ones, and startable types alongside pi's file completion; `@main` forces text back to the main model. Toggle via `/agents → Settings → Agent mentions`
@@ -61,7 +61,7 @@ Agent({
 })
 ```
 
-Foreground agents block until complete and return results inline. Background agents return an ID immediately and notify you on completion.
+Foreground agents block until complete and return results inline by default. A live foreground run can be sent to the background with `b` in its conversation viewer or by the optional `foregroundTimeoutMs` setting; the same run continues and returns its ID. Background agents return an ID immediately and notify you on completion.
 
 ### Scheduling
 
@@ -127,7 +127,7 @@ While subagents are running, a Claude Code-style navigable list renders **below*
                                                                                    ↓ 3 more
 ```
 
-The list is ordered earliest-launched first, and only shows agents you can actually open (pending/queued agents with no session yet appear once they start). At an **empty prompt**, press `↓` (or `←`) to move focus from the prompt into the list — the selected row is marked `●`, the rest `○`. `↑`/`↓` move the selection, `Enter` opens the selected agent's live conversation overlay (it auto-updates as the agent works), and `Esc` (or `↑` above `main`) returns to the prompt. Selecting `main` returns to the normal view. Inside the overlay, press `Enter` to steer the running agent — type a message and `Enter` to send it (`Esc` or an empty submit returns), and it redirects the agent the same way the `steer_subagent` tool does. A viewer stays open when its agent finishes so you can read the final output, and finished agents linger in the list for a few seconds before dropping out. Typing anything at a non-empty prompt behaves normally — the list only captures arrow keys when the prompt is empty. Disable it entirely via `/agents → Settings → Fleet view`.
+The list is ordered earliest-launched first, and only shows agents you can actually open (pending/queued agents with no session yet appear once they start). At an **empty prompt**, press `↓` (or `←`) to move focus from the prompt into the list — the selected row is marked `●`, the rest `○`. `↑`/`↓` move the selection, `Enter` opens the selected agent's live conversation overlay (it auto-updates as the agent works), and `Esc` (or `↑` above `main`) returns to the prompt. Selecting `main` returns to the normal view. Inside the overlay, press `Enter` to steer the running agent — type a message and `Enter` to send it (`Esc` or an empty submit returns), and it redirects the agent the same way the `steer_subagent` tool does. For a currently-running foreground Agent call, press `b` to send that same live run to the background; the foreground tool call returns its agent ID, and the child continues without a restart. The `b` hint is hidden for background, queued, and finished agents. A viewer stays open when its agent finishes so you can read the final output, and finished agents linger in the list for a few seconds before dropping out. Typing anything at a non-empty prompt behaves normally — the list only captures arrow keys when the prompt is empty. Disable it entirely via `/agents → Settings → Fleet view`.
 
 ### Agent mentions
 
@@ -436,10 +436,10 @@ The `/agents` command opens an interactive menu:
 Running agents (2) — 1 running, 1 done     ← only shown when agents exist
 Agent types (6)                             ← unified list: defaults + custom
 Create new agent                            ← manual wizard or AI-generated
-Settings                                    ← max concurrency, max turns, grace turns, join mode
+Settings                                    ← max concurrency, foreground timeout, max turns, grace turns, join mode
 ```
 
-- **Running agents** — select one to open its live conversation viewer. While it's still running, press `Enter` to open the steering composer, then `Enter` again to send a message that redirects the agent (same mechanism as the `steer_subagent` tool; `Esc` or an empty submit returns), or press `x` (then `x` again to confirm) to stop/abort it — including **background** agents, which a global Esc can't unambiguously target (Esc still stops a blocking foreground `Agent` call). A stopped agent reports its partial output flagged as incomplete, not as a completion.
+- **Running agents** — select one to open its live conversation viewer. While it's still running, press `Enter` to open the steering composer, then `Enter` again to send a message that redirects the agent (same mechanism as the `steer_subagent` tool; `Esc` or an empty submit returns). On a live foreground run, press `b` to send the same session and in-flight work to the background without stopping or restarting it. Press `x` (then `x` again to confirm) to stop/abort it — including **background** agents, which a global Esc can't unambiguously target (Esc still stops a blocking foreground `Agent` call before detachment). A stopped agent reports its partial output flagged as incomplete, not as a completion.
 - **Agent types** — unified list with source indicators: `•` (project), `◦` (global), `✕` (disabled). Each row shows the agent's model, and the highlighted agent's full description appears below the list. The model column flags `(unavailable, fallback: inherit)` when a configured model can't be resolved (it would silently inherit the parent model), and shows `(→ provider/id)` when it resolves to a different provider or version than configured. Select an agent to manage it:
   - **Default agents** (no override): Eject (export as `.md`), Disable
   - **Default agents** (ejected/overridden): Edit, Disable, Reset to default, Delete
@@ -448,7 +448,7 @@ Settings                                    ← max concurrency, max turns, grac
 - **Eject** — writes the embedded default config as a `.md` file to project or personal location, so you can customize it
 - **Disable/Enable** — toggle agent availability. Disabled agents stay visible in the list (marked `✕`) and can be re-enabled
 - **Create new agent** — choose project/personal location, then manual wizard (step-by-step prompts for name, tools, model, thinking, system prompt) or AI-generated (describe what the agent should do and a sub-agent writes the `.md` file). Any name is allowed, including default agent names (overrides them)
-- **Settings** — configure max concurrency, default max turns, grace turns, and join mode at runtime
+- **Settings** — configure max concurrency, foreground timeout, default max turns, grace turns, and join mode at runtime
 
 ## Graceful Max Turns
 
@@ -469,7 +469,7 @@ Instead of hard-aborting at the turn limit, agents get a graceful shutdown:
 
 Background agents are subject to a configurable concurrency limit (default: 4). Excess agents are automatically queued and start as running agents complete. The widget shows queued agents as a collapsed count.
 
-Foreground agents bypass the queue — they block the parent anyway.
+Foreground agents bypass the queue — they block the parent anyway. If a live foreground run is sent to the background while all slots are full, it keeps running and counts as an extra occupied slot. New queued work does not start until the running count drops below the configured limit.
 
 ## Join Strategies
 
@@ -510,12 +510,14 @@ When on, each subagent spawn's effective model is validated against pi's own `en
 
 ## Persistent Settings
 
-Runtime tuning values set via `/agents` → Settings (max concurrency, default max turns, grace turns, nested depth, fallback agent, default join mode, scheduling on/off, scope models on/off, disable defaults on/off, strict agent files on/off, agent mentions on/off, output transcript on/off, tool description full/compact/custom, widget all/background/off) persist across pi restarts. Two files, merged on load:
+Runtime tuning values set via `/agents` → Settings (max concurrency, foreground timeout, default max turns, grace turns, nested depth, fallback agent, default join mode, scheduling on/off, scope models on/off, disable defaults on/off, strict agent files on/off, agent mentions on/off, output transcript on/off, tool description full/compact/custom, widget all/background/off) persist across pi restarts. Two files, merged on load:
 
 - **Global:** `~/.pi/agent/subagents.json` — your machine-wide defaults. Edit by hand; the `/agents` menu never writes here.
 - **Project:** `<cwd>/.pi/subagents.json` — per-project overrides. Written by `/agents` → Settings.
 
-**Precedence:** project overrides global on any field present in both. Missing fields fall back to the hardcoded defaults (max concurrency `4`, default max turns unlimited, grace turns `5`, nested depth `2`, join mode `smart`, defaults enabled).
+**Precedence:** project overrides global on any field present in both. Missing fields fall back to the hardcoded defaults (max concurrency `4`, foreground timeout disabled, default max turns unlimited, grace turns `5`, nested depth `2`, join mode `smart`, defaults enabled).
+
+**Foreground timeout** (`foregroundTimeoutMs`, default `0`): the number of milliseconds a top-level foreground Agent run can block before it is sent to the background. `0` or a missing field disables the timeout and preserves normal blocking behavior. The same child session and in-flight work continue; the foreground tool call returns the agent ID and later receives the normal background completion notification. Frontmatter `run_in_background` and explicit `run_in_background: true` launches keep their current immediate background behavior. Also settable from `/agents → Settings → Foreground timeout`.
 
 **Nested depth** (`maxSubagentDepth`, default `2`): the hard ceiling on [nested delegation](#nested-subagents), counted from the main session (main = 0, its subagents = 1). `0` or `1` disables nesting project-wide regardless of any agent's `allowed_subagents`. Read when a subagent session is built, so a change applies to agents started after it.
 

--- a/src/agent-manager.ts
+++ b/src/agent-manager.ts
@@ -25,6 +25,8 @@ export type CompactionInfo = { reason: "manual" | "threshold" | "overflow"; toke
 
 /** Default max concurrent background agents. */
 const DEFAULT_MAX_CONCURRENT = 4;
+/** Largest delay Node timers accept without overflowing to an immediate timer. */
+const MAX_FOREGROUND_TIMEOUT_MS = 2_147_483_647;
 
 /**
  * How many evicted agents stay addressable by name. Only a bound on memory —
@@ -130,6 +132,11 @@ interface SpawnOptions {
   invocation?: AgentInvocation;
   /** Parent abort signal — when aborted, the subagent is also stopped. */
   signal?: AbortSignal;
+  /**
+   * Foreground-only timeout before the same live run is sent to the background.
+   * `undefined` uses the manager default; `0` disables it for this spawn.
+   */
+  foregroundTimeoutMs?: number;
   /** Called on tool start/end with activity info (for streaming progress to UI). */
   onToolActivity?: (activity: ToolActivity) => void;
   /** Called on streaming text deltas from the assistant response. */
@@ -203,6 +210,16 @@ export class AgentManager {
   private queue: { id: string; start: () => void }[] = [];
   /** Number of currently running background agents. */
   private runningBackground = 0;
+  /** Top-level records that currently occupy a background pool slot. */
+  private poolSlots = new Set<string>();
+  /** Parent AbortSignal listener cleanup, removable when a foreground run detaches. */
+  private parentSignalCleanups = new Map<string, () => void>();
+  /** Resolves spawnAndWait as soon as its live foreground run detaches. */
+  private foregroundDetachWaiters = new Map<string, () => void>();
+  /** 0 disables automatic foreground detachment. */
+  private foregroundTimeoutMs = 0;
+  /** Shared settlement for repeated shutdown requests. */
+  private shutdownSettlement?: Promise<void>;
 
   constructor(
     onComplete?: OnAgentComplete,
@@ -228,6 +245,38 @@ export class AgentManager {
 
   getMaxConcurrent(): number {
     return this.maxConcurrent;
+  }
+
+  /** Set the default foreground timeout. `0` disables automatic detachment. */
+  setForegroundTimeoutMs(ms: number): void {
+    this.foregroundTimeoutMs = Number.isFinite(ms)
+      ? Math.min(MAX_FOREGROUND_TIMEOUT_MS, Math.max(0, Math.trunc(ms)))
+      : 0;
+  }
+
+  getForegroundTimeoutMs(): number {
+    return this.foregroundTimeoutMs;
+  }
+
+  /** Count a top-level background run once, including a detached foreground run. */
+  private acquirePoolSlot(record: AgentRecord): void {
+    if (!occupiesPoolSlot(record) || this.poolSlots.has(record.id)) return;
+    this.poolSlots.add(record.id);
+    this.runningBackground++;
+  }
+
+  /** Release a top-level background slot once. */
+  private releasePoolSlot(record: AgentRecord): void {
+    if (!this.poolSlots.delete(record.id)) return;
+    this.runningBackground--;
+  }
+
+  /** Remove the parent interrupt listener without aborting the child. */
+  private detachParentSignal(id: string): void {
+    const cleanup = this.parentSignalCleanups.get(id);
+    if (!cleanup) return;
+    this.parentSignalCleanups.delete(id);
+    cleanup();
   }
 
   /**
@@ -345,17 +394,20 @@ export class AgentManager {
 
     record.status = "running";
     record.startedAt = Date.now();
-    if (occupiesPoolSlot(record)) this.runningBackground++;
+    this.acquirePoolSlot(record);
     this.onStart?.(record);
 
-    // Wire parent abort signal to stop the subagent when the parent is interrupted
-    let detachParentSignal: (() => void) | undefined;
+    // Wire parent abort signal to stop the subagent when the parent is interrupted.
+    // A foreground-to-background detach removes this listener while the run stays live.
     if (options.signal) {
-      const onParentAbort = () => this.abort(id);
-      options.signal.addEventListener("abort", onParentAbort, { once: true });
-      detachParentSignal = () => options.signal!.removeEventListener("abort", onParentAbort);
+      if (options.signal.aborted) {
+        this.abort(id);
+      } else {
+        const onParentAbort = () => this.abort(id);
+        options.signal.addEventListener("abort", onParentAbort, { once: true });
+        this.parentSignalCleanups.set(id, () => options.signal!.removeEventListener("abort", onParentAbort));
+      }
     }
-    const detach = () => { detachParentSignal?.(); detachParentSignal = undefined; };
 
     const promise = runAgent(ctx, type, prompt, {
       pi,
@@ -439,7 +491,7 @@ export class AgentManager {
         record.session = session;
         record.completedAt ??= Date.now();
 
-        detach();
+        this.detachParentSignal(id);
 
         // Final flush of streaming output file
         if (record.outputCleanup) {
@@ -462,13 +514,13 @@ export class AgentManager {
 
         this.abortOwnedChildren(id);
 
-        // Fire onComplete for foreground agents too — lifecycle symmetry.
-        // Mark resultConsumed so the callback skips notifications (result returned inline).
-        if (!options.isBackground) {
+        // Read the live record mode, not the spawn-time option: a foreground run
+        // can become background while this same promise is still in flight.
+        if (!record.isBackground) {
           record.resultConsumed = true;
           try { this.onComplete?.(record); } catch { /* ignore completion side-effect errors */ }
         } else {
-          if (occupiesPoolSlot(record)) this.runningBackground--;
+          this.releasePoolSlot(record);
           try { this.onComplete?.(record); } catch { /* ignore completion side-effect errors */ }
           this.drainQueue();
         }
@@ -482,7 +534,7 @@ export class AgentManager {
         record.error = err instanceof Error ? err.message : String(err);
         record.completedAt ??= Date.now();
 
-        detach();
+        this.detachParentSignal(id);
 
         // Final flush of streaming output file on error
         if (record.outputCleanup) {
@@ -500,14 +552,13 @@ export class AgentManager {
 
         this.abortOwnedChildren(id);
 
-        // Fire onComplete for foreground agents too — lifecycle symmetry.
-        // Mark resultConsumed so the callback skips notifications (result returned inline).
-        if (!options.isBackground) {
+        // Read the live record mode, as on the success path above.
+        if (!record.isBackground) {
           record.resultConsumed = true;
-          this.onComplete?.(record);
+          try { this.onComplete?.(record); } catch { /* ignore completion side-effect errors */ }
         } else {
-          if (occupiesPoolSlot(record)) this.runningBackground--;
-          this.onComplete?.(record);
+          this.releasePoolSlot(record);
+          try { this.onComplete?.(record); } catch { /* ignore completion side-effect errors */ }
           this.drainQueue();
         }
         return "";
@@ -588,8 +639,51 @@ export class AgentManager {
       this.onSpawned = prevOnSpawned;
     }
     const record = this.agents.get(id)!;
-    await record.promise;
+    let resolveDetached!: () => void;
+    const detached = new Promise<void>((resolve) => { resolveDetached = resolve; });
+    this.foregroundDetachWaiters.set(id, resolveDetached);
+
+    const timeoutMs = options.parentAgentId === undefined
+      ? options.foregroundTimeoutMs ?? this.foregroundTimeoutMs
+      : 0;
+    const timeout = timeoutMs > 0
+      ? setTimeout(() => this.detachForeground(id), timeoutMs)
+      : undefined;
+    timeout?.unref();
+
+    try {
+      await Promise.race([record.promise, detached]);
+    } finally {
+      if (timeout) clearTimeout(timeout);
+      if (this.foregroundDetachWaiters.get(id) === resolveDetached) {
+        this.foregroundDetachWaiters.delete(id);
+      }
+    }
     return { id, record };
+  }
+
+  /**
+   * Send a running top-level foreground agent to the background without changing
+   * its session, promise, or abort controller. Returns false when the transition
+   * is no longer valid or already happened.
+   */
+  detachForeground(id: string): boolean {
+    const record = this.agents.get(id);
+    if (
+      !record
+      || record.parentAgentId !== undefined
+      || record.status !== "running"
+      || record.isBackground !== false
+    ) {
+      return false;
+    }
+
+    this.detachParentSignal(id);
+    record.isBackground = true;
+    record.resultConsumed = false;
+    this.acquirePoolSlot(record);
+    this.foregroundDetachWaiters.get(id)?.();
+    return true;
   }
 
   /**
@@ -700,7 +794,7 @@ export class AgentManager {
 
     record.status = "running";
     record.startedAt = Date.now();
-    if (occupiesPoolSlot(record)) this.runningBackground++;
+    this.acquirePoolSlot(record);
     this.onStart?.(record);
 
     // Fresh abort controller so /agents stop and steering target THIS run rather
@@ -732,7 +826,7 @@ export class AgentManager {
       }
       // Children spawned during the resumed turn must not outlive it.
       this.abortOwnedChildren(id);
-      if (occupiesPoolSlot(record)) this.runningBackground--;
+      this.releasePoolSlot(record);
       try { this.onComplete?.(record); } catch { /* ignore completion side-effect errors */ }
       this.drainQueue();
     };
@@ -989,6 +1083,26 @@ export class AgentManager {
     return count;
   }
 
+  /**
+   * Stop all work, release foreground tool calls, and settle the promises that
+   * existed when shutdown began. The caller owns the bounded fallback because
+   * it also owns the final manager and UI disposal order.
+   */
+  stopForShutdown(): Promise<void> {
+    if (this.shutdownSettlement) return this.shutdownSettlement;
+
+    const inFlight = [...this.agents.values()]
+      .map(record => record.promise)
+      .filter((promise): promise is Promise<string> => promise !== undefined);
+
+    this.abortAll();
+    for (const resolveDetached of this.foregroundDetachWaiters.values()) resolveDetached();
+    this.foregroundDetachWaiters.clear();
+
+    this.shutdownSettlement = Promise.allSettled(inFlight).then(() => {});
+    return this.shutdownSettlement;
+  }
+
   /** Wait for all running and queued agents to complete (including queued ones). */
   async waitForAll(): Promise<void> {
     // Loop because drainQueue respects the concurrency limit — as running
@@ -1006,9 +1120,17 @@ export class AgentManager {
 
   dispose() {
     clearInterval(this.cleanupInterval);
+    for (const id of this.parentSignalCleanups.keys()) this.detachParentSignal(id);
+    this.foregroundDetachWaiters.clear();
+    this.poolSlots.clear();
+    this.runningBackground = 0;
     // Clear queue
     this.queue = [];
     for (const record of this.agents.values()) {
+      if (record.outputCleanup) {
+        try { record.outputCleanup(); } catch { /* ignore */ }
+        record.outputCleanup = undefined;
+      }
       record.session?.dispose();
     }
     this.agents.clear();

--- a/src/agent-runner.ts
+++ b/src/agent-runner.ts
@@ -539,6 +539,10 @@ function finalTurnError(session: AgentSession, startIndex = 0): string | undefin
  */
 function forwardAbortSignal(session: AgentSession, signal?: AbortSignal): () => void {
   if (!signal) return () => {};
+  if (signal.aborted) {
+    session.abort();
+    return () => {};
+  }
   const onAbort = () => session.abort();
   signal.addEventListener("abort", onAbort, { once: true });
   return () => signal.removeEventListener("abort", onAbort);

--- a/src/index.ts
+++ b/src/index.ts
@@ -34,7 +34,7 @@ import { getMaxSubagentDepth, setMaxSubagentDepth } from "./nested-tools.js";
 import { createOutputFilePath, ensureOutputFile, getOutputTranscriptDefault, setOutputTranscriptDefault, streamToOutputFile, writeInitialEntry } from "./output-file.js";
 import { SubagentScheduler } from "./schedule.js";
 import { resolveStorePath, ScheduleStore } from "./schedule-store.js";
-import { applyAndEmitLoaded, loadSettings, type SubagentsSettings, saveAndEmitChanged, type ToolDescriptionMode } from "./settings.js";
+import { applyAndEmitLoaded, FOREGROUND_TIMEOUT_CEILING_MS, loadSettings, type SubagentsSettings, saveAndEmitChanged, type ToolDescriptionMode } from "./settings.js";
 import { getForegroundOutcomeNote, getStatusNote, partialOutputSuffix } from "./status-note.js";
 import { type AgentConfig, type AgentInvocation, type AgentMentionMode, type AgentRecord, type JoinMode, type NotificationDetails, type SubagentType, type WidgetMode } from "./types.js";
 import { createMentionProvider, mentionRoster, type TypeInfo } from "./ui/agent-mention.js";
@@ -61,6 +61,13 @@ import { selectItem } from "./ui/select-item.js";
 import { addUsage, getLifetimeTotal, getSessionContextPercent, type LifetimeUsage } from "./usage.js";
 
 // ---- Shared helpers ----
+
+/**
+ * Abort-aware runners normally settle at once. One second still allows their
+ * transcript and worktree cleanup to finish without letting a hung provider or
+ * tool block host shutdown forever.
+ */
+const SHUTDOWN_SETTLEMENT_TIMEOUT_MS = 1_000;
 
 /** Tool execute return value for a text response. */
 function textResult(msg: string, details?: AgentDetails) {
@@ -338,6 +345,8 @@ export default function (pi: ExtensionAPI) {
   // ---- Agent activity tracking + widget ----
   const agentActivity = new Map<string, AgentActivity>();
 
+  let shuttingDown = false;
+
   // ---- Cancellable pending notifications ----
   // Holds notifications briefly so get_subagent_result can cancel them
   // before they reach pi.sendMessage (fire-and-forget).
@@ -348,9 +357,11 @@ export default function (pi: ExtensionAPI) {
   const QUEUE_WAIT_POLL_MS = Math.floor(NUDGE_HOLD_MS / 4);
 
   function scheduleNudge(key: string, send: () => void, delay = NUDGE_HOLD_MS) {
+    if (shuttingDown) return;
     cancelNudge(key);
     pendingNudges.set(key, setTimeout(() => {
       pendingNudges.delete(key);
+      if (shuttingDown) return;
       try { send(); } catch { /* ignore stale completion side-effect errors */ }
     }, delay));
   }
@@ -389,6 +400,7 @@ export default function (pi: ExtensionAPI) {
   // ---- Group join manager ----
   const groupJoin = new GroupJoinManager(
     (records, partial) => {
+      if (shuttingDown) return;
       for (const r of records) { agentActivity.delete(r.id); widget.markFinished(r.id); fleet.onAgentFinished(r.id); }
 
       const groupKey = `group:${records.map(r => r.id).join(",")}`;
@@ -445,8 +457,11 @@ export default function (pi: ExtensionAPI) {
     };
   }
 
-  // Background completion: route through group join or send individual nudge
+  // Background completion: route through group join or send individual nudge.
+  // Shutdown suppresses callbacks before it waits for runner cleanup, so late
+  // settlement cannot recreate cleared notification timers.
   const manager = new AgentManager((record) => {
+    if (shuttingDown) return;
     // Nested children report only through their owning parent's scoped tools.
     // Keep them out of top-level lifecycle, transcript, notification, and UI channels.
     if (record.parentAgentId) return;
@@ -907,6 +922,7 @@ export default function (pi: ExtensionAPI) {
   // On shutdown, abort all agents immediately and clean up.
   // If the session is going down, there's nothing left to consume agent results.
   pi.on("session_shutdown", async () => {
+    shuttingDown = true;
     rpcHandle?.unsubSpawn();
     rpcHandle?.unsubStop();
     rpcHandle?.unsubPing();
@@ -918,9 +934,24 @@ export default function (pi: ExtensionAPI) {
       delete (globalThis as any)[MANAGER_KEY];
     }
     scheduler.stop();
-    manager.abortAll();
+    if (batchFinalizeTimer) {
+      clearTimeout(batchFinalizeTimer);
+      batchFinalizeTimer = undefined;
+    }
+    currentBatchAgents = [];
+    groupJoin.dispose();
     for (const timer of pendingNudges.values()) clearTimeout(timer);
     pendingNudges.clear();
+
+    const settlement = manager.stopForShutdown();
+    let settlementTimer: ReturnType<typeof setTimeout> | undefined;
+    const boundedFallback = new Promise<void>(resolve => {
+      settlementTimer = setTimeout(resolve, SHUTDOWN_SETTLEMENT_TIMEOUT_MS);
+    });
+    await Promise.race([settlement, boundedFallback]);
+    if (settlementTimer) clearTimeout(settlementTimer);
+
+    widget.dispose();
     fleet.dispose();
     manager.dispose();
   });
@@ -936,7 +967,15 @@ export default function (pi: ExtensionAPI) {
   function setWidgetMode(m: WidgetMode): void { widgetMode = m; widget.update(); }
 
   // Claude Code-style FleetView: navigable list of main + subagents below the editor.
-  const fleet = new FleetList(manager, agentActivity);
+  const fleet = new FleetList(manager, agentActivity, sendForegroundToBackground);
+  function sendForegroundToBackground(record: AgentRecord): boolean {
+    if (!manager.detachForeground(record.id)) return false;
+    widget.ensureTimer();
+    widget.update();
+    fleet.ensureTimer();
+    fleet.update();
+    return true;
+  }
   let fleetViewEnabled = true;
   function isFleetViewEnabled(): boolean { return fleetViewEnabled; }
   function setFleetViewEnabled(b: boolean): void { fleetViewEnabled = b; fleet.setEnabled(b); }
@@ -1005,6 +1044,10 @@ export default function (pi: ExtensionAPI) {
   /** Finalize the current batch: if 2+ smart-mode agents, register as a group. */
   function finalizeBatch() {
     batchFinalizeTimer = undefined;
+    if (shuttingDown) {
+      currentBatchAgents = [];
+      return;
+    }
     const batchAgents = [...currentBatchAgents];
     currentBatchAgents = [];
 
@@ -1176,6 +1219,7 @@ export default function (pi: ExtensionAPI) {
   applyAndEmitLoaded(
     {
       setMaxConcurrent: (n) => manager.setMaxConcurrent(n),
+      setForegroundTimeoutMs: (n) => manager.setForegroundTimeoutMs(n),
       setDefaultMaxTurns,
       setGraceTurns,
       setDefaultJoinMode,
@@ -1893,7 +1937,9 @@ Terse command-style prompts produce shallow, generic work.
           ...fgCallbacks,
         }, (fgAgentId) => {
           // onSpawned: called synchronously after spawn, before onSessionCreated fires.
-          // Set up the output file so streamToOutputFile can pick it up.
+          // Set up every record-owned surface before a very short timeout can detach it.
+          fgId = fgAgentId;
+          agentActivity.set(fgAgentId, fgState);
           const fgRec = manager.getRecord(fgAgentId);
           attachTranscript(fgRec, fgAgentId);
         });
@@ -1904,10 +1950,34 @@ Terse command-style prompts produce shallow, generic work.
         // ticking or a finished agent on the widget.
         clearInterval(spinnerInterval);
         if (fgId) {
-          agentActivity.delete(fgId);
-          widget.markFinished(fgId);
-          fleet.onAgentFinished(fgId);
+          const current = manager.getRecord(fgId);
+          if (current?.isBackground && current.status === "running") {
+            // The tool call is done, but this same agent is not. Keep its live
+            // activity/session surfaces until the background completion path
+            // performs the normal final cleanup and notification.
+            widget.ensureTimer();
+            widget.update();
+            fleet.ensureTimer();
+            fleet.update();
+          } else {
+            agentActivity.delete(fgId);
+            widget.markFinished(fgId);
+            fleet.onAgentFinished(fgId);
+          }
         }
+      }
+
+      if (record.isBackground) {
+        return textResult(
+          `${fallbackNote}Agent sent to background.\n` +
+          `Agent ID: ${record.id}\n` +
+          `Type: ${displayName}\n` +
+          `Description: ${record.description}\n` +
+          (record.outputFile ? `Output file: ${record.outputFile}\n` : "") +
+          `\nThe same live run is continuing. You will be notified when it completes.\n` +
+          `Use get_subagent_result to retrieve full results, or steer_subagent to send it messages.`,
+          { ...detailBase, toolUses: record.toolUses, tokens: formatLifetimeTokens(fgState), durationMs: Date.now() - record.startedAt, status: "background" as const, agentId: record.id },
+        );
       }
 
       // Get final token count
@@ -2260,7 +2330,11 @@ Terse command-style prompts produce shallow, generic work.
           if (manager.abort(record.id)) {
             ctx.ui.notify(`Stopped "${record.description}".`, "info");
           }
-        }, keybindings, (message: string) => manager.steer(record.id, message));
+        }, keybindings, (message: string) => manager.steer(record.id, message), () => {
+          if (sendForegroundToBackground(record)) {
+            ctx.ui.notify(`Sent "${record.description}" to the background.`, "info");
+          }
+        });
       },
       {
         overlay: true,
@@ -2510,6 +2584,8 @@ Write the file using the write tool. Only write the file, nothing else.`;
     const { record } = await manager.spawnAndWait(pi, ctx, "general-purpose", generatePrompt, {
       description: `Generate ${name} agent`,
       maxTurns: 5,
+      // This command needs the file before it can continue its wizard flow.
+      foregroundTimeoutMs: 0,
     });
 
     if (record.status === "error") {
@@ -2613,6 +2689,7 @@ Write the file using the write tool. Only write the file, nothing else.`;
   function snapshotSettings() {
     return {
       maxConcurrent: manager.getMaxConcurrent(),
+      foregroundTimeoutMs: manager.getForegroundTimeoutMs(),
       // 0 = unlimited — per SubagentsSettings.defaultMaxTurns docstring and
       // normalizeMaxTurns() in agent-runner.ts (which maps 0 → undefined).
       defaultMaxTurns: getDefaultMaxTurns() ?? 0,
@@ -2648,11 +2725,12 @@ Write the file using the write tool. Only write the file, nothing else.`;
   const _settingsSnapshotIsComplete: _NoMissingSettingsKeys = true;
   void _settingsSnapshotIsComplete;
 
-  const NUMERIC_IDS = new Set(["maxConcurrent", "defaultMaxTurns", "graceTurns", "maxSubagentDepth"]);
+  const NUMERIC_IDS = new Set(["maxConcurrent", "foregroundTimeoutMs", "defaultMaxTurns", "graceTurns", "maxSubagentDepth"]);
 
   async function showSettings(ctx: ExtensionCommandContext) {
     function buildItems(): SettingItem[] {
       const mc = manager.getMaxConcurrent();
+      const ftm = manager.getForegroundTimeoutMs();
       const dmt = getDefaultMaxTurns() ?? 0;
       const gt = getGraceTurns();
       const msd = getMaxSubagentDepth();
@@ -2671,6 +2749,13 @@ Write the file using the write tool. Only write the file, nothing else.`;
           description: "Max concurrent background agents (Enter to type)",
           currentValue: String(mc),
           values: [String(mc)],
+        },
+        {
+          id: "foregroundTimeoutMs",
+          label: "Foreground timeout",
+          description: "Send live foreground runs to the background after this many milliseconds (0 = disabled, Enter to type)",
+          currentValue: String(ftm),
+          values: [String(ftm)],
         },
         {
           id: "defaultMaxTurns",
@@ -2786,6 +2871,15 @@ Write the file using the write tool. Only write the file, nothing else.`;
         if (n >= 1) {
           manager.setMaxConcurrent(n);
           notifyApplied(ctx, `Max concurrency set to ${n}`);
+        }
+      } else if (id === "foregroundTimeoutMs") {
+        const n = parseInt(value, 10);
+        if (n >= 0 && n <= FOREGROUND_TIMEOUT_CEILING_MS) {
+          manager.setForegroundTimeoutMs(n);
+          notifyApplied(
+            ctx,
+            n === 0 ? "Foreground timeout disabled" : `Foreground timeout set to ${n} ms`,
+          );
         }
       } else if (id === "defaultMaxTurns") {
         const n = parseInt(value, 10);
@@ -2928,19 +3022,23 @@ Write the file using the write tool. Only write the file, nothing else.`;
     if (result && NUMERIC_IDS.has(result)) {
       const current = result === "maxConcurrent"
         ? String(manager.getMaxConcurrent())
-        : result === "defaultMaxTurns"
-          ? String(getDefaultMaxTurns() ?? 0)
-          : result === "maxSubagentDepth"
-            ? String(getMaxSubagentDepth())
-            : String(getGraceTurns());
+        : result === "foregroundTimeoutMs"
+          ? String(manager.getForegroundTimeoutMs())
+          : result === "defaultMaxTurns"
+            ? String(getDefaultMaxTurns() ?? 0)
+            : result === "maxSubagentDepth"
+              ? String(getMaxSubagentDepth())
+              : String(getGraceTurns());
 
       const label = result === "maxConcurrent"
         ? "Max concurrency (1+)"
-        : result === "defaultMaxTurns"
-          ? "Default max turns (0 = unlimited)"
-          : result === "maxSubagentDepth"
-            ? "Nested depth (0/1 = nesting off)"
-            : "Grace turns (1+)";
+        : result === "foregroundTimeoutMs"
+          ? "Foreground timeout in milliseconds (0 = disabled)"
+          : result === "defaultMaxTurns"
+            ? "Default max turns (0 = unlimited)"
+            : result === "maxSubagentDepth"
+              ? "Nested depth (0/1 = nesting off)"
+              : "Grace turns (1+)";
 
       // Loop until user enters a valid integer or cancels (Esc / null).
       // Silently trims whitespace; rejects non-numeric input by re-prompting.
@@ -2948,7 +3046,9 @@ Write the file using the write tool. Only write the file, nothing else.`;
       while (input != null) {
         const trimmed = input.trim();
         const n = Number(trimmed);
-        if (trimmed !== "" && Number.isInteger(n)) {
+        const inRange = result !== "foregroundTimeoutMs"
+          || (n >= 0 && n <= FOREGROUND_TIMEOUT_CEILING_MS);
+        if (trimmed !== "" && Number.isInteger(n) && inRange) {
           applyValue(result, String(n));
           await showSettings(ctx);
           return;

--- a/src/settings.ts
+++ b/src/settings.ts
@@ -11,6 +11,11 @@ import type { AgentMentionMode, JoinMode, WidgetMode } from "./types.js";
 export interface SubagentsSettings {
   maxConcurrent?: number;
   /**
+   * Milliseconds before a top-level foreground Agent run is detached to the
+   * background. `0` or omitted disables the timeout. Defaults to `0`.
+   */
+  foregroundTimeoutMs?: number;
+  /**
    * 0 = unlimited — the extension's single source of truth for that convention:
    * `normalizeMaxTurns()` in agent-runner.ts treats 0 → `undefined`, and the
    * `/agents` → Settings input prompt explicitly says "0 = unlimited".
@@ -164,6 +169,7 @@ export type ToolDescriptionMode = "full" | "compact" | "custom";
 /** Setter hooks used by applySettings to wire persisted values into in-memory state. */
 export interface SettingsAppliers {
   setMaxConcurrent: (n: number) => void;
+  setForegroundTimeoutMs: (n: number) => void;
   setDefaultMaxTurns: (n: number) => void;
   setGraceTurns: (n: number) => void;
   setDefaultJoinMode: (mode: JoinMode) => void;
@@ -193,6 +199,7 @@ const VALID_AGENT_MENTION_MODES: ReadonlySet<string> = new Set<AgentMentionMode>
 // make no operational sense (e.g. 1e6 concurrent subagents). Permissive enough
 // that any realistic power-user setting passes through.
 const MAX_CONCURRENT_CEILING = 1024;
+export const FOREGROUND_TIMEOUT_CEILING_MS = 2_147_483_647;
 const MAX_TURNS_CEILING = 10_000;
 const GRACE_TURNS_CEILING = 1_000;
 const SUBAGENT_DEPTH_CEILING = 16;
@@ -208,6 +215,13 @@ function sanitize(raw: unknown): SubagentsSettings {
     (r.maxConcurrent as number) <= MAX_CONCURRENT_CEILING
   ) {
     out.maxConcurrent = r.maxConcurrent as number;
+  }
+  if (
+    Number.isInteger(r.foregroundTimeoutMs) &&
+    (r.foregroundTimeoutMs as number) >= 0 &&
+    (r.foregroundTimeoutMs as number) <= FOREGROUND_TIMEOUT_CEILING_MS
+  ) {
+    out.foregroundTimeoutMs = r.foregroundTimeoutMs as number;
   }
   if (
     Number.isInteger(r.defaultMaxTurns) &&
@@ -328,6 +342,7 @@ export function saveSettings(s: SubagentsSettings, cwd: string = process.cwd()):
 /** Apply persisted settings to the in-memory state via caller-supplied setters. */
 export function applySettings(s: SubagentsSettings, appliers: SettingsAppliers): void {
   if (typeof s.maxConcurrent === "number") appliers.setMaxConcurrent(s.maxConcurrent);
+  if (typeof s.foregroundTimeoutMs === "number") appliers.setForegroundTimeoutMs(s.foregroundTimeoutMs);
   if (typeof s.defaultMaxTurns === "number") appliers.setDefaultMaxTurns(s.defaultMaxTurns);
   if (typeof s.graceTurns === "number") appliers.setGraceTurns(s.graceTurns);
   if (typeof s.maxSubagentDepth === "number") appliers.setMaxSubagentDepth(s.maxSubagentDepth);

--- a/src/types.ts
+++ b/src/types.ts
@@ -184,9 +184,10 @@ export interface AgentRecord {
   /** Number of times this agent's session has compacted. Initialized to 0 at spawn. */
   compactionCount: number;
   /**
-   * Whether this agent was spawned to run in the background. Tri-state, set at
-   * spawn from `SpawnOptions.isBackground`: `true` = background, `false` =
-   * foreground (has an inline Agent tool-result surface), `undefined` = the
+   * Whether this agent runs in the background. Tri-state, initialized from
+   * `SpawnOptions.isBackground` and changed from `false` to `true` when a live
+   * foreground run detaches: `true` = background, `false` = foreground (has an
+   * inline Agent tool-result surface), `undefined` = the
    * caller never declared it (e.g. a cross-extension RPC spawn, which is detached
    * and has no inline surface). The widget's background-only filter keys off this
    * — and excludes only explicit `false`, so `undefined` agents stay visible.

--- a/src/ui/conversation-viewer.ts
+++ b/src/ui/conversation-viewer.ts
@@ -46,6 +46,8 @@ export class ConversationViewer implements Component {
     keybindings?: ViewerKeybindings,
     /** Send a steering message to the agent. Omitted → no compose affordance. */
     private onSteer?: (message: string) => void,
+    /** Detach this live foreground run. Omitted → no background affordance. */
+    private onBackground?: () => void,
   ) {
     this.keys = createViewerKeys(keybindings);
     this.unsubscribe = session.subscribe(() => {
@@ -75,6 +77,15 @@ export class ConversationViewer implements Component {
     if (matchesKey(data, "enter") && this.canSteer()) {
       this.stopArmed = false;
       this.openComposer();
+      return;
+    }
+
+    // Send this same live foreground run to the background. This is a one-way,
+    // single-press transition; the manager rejects stale or repeated attempts.
+    if (matchesKey(data, "b") && this.canSendToBackground()) {
+      this.stopArmed = false;
+      this.onBackground?.();
+      this.tui.requestRender();
       return;
     }
 
@@ -197,6 +208,7 @@ export class ConversationViewer implements Component {
       const sep = th.fg("dim", " · ");
       const actions: string[] = [];
       if (this.canSteer()) actions.push(th.fg("dim", "Enter steer"));
+      if (this.canSendToBackground()) actions.push(th.fg("dim", "b background"));
       if (this.isStoppable()) {
         actions.push(this.stopArmed ? th.fg("error", "x again to STOP") : th.fg("dim", "x stop"));
       }
@@ -229,6 +241,11 @@ export class ConversationViewer implements Component {
   /** Steerable only when a steer handler exists and the agent is still active. */
   private canSteer(): boolean {
     return !!this.onSteer && (this.record.status === "running" || this.record.status === "queued");
+  }
+
+  /** Only a currently-running foreground Agent call can detach. */
+  private canSendToBackground(): boolean {
+    return !!this.onBackground && this.record.status === "running" && this.record.isBackground === false;
   }
 
   /** Open the inline steering composer and route subsequent input to it. */

--- a/src/ui/fleet-list.ts
+++ b/src/ui/fleet-list.ts
@@ -94,6 +94,8 @@ export class FleetList {
   constructor(
     private manager: AgentManager,
     private agentActivity: Map<string, AgentActivity>,
+    /** Detach a live foreground run and refresh extension-owned surfaces. */
+    private onBackground?: (record: AgentRecord) => boolean,
   ) {}
 
   // ---- Lifecycle ----
@@ -311,6 +313,11 @@ export class FleetList {
           },
           keybindings,
           (message: string) => this.manager.steer(record.id, message),
+          () => {
+            if (this.onBackground?.(record)) {
+              this.ui?.notify(`Sent "${record.description}" to the background.`, "info");
+            }
+          },
         );
       },
       {

--- a/test/agent-manager.test.ts
+++ b/test/agent-manager.test.ts
@@ -113,6 +113,7 @@ describe("AgentManager — Bug 1 race condition (resultConsumed vs onComplete)",
     // resultConsumed is set by spawnAndWait so onComplete skips notifications
     expect(completedRecord!.resultConsumed).toBe(true);
     expect(record).toBe(completedRecord);
+    expect(manager.detachForeground(record.id)).toBe(false);
   });
 });
 
@@ -1018,6 +1019,34 @@ describe("AgentManager — parent abort signal forwarding (#44)", () => {
   let manager: AgentManager;
   afterEach(() => manager?.dispose());
 
+  it("starts with the child already stopped when the parent signal was pre-aborted", async () => {
+    manager = new AgentManager();
+    const parent = new AbortController();
+    parent.abort();
+    let childSignal: AbortSignal | undefined;
+    vi.mocked(runAgent).mockImplementation((_ctx, _type, _prompt, options) => {
+      childSignal = options.signal;
+      return Promise.resolve({
+        responseText: "",
+        session: mockSession(),
+        aborted: true,
+        steered: false,
+      });
+    });
+
+    const id = manager.spawn(mockPi, mockCtx, "X", "p", {
+      description: "x",
+      isBackground: false,
+      signal: parent.signal,
+    });
+    const record = manager.getRecord(id)!;
+
+    expect(record.status).toBe("stopped");
+    expect(childSignal?.aborted).toBe(true);
+    await record.promise;
+    expect(record.status).toBe("stopped");
+  });
+
   it("aborts the child when the parent signal aborts", () => {
     manager = new AgentManager();
     vi.mocked(runAgent).mockImplementation(() => new Promise(() => {}));
@@ -1034,6 +1063,176 @@ describe("AgentManager — parent abort signal forwarding (#44)", () => {
     parent.abort();
     expect(record.status).toBe("stopped");
     expect(record.completedAt).toBeGreaterThan(0);
+  });
+});
+
+describe("AgentManager — foreground detachment", () => {
+  let manager: AgentManager;
+
+  afterEach(() => {
+    vi.useRealTimers();
+    manager?.dispose();
+  });
+
+  it("returns spawnAndWait promptly while the same run continues and notifies once", async () => {
+    const onComplete = vi.fn();
+    manager = new AgentManager(onComplete);
+    const parent = new AbortController();
+    const session = mockSession();
+    let finish!: (value: any) => void;
+    vi.mocked(runAgent).mockImplementation((_ctx, _type, _prompt, options: any) => {
+      options.onSessionCreated?.(session);
+      return new Promise(resolve => { finish = resolve; });
+    });
+
+    let id = "";
+    const waiting = manager.spawnAndWait(mockPi, mockCtx, "X", "live", {
+      description: "live",
+      signal: parent.signal,
+    }, spawnedId => { id = spawnedId; });
+    const record = manager.getRecord(id)!;
+    const runPromise = record.promise;
+    const childController = record.abortController;
+
+    expect(manager.detachForeground(id)).toBe(true);
+    const detached = await waiting;
+    expect(detached.record).toBe(record);
+    expect(record.status).toBe("running");
+    expect(record.isBackground).toBe(true);
+    expect(record.promise).toBe(runPromise);
+    expect(record.session).toBe(session);
+    expect(onComplete).not.toHaveBeenCalled();
+
+    // The foreground tool's signal no longer owns this detached child.
+    parent.abort();
+    expect(record.status).toBe("running");
+    expect(childController?.signal.aborted).toBe(false);
+    expect(manager.detachForeground(id)).toBe(false);
+
+    finish({ responseText: "done", session, aborted: false, steered: false });
+    await runPromise;
+    expect(record.status).toBe("completed");
+    expect(record.resultConsumed).toBe(false);
+    expect(onComplete).toHaveBeenCalledTimes(1);
+  });
+
+  it("keeps a parent Esc before detachment as a normal foreground stop", async () => {
+    const onComplete = vi.fn();
+    manager = new AgentManager(onComplete);
+    const parent = new AbortController();
+    vi.mocked(runAgent).mockImplementation((_ctx, _type, _prompt, options: any) =>
+      new Promise(resolve => {
+        options.signal.addEventListener("abort", () => {
+          resolve({ responseText: "partial", session: mockSession(), aborted: true, steered: false });
+        });
+      }),
+    );
+
+    let id = "";
+    const waiting = manager.spawnAndWait(
+      mockPi,
+      mockCtx,
+      "X",
+      "stop first",
+      { description: "stop first", signal: parent.signal },
+      spawnedId => { id = spawnedId; },
+    );
+    parent.abort();
+    expect(manager.detachForeground(id)).toBe(false);
+
+    const { record } = await waiting;
+    expect(record.status).toBe("stopped");
+    expect(record.isBackground).toBe(false);
+    expect(record.resultConsumed).toBe(true);
+    expect(onComplete).toHaveBeenCalledTimes(1);
+  });
+
+  it("automatically detaches at the configured timeout without aborting the run", async () => {
+    vi.useFakeTimers();
+    manager = new AgentManager();
+    manager.setForegroundTimeoutMs(1_000);
+    const session = mockSession();
+    let finish!: (value: any) => void;
+    vi.mocked(runAgent).mockImplementation(() => new Promise(resolve => { finish = resolve; }));
+
+    let id = "";
+    const waiting = manager.spawnAndWait(
+      mockPi,
+      mockCtx,
+      "X",
+      "timed",
+      { description: "timed" },
+      spawnedId => { id = spawnedId; },
+    );
+    let returned = false;
+    void waiting.then(() => { returned = true; });
+
+    await vi.advanceTimersByTimeAsync(999);
+    expect(returned).toBe(false);
+    await vi.advanceTimersByTimeAsync(1);
+    const { record } = await waiting;
+    expect(record.id).toBe(id);
+    expect(record.status).toBe("running");
+    expect(record.isBackground).toBe(true);
+    expect(record.abortController?.signal.aborted).toBe(false);
+
+    finish({ responseText: "done", session, aborted: false, steered: false });
+    await record.promise;
+  });
+
+  it("keeps normal foreground blocking when the timeout is disabled", async () => {
+    vi.useFakeTimers();
+    manager = new AgentManager();
+    expect(manager.getForegroundTimeoutMs()).toBe(0);
+    let finish!: (value: any) => void;
+    vi.mocked(runAgent).mockImplementation(() => new Promise(resolve => { finish = resolve; }));
+
+    const waiting = manager.spawnAndWait(mockPi, mockCtx, "X", "blocking", { description: "blocking" });
+    let returned = false;
+    void waiting.then(() => { returned = true; });
+    await vi.advanceTimersByTimeAsync(60_000);
+    expect(returned).toBe(false);
+
+    finish({ responseText: "done", session: mockSession(), aborted: false, steered: false });
+    await waiting;
+  });
+
+  it("counts a detached foreground run above capacity and holds queued work", async () => {
+    const resolvers = new Map<string, (value: any) => void>();
+    vi.mocked(runAgent).mockImplementation((_ctx, _type, prompt) =>
+      new Promise(resolve => { resolvers.set(prompt, resolve); }),
+    );
+    manager = new AgentManager(undefined, 1);
+
+    const blockerId = manager.spawn(mockPi, mockCtx, "X", "blocker", {
+      description: "blocker",
+      isBackground: true,
+    });
+    let foregroundId = "";
+    const foregroundWait = manager.spawnAndWait(
+      mockPi,
+      mockCtx,
+      "X",
+      "foreground",
+      { description: "foreground" },
+      id => { foregroundId = id; },
+    );
+    const queuedId = manager.spawn(mockPi, mockCtx, "X", "queued", {
+      description: "queued",
+      isBackground: true,
+    });
+    expect(manager.getRecord(queuedId)?.status).toBe("queued");
+
+    expect(manager.detachForeground(foregroundId)).toBe(true);
+    await foregroundWait;
+    resolvers.get("blocker")!({ responseText: "done", session: mockSession(), aborted: false, steered: false });
+    await manager.getRecord(blockerId)!.promise;
+    // The detached run still occupies one slot, so this cannot drain yet.
+    expect(manager.getRecord(queuedId)?.status).toBe("queued");
+
+    resolvers.get("foreground")!({ responseText: "done", session: mockSession(), aborted: false, steered: false });
+    await manager.getRecord(foregroundId)!.promise;
+    expect(manager.getRecord(queuedId)?.status).toBe("running");
   });
 });
 

--- a/test/agent-runner.test.ts
+++ b/test/agent-runner.test.ts
@@ -2340,6 +2340,34 @@ describe("agent-runner turn limits", () => {
 // nothing checked that the signal actually reaches the session, so a child could
 // be marked stopped while it keeps running and burning tokens.
 describe("agent-runner abort signal forwarding", () => {
+  it("aborts before prompting when the signal fired before child session creation", async () => {
+    vi.mocked(getAgentConfig).mockReturnValueOnce(makeAgentConfig());
+    const controller = new AbortController();
+    controller.abort();
+    const { session } = createSession("NEVER STARTED NORMALLY");
+    createAgentSession.mockResolvedValue({ session });
+
+    await runAgent(ctx, "Explore", "go", { pi, signal: controller.signal });
+
+    expect(session.abort).toHaveBeenCalledTimes(1);
+    expect(session.abort.mock.invocationCallOrder[0]).toBeLessThan(
+      session.prompt.mock.invocationCallOrder[0],
+    );
+  });
+
+  it("resumeAgent aborts immediately when its signal is already aborted", async () => {
+    const controller = new AbortController();
+    controller.abort();
+    const { session } = createSession("RESUME");
+
+    await resumeAgent(session as any, "continue", { signal: controller.signal });
+
+    expect(session.abort).toHaveBeenCalledTimes(1);
+    expect(session.abort.mock.invocationCallOrder[0]).toBeLessThan(
+      session.prompt.mock.invocationCallOrder[0],
+    );
+  });
+
   it("aborts the session when the parent signal fires mid-run", async () => {
     vi.mocked(getAgentConfig).mockReturnValueOnce(makeAgentConfig());
     const controller = new AbortController();

--- a/test/conversation-viewer.test.ts
+++ b/test/conversation-viewer.test.ts
@@ -402,6 +402,61 @@ describe("ConversationViewer", () => {
     });
   });
 
+  describe("background key", () => {
+    const W = 80;
+
+    it("shows b only for a running foreground agent and detaches once", () => {
+      const record = mockRecord({ status: "running", isBackground: false });
+      const onBackground = vi.fn(() => { record.isBackground = true; });
+      const tui = mockTui(30, W);
+      const viewer = new ConversationViewer(
+        tui,
+        mockSession(),
+        record,
+        undefined,
+        ansiTheme(),
+        vi.fn(),
+        undefined,
+        undefined,
+        undefined,
+        onBackground,
+      );
+
+      expect(viewer.render(W).join("\n")).toContain("b background");
+      viewer.handleInput("b");
+      expect(onBackground).toHaveBeenCalledTimes(1);
+      expect(tui.requestRender).toHaveBeenCalled();
+      expect(viewer.render(W).join("\n")).not.toContain("b background");
+      viewer.handleInput("b");
+      expect(onBackground).toHaveBeenCalledTimes(1);
+    });
+
+    it("hides and ignores b for background, queued, and completed agents", () => {
+      for (const overrides of [
+        { status: "running" as const, isBackground: true },
+        { status: "queued" as const, isBackground: false },
+        { status: "completed" as const, isBackground: false },
+      ]) {
+        const onBackground = vi.fn();
+        const viewer = new ConversationViewer(
+          mockTui(30, W),
+          mockSession(),
+          mockRecord(overrides),
+          undefined,
+          ansiTheme(),
+          vi.fn(),
+          undefined,
+          undefined,
+          undefined,
+          onBackground,
+        );
+        expect(viewer.render(W).join("\n")).not.toContain("b background");
+        viewer.handleInput("b");
+        expect(onBackground).not.toHaveBeenCalled();
+      }
+    });
+  });
+
   describe("steer composer", () => {
     const W = 80;
 

--- a/test/fleet-list.test.ts
+++ b/test/fleet-list.test.ts
@@ -41,6 +41,12 @@ function fakeManager(agents: AgentRecord[]): AgentManager {
     listAgents: () => agents,
     abort: () => true,
     steer: vi.fn(() => true),
+    detachForeground: vi.fn((id: string) => {
+      const record = agents.find(agent => agent.id === id);
+      if (!record || record.status !== "running" || record.isBackground !== false) return false;
+      record.isBackground = true;
+      return true;
+    }),
   } as unknown as AgentManager;
 }
 
@@ -93,7 +99,7 @@ function harness(agents: AgentRecord[]): Harness {
   };
 
   const manager = fakeManager(agents);
-  const fleet = new FleetList(manager, new Map());
+  const fleet = new FleetList(manager, new Map(), record => manager.detachForeground(record.id));
   fleet.setUICtx(ui);
   fleet.update();
 
@@ -397,6 +403,21 @@ describe("FleetList overlay lifecycle", () => {
     // Selection follows a2 ("two") to its new position, not whatever is at idx 2 now.
     expect(h.render().find(l => l.includes("two"))).toContain("●");
     expect(h.render().find(l => l.includes("three"))).toContain("○");
+  });
+
+  it("wires the viewer's b action to the same foreground record", () => {
+    const agents = [makeRecord({ id: "live", description: "the one", isBackground: false })];
+    const h = harness(agents);
+    h.press(DOWN);
+    h.press(DOWN);
+    h.press(ENTER);
+
+    const viewer = h.overlayComponent();
+    expect(viewer).toBeDefined();
+    viewer!.handleInput("b");
+
+    expect(h.manager.detachForeground).toHaveBeenCalledWith("live");
+    expect(agents[0].isBackground).toBe(true);
   });
 
   it("wires the viewer's steer composer to manager.steer with the agent id", () => {

--- a/test/foreground-result-retrieval.test.ts
+++ b/test/foreground-result-retrieval.test.ts
@@ -21,9 +21,10 @@
  * and "not found" was the correct answer. Test 3 pins the eviction rule that
  * DOES apply, so the two are not confused again.
  */
-import { mkdirSync, mkdtempSync, rmSync, writeFileSync } from "node:fs";
+import { mkdirSync, mkdtempSync, readFileSync, rmSync, writeFileSync } from "node:fs";
 import { tmpdir } from "node:os";
 import { join } from "node:path";
+import { initTheme } from "@earendil-works/pi-coding-agent";
 import { afterEach, beforeEach, describe, expect, it, vi } from "vitest";
 
 vi.mock("../src/agent-runner.js", async () => {
@@ -33,14 +34,16 @@ vi.mock("../src/agent-runner.js", async () => {
 
 import { runAgent } from "../src/agent-runner.js";
 import subagentsExtension from "../src/index.js";
+import { FOREGROUND_TIMEOUT_CEILING_MS } from "../src/settings.js";
 
 function makePi() {
   const tools = new Map<string, any>();
   const lifecycle = new Map<string, any>();
+  const commands = new Map<string, any>();
   const pi = {
     registerMessageRenderer: vi.fn(),
     registerTool: vi.fn((t: any) => tools.set(t.name, t)),
-    registerCommand: vi.fn(),
+    registerCommand: vi.fn((name: string, command: any) => commands.set(name, command)),
     on: vi.fn((event: string, handler: any) => lifecycle.set(event, handler)),
     events: {
       emit: vi.fn(),
@@ -49,7 +52,7 @@ function makePi() {
     appendEntry: vi.fn(),
     sendMessage: vi.fn(),
   } as any;
-  return { pi, tools, lifecycle };
+  return { pi, tools, lifecycle, commands };
 }
 
 function ctx() {
@@ -123,6 +126,7 @@ describe("issue #174: foreground agent that hits max_turns", () => {
   });
 
   afterEach(() => {
+    vi.useRealTimers();
     process.chdir(prevCwd);
     if (prevAgentDir == null) delete process.env.PI_CODING_AGENT_DIR;
     else process.env.PI_CODING_AGENT_DIR = prevAgentDir;
@@ -199,6 +203,319 @@ describe("issue #174: foreground agent that hits max_turns", () => {
     expect(out).toContain("THE-RESULT-PAYLOAD");
 
     await parent.lifecycle.get("session_shutdown")?.({}, ctx());
+  });
+
+  it("applies foregroundTimeoutMs and returns the live run as background", async () => {
+    vi.useFakeTimers();
+    writeFileSync(
+      join(tmpDir, ".pi", "subagents.json"),
+      JSON.stringify({ schedulingEnabled: false, defaultJoinMode: "async", foregroundTimeoutMs: 1_000 }),
+    );
+    const session = { dispose: vi.fn(), messages: [], subscribe: vi.fn(() => vi.fn()) } as any;
+    let finish!: (value: any) => void;
+    vi.mocked(runAgent).mockImplementation((_ctx, _type, _prompt, options: any) => {
+      options.onSessionCreated?.(session);
+      return new Promise(resolve => { finish = resolve; });
+    });
+
+    const { pi, tools, lifecycle } = makePi();
+    subagentsExtension(pi);
+    const parent = new AbortController();
+    const execution = tools.get("Agent").execute(
+      "tc-timeout",
+      { prompt: "keep working", description: "long task", subagent_type: "general-purpose" },
+      parent.signal,
+      undefined,
+      ctx(),
+    );
+
+    await vi.advanceTimersByTimeAsync(1_000);
+    const result = await execution;
+    const output = textOf(result);
+    expect(output).toContain("Agent sent to background");
+    const id = output.match(/Agent ID: (\S+)/)?.[1];
+    expect(id).toBeTruthy();
+
+    // Esc after the tool returned cannot stop the detached child.
+    parent.abort();
+    const running = await tools.get("get_subagent_result").execute(
+      "tc-status",
+      { agent_id: id },
+      undefined,
+      undefined,
+      ctx(),
+    );
+    expect(textOf(running)).toContain("Status: running");
+
+    finish({ responseText: "FINISHED-SAME-RUN", session, aborted: false, steered: false });
+    await vi.advanceTimersByTimeAsync(200);
+    await Promise.resolve();
+    await vi.advanceTimersByTimeAsync(200);
+    expect(pi.sendMessage).toHaveBeenCalledTimes(1);
+    expect(pi.sendMessage.mock.calls[0][0].content).toContain("FINISHED-SAME-RUN");
+
+    await lifecycle.get("session_shutdown")?.({}, ctx());
+  });
+
+  it("releases a blocked foreground tool call and bounds shutdown when its runner hangs", async () => {
+    vi.useFakeTimers();
+    writeFileSync(
+      join(tmpDir, ".pi", "subagents.json"),
+      JSON.stringify({ schedulingEnabled: false, foregroundTimeoutMs: 0, outputTranscript: false }),
+    );
+    const session = { dispose: vi.fn(), messages: [], subscribe: vi.fn(() => vi.fn()) } as any;
+    let childSignal: AbortSignal | undefined;
+    let childId: string | undefined;
+    vi.mocked(runAgent).mockImplementation((_ctx, _type, _prompt, options: any) => {
+      childSignal = options.signal;
+      childId = options.agentId;
+      options.onSessionCreated?.(session);
+      return new Promise(() => {});
+    });
+
+    const { pi, tools, lifecycle } = makePi();
+    subagentsExtension(pi);
+    const execution = tools.get("Agent").execute(
+      "tc-blocked-shutdown",
+      { prompt: "hang", description: "blocked foreground", subagent_type: "general-purpose" },
+      new AbortController().signal,
+      undefined,
+      ctx(),
+    );
+    await vi.advanceTimersByTimeAsync(0);
+    expect(childSignal).toBeDefined();
+    expect(childId).toBeDefined();
+    const registry = (globalThis as any)[Symbol.for("pi-subagents:manager")];
+    const record = registry.getRecord(childId) as any;
+    const cleanup = vi.fn();
+    record.outputCleanup = cleanup;
+
+    const shutdown = lifecycle.get("session_shutdown")?.({}, ctx());
+    const result = await execution;
+
+    expect(childSignal?.aborted).toBe(true);
+    expect(textOf(result)).toContain("STOPPED BY THE USER");
+    expect(cleanup).not.toHaveBeenCalled();
+    expect(session.dispose).not.toHaveBeenCalled();
+
+    await vi.advanceTimersByTimeAsync(999);
+    expect(cleanup).not.toHaveBeenCalled();
+    expect(session.dispose).not.toHaveBeenCalled();
+    await vi.advanceTimersByTimeAsync(1);
+    await shutdown;
+
+    expect(cleanup).toHaveBeenCalledTimes(1);
+    expect(record.outputCleanup).toBeUndefined();
+    expect(session.dispose).toHaveBeenCalledTimes(1);
+    expect(cleanup.mock.invocationCallOrder[0]).toBeLessThan(
+      session.dispose.mock.invocationCallOrder[0],
+    );
+    expect(pi.sendMessage).not.toHaveBeenCalled();
+  });
+
+  it("clears pending smart-join batch finalization on shutdown", async () => {
+    vi.useFakeTimers();
+    writeFileSync(
+      join(tmpDir, ".pi", "subagents.json"),
+      JSON.stringify({ schedulingEnabled: false, defaultJoinMode: "smart", outputTranscript: false }),
+    );
+    const session = { dispose: vi.fn(), messages: [], subscribe: vi.fn(() => vi.fn()) } as any;
+    vi.mocked(runAgent).mockImplementation((_ctx, _type, _prompt, options: any) => {
+      options.onSessionCreated?.(session);
+      return Promise.resolve({ responseText: "done", session, aborted: false, steered: false });
+    });
+
+    const { pi, tools, lifecycle } = makePi();
+    subagentsExtension(pi);
+    await tools.get("Agent").execute(
+      "tc-batch-shutdown",
+      {
+        prompt: "finish now",
+        description: "pending batch",
+        subagent_type: "general-purpose",
+        run_in_background: true,
+      },
+      undefined,
+      undefined,
+      ctx(),
+    );
+
+    await lifecycle.get("session_shutdown")?.({}, ctx());
+    await vi.advanceTimersByTimeAsync(1_000);
+
+    expect(pi.sendMessage).not.toHaveBeenCalled();
+  });
+
+  it("disposes an active join group and suppresses its late completion", async () => {
+    vi.useFakeTimers();
+    writeFileSync(
+      join(tmpDir, ".pi", "subagents.json"),
+      JSON.stringify({ schedulingEnabled: false, defaultJoinMode: "smart", outputTranscript: false }),
+    );
+    const sessions = [
+      { dispose: vi.fn(), messages: [], subscribe: vi.fn(() => vi.fn()) },
+      { dispose: vi.fn(), messages: [], subscribe: vi.fn(() => vi.fn()) },
+    ] as any[];
+    let finishSecond!: (value: any) => void;
+    let secondSignal: AbortSignal | undefined;
+    vi.mocked(runAgent).mockImplementation((_ctx, _type, prompt, options: any) => {
+      const session = prompt === "first" ? sessions[0] : sessions[1];
+      options.onSessionCreated?.(session);
+      if (prompt === "first") {
+        return Promise.resolve({ responseText: "first done", session, aborted: false, steered: false });
+      }
+      secondSignal = options.signal;
+      return new Promise(resolve => { finishSecond = resolve; });
+    });
+
+    const { pi, tools, lifecycle } = makePi();
+    subagentsExtension(pi);
+    for (const prompt of ["first", "second"]) {
+      await tools.get("Agent").execute(
+        `tc-group-${prompt}`,
+        {
+          prompt,
+          description: `${prompt} group member`,
+          subagent_type: "general-purpose",
+          run_in_background: true,
+        },
+        undefined,
+        undefined,
+        ctx(),
+      );
+    }
+    await vi.advanceTimersByTimeAsync(100);
+
+    const shutdown = lifecycle.get("session_shutdown")?.({}, ctx());
+    expect(secondSignal?.aborted).toBe(true);
+    await vi.advanceTimersByTimeAsync(1_000);
+    await shutdown;
+
+    finishSecond({ responseText: "late second", session: sessions[1], aborted: true, steered: false });
+    await vi.advanceTimersByTimeAsync(60_000);
+
+    expect(pi.sendMessage).not.toHaveBeenCalled();
+  });
+
+  it("stops a detached foreground run cleanly on session shutdown without notifying", async () => {
+    vi.useFakeTimers();
+    writeFileSync(
+      join(tmpDir, ".pi", "subagents.json"),
+      JSON.stringify({
+        schedulingEnabled: false,
+        defaultJoinMode: "async",
+        foregroundTimeoutMs: 1,
+        outputTranscript: false,
+      }),
+    );
+    const session = {
+      dispose: vi.fn(),
+      messages: [],
+      subscribe: vi.fn(() => vi.fn()),
+    } as any;
+    vi.mocked(runAgent).mockImplementation((_ctx, _type, _prompt, options: any) =>
+      new Promise(resolve => {
+        options.onSessionCreated?.(session);
+        options.signal.addEventListener("abort", () => {
+          resolve({ responseText: "partial", session, aborted: true, steered: false });
+        }, { once: true });
+      }),
+    );
+
+    const { pi, tools, lifecycle } = makePi();
+    subagentsExtension(pi);
+    const execution = tools.get("Agent").execute(
+      "tc-shutdown",
+      { prompt: "keep working", description: "shutdown task", subagent_type: "general-purpose" },
+      new AbortController().signal,
+      undefined,
+      ctx(),
+    );
+    await vi.advanceTimersByTimeAsync(1);
+    const result = await execution;
+    const id = textOf(result).match(/Agent ID: (\S+)/)?.[1];
+    expect(id).toBeTruthy();
+
+    const registry = (globalThis as any)[Symbol.for("pi-subagents:manager")];
+    const record = registry.getRecord(id) as any;
+    const cleanup = vi.fn();
+    record.outputCleanup = cleanup;
+
+    await lifecycle.get("session_shutdown")?.({}, ctx());
+    await record.promise;
+    await vi.advanceTimersByTimeAsync(1_000);
+
+    expect(record.status).toBe("stopped");
+    expect(cleanup).toHaveBeenCalledTimes(1);
+    expect(record.outputCleanup).toBeUndefined();
+    expect(session.dispose).toHaveBeenCalledTimes(1);
+    expect(pi.sendMessage).not.toHaveBeenCalled();
+  });
+
+  it("shows and persists Foreground timeout in /agents Settings", async () => {
+    initTheme(undefined, false);
+    const { pi, lifecycle, commands } = makePi();
+    subagentsExtension(pi);
+    const rendered: string[] = [];
+    const select = vi.fn()
+      .mockResolvedValueOnce("Settings")
+      .mockResolvedValueOnce(undefined);
+    const invalidTimeout = String(FOREGROUND_TIMEOUT_CEILING_MS + 1);
+    const validTimeout = String(FOREGROUND_TIMEOUT_CEILING_MS);
+    const input = vi.fn()
+      .mockResolvedValueOnce(invalidTimeout)
+      .mockResolvedValueOnce(validTimeout);
+    const notify = vi.fn();
+    const custom = vi.fn()
+      .mockImplementationOnce((factory: any) => new Promise(resolve => {
+        const component = factory(
+          { requestRender: vi.fn(), terminal: { rows: 40, columns: 120 } },
+          {},
+          undefined,
+          resolve,
+        );
+        rendered.push(...component.render(120));
+        component.handleInput("\x1b[B"); // Foreground timeout is the second numeric row.
+        component.handleInput("\r");
+      }))
+      .mockImplementationOnce(async (factory: any) => {
+        const component = factory(
+          { requestRender: vi.fn(), terminal: { rows: 40, columns: 120 } },
+          {},
+          undefined,
+          vi.fn(),
+        );
+        rendered.push(...component.render(120));
+        return undefined;
+      });
+    const commandCtx = {
+      ...ctx(),
+      hasUI: true,
+      ui: {
+        ...ctx().ui,
+        select,
+        input,
+        custom,
+        notify,
+      },
+    } as any;
+
+    await commands.get("agents").handler("", commandCtx);
+
+    expect(rendered.join("\n")).toContain("Foreground timeout");
+    const label = "Foreground timeout in milliseconds (0 = disabled)";
+    expect(input.mock.calls).toEqual([
+      [label, "0"],
+      [label, invalidTimeout],
+    ]);
+    expect(JSON.parse(readFileSync(join(tmpDir, ".pi", "subagents.json"), "utf-8")).foregroundTimeoutMs)
+      .toBe(FOREGROUND_TIMEOUT_CEILING_MS);
+    expect(notify).toHaveBeenCalledWith(
+      `Foreground timeout set to ${FOREGROUND_TIMEOUT_CEILING_MS} ms`,
+      "info",
+    );
+    expect(notify.mock.calls.flat().join(" ")).not.toContain(invalidTimeout);
+    await lifecycle.get("session_shutdown")?.({}, commandCtx);
   });
 
   it("IS evicted by a session switch — its result was already delivered inline", async () => {

--- a/test/settings.test.ts
+++ b/test/settings.test.ts
@@ -85,6 +85,7 @@ describe("settings persistence", () => {
   it("round-trips values: saveSettings then loadSettings", () => {
     const settings = {
       maxConcurrent: 7,
+      foregroundTimeoutMs: 45_000,
       defaultMaxTurns: 30,
       graceTurns: 3,
       defaultJoinMode: "smart" as const,
@@ -190,6 +191,12 @@ describe("settings persistence", () => {
     expect(loadSettings(projectDir)).toEqual({ defaultMaxTurns: 0 });
   });
 
+  it("merges foregroundTimeoutMs with project precedence and keeps 0 as disabled", () => {
+    writeGlobal({ foregroundTimeoutMs: 60_000 });
+    writeProject({ foregroundTimeoutMs: 0 });
+    expect(loadSettings(projectDir)).toEqual({ foregroundTimeoutMs: 0 });
+  });
+
   it("ignores unknown extra fields on load (forward-compat)", () => {
     writeProject({ maxConcurrent: 2, futureField: "ignored" });
     const loaded = loadSettings(projectDir);
@@ -232,6 +239,17 @@ describe("settings persistence", () => {
     it("drops negative defaultMaxTurns", () => {
       writeProject({ defaultMaxTurns: -1 });
       expect(loadSettings(projectDir)).toEqual({});
+    });
+
+    it("accepts a non-negative integer foregroundTimeoutMs and drops invalid values", () => {
+      for (const value of [0, 1, 2_147_483_647]) {
+        writeProject({ foregroundTimeoutMs: value });
+        expect(loadSettings(projectDir)).toEqual({ foregroundTimeoutMs: value });
+      }
+      for (const value of [-1, 1.5, "1000", 2_147_483_648]) {
+        writeProject({ foregroundTimeoutMs: value });
+        expect(loadSettings(projectDir)).toEqual({});
+      }
     });
 
     it("drops graceTurns < 1", () => {
@@ -450,6 +468,7 @@ describe("settings persistence", () => {
     beforeEach(() => {
       appliers = {
         setMaxConcurrent: vi.fn(),
+        setForegroundTimeoutMs: vi.fn(),
         setDefaultMaxTurns: vi.fn(),
         setGraceTurns: vi.fn(),
         setDefaultJoinMode: vi.fn(),
@@ -480,6 +499,11 @@ describe("settings persistence", () => {
       expect(appliers.setToolDescriptionMode).not.toHaveBeenCalled();
     });
 
+    it("applies foregroundTimeoutMs including the disabled value", () => {
+      applySettings({ foregroundTimeoutMs: 0 }, appliers);
+      expect(appliers.setForegroundTimeoutMs).toHaveBeenCalledWith(0);
+    });
+
     it("applies fallbackSubagent through to the registry", () => {
       // Without this, deleting the applySettings line for this field leaves the
       // whole suite green while `subagents.json` silently stops working.
@@ -488,8 +512,9 @@ describe("settings persistence", () => {
     });
 
     it("applies only the fields that are present", () => {
-      applySettings({ maxConcurrent: 4, graceTurns: 3, maxSubagentDepth: 1 }, appliers);
+      applySettings({ maxConcurrent: 4, foregroundTimeoutMs: 2_500, graceTurns: 3, maxSubagentDepth: 1 }, appliers);
       expect(appliers.setMaxConcurrent).toHaveBeenCalledWith(4);
+      expect(appliers.setForegroundTimeoutMs).toHaveBeenCalledWith(2_500);
       expect(appliers.setGraceTurns).toHaveBeenCalledWith(3);
       expect(appliers.setMaxSubagentDepth).toHaveBeenCalledWith(1);
       expect(appliers.setDefaultMaxTurns).not.toHaveBeenCalled();
@@ -502,6 +527,7 @@ describe("settings persistence", () => {
       applySettings(
         {
           maxConcurrent: 8,
+          foregroundTimeoutMs: 60_000,
           defaultMaxTurns: 50,
           graceTurns: 7,
           defaultJoinMode: "group",
@@ -515,6 +541,7 @@ describe("settings persistence", () => {
         appliers,
       );
       expect(appliers.setMaxConcurrent).toHaveBeenCalledWith(8);
+      expect(appliers.setForegroundTimeoutMs).toHaveBeenCalledWith(60_000);
       expect(appliers.setDefaultMaxTurns).toHaveBeenCalledWith(50);
       expect(appliers.setGraceTurns).toHaveBeenCalledWith(7);
       expect(appliers.setDefaultJoinMode).toHaveBeenCalledWith("group");
@@ -633,6 +660,7 @@ describe("settings persistence", () => {
     beforeEach(() => {
       appliers = {
         setMaxConcurrent: vi.fn(),
+        setForegroundTimeoutMs: vi.fn(),
         setDefaultMaxTurns: vi.fn(),
         setGraceTurns: vi.fn(),
         setDefaultJoinMode: vi.fn(),


### PR DESCRIPTION
## Summary

Foreground agents can take longer than expected. Today, the user must either keep waiting or stop the run.

This adds a one-way foreground-to-background transition without restarting the agent:

- Press `b` in the conversation viewer to send a running foreground agent to the background.
- Set `foregroundTimeoutMs` to detach foreground agents automatically after a configured delay.
- Use `0` or omit the setting to keep the existing blocking behavior.

The same session, promise, in-flight work, transcript, and worktree continue after detachment. The original `Agent` call returns the agent ID, and the normal background completion notification arrives later.

Detached runs count against background concurrency. If the pool is full, the live run continues above capacity and queued work waits for capacity to become available.

The change also handles parent abort signals, completion races, repeated detach attempts, and shutdown cleanup.

## Configuration

```json
{
  "foregroundTimeoutMs": 60000
}
```

The setting is also available through `/agents → Settings → Foreground timeout`.

## Verification

- `npm run lint`
- `npm run typecheck`
- `npm run test` — 1274 passed, 4 skipped
- `npm run test:e2e` — 52 passed, 4 skipped
- `npm run build`

Related to #229.
