### PR TITLE
Load required policy handlers in isolated subagents

### DIFF
--- a/README.md
+++ b/README.md
@@ -307,7 +307,7 @@ All fields are optional — sensible defaults for everything.
 | `prompt_mode` | `replace` | `replace`: body is the full system prompt (no AGENTS.md / CLAUDE.md inheritance). `append`: body appended to parent's prompt (agent acts as a "parent twin" — inherits parent's AGENTS.md / CLAUDE.md) |
 | `inherit_context` | `false` | Fork parent conversation into agent |
 | `run_in_background` | — | Pin this agent to background (`true`) or foreground (`false`). Omit to follow `backgroundByDefault` |
-| `isolated` | `false` | Hermetic specialist mode: forces `extensions: false` + `skills: false` + drops `ext:` selectors. Only built-in tools. Distinct from `isolation: worktree` (filesystem) |
+| `isolated` | `false` | Specialist mode: forces optional `extensions: false` + `skills: false` + drops `ext:` selectors. Only built-in tools surface; global `requiredExtensions` policy handlers still run. Distinct from `isolation: worktree` (filesystem) |
 | `enabled` | `true` | Set to `false` to disable an agent (useful for hiding a default agent per-project) |
 
 Frontmatter is authoritative. If an agent file sets `model`, `thinking`, `max_turns`, `inherit_context`, `run_in_background`, `isolated`, or `isolation`, those values are locked for that agent. `Agent` tool parameters only fill fields the agent config leaves unspecified.
@@ -358,7 +358,7 @@ exclude_extensions: pi-notify     # everything except pi-notify (with extensions
 extensions: [mcp]
 tools: "*, ext:mcp/search"
 
-isolated: true                    # hermetic: built-ins only, no extensions/skills/context
+isolated: true                    # built-ins only; no optional extensions/skills/context
 ```
 
 A few rules the examples don't make obvious:
@@ -517,7 +517,15 @@ Runtime tuning values set via `/agents` → Settings (max concurrency, default m
 - **Global:** `~/.pi/agent/subagents.json` — your machine-wide defaults. Edit by hand; the `/agents` menu never writes here.
 - **Project:** `<cwd>/.pi/subagents.json` — per-project overrides. Written by `/agents` → Settings.
 
-**Precedence:** project overrides global on any field present in both. Missing fields fall back to the hardcoded defaults (max concurrency `4`, default max turns unlimited, grace turns `5`, nested depth `2`, join mode `smart`, defaults enabled).
+**Precedence:** project overrides global on any field present in both. Missing fields fall back to the hardcoded defaults (max concurrency `4`, default max turns unlimited, grace turns `5`, nested depth `2`, join mode `smart`, defaults enabled). `requiredExtensions` is the exception: it is read only from the global file, so project configuration cannot weaken machine-level policy.
+
+**Required extensions** (`requiredExtensions`, global only): absolute paths, `~/` paths, or paths relative to `~/.pi/agent` for handler-only extensions loaded into every child session, including `isolated: true` agents. Their lifecycle and tool-call handlers run, but their registered tools are never exposed to the child model. This is intended for permission, audit, and policy enforcement—not ordinary tool extensions.
+
+```json
+{
+  "requiredExtensions": ["/opt/company/pi-policy.ts"]
+}
+```
 
 **Nested depth** (`maxSubagentDepth`, default `2`): the hard ceiling on [nested delegation](#nested-subagents), counted from the main session (main = 0, its subagents = 1). `0` or `1` disables nesting project-wide regardless of any agent's `allowed_subagents`. Read when a subagent session is built, so a change applies to agents started after it.
 
@@ -566,7 +574,7 @@ EOF
 
 Every project now starts with concurrency 16 and grace 10, without ever touching the menu. Individual projects can still override via `/agents` → Settings.
 
-**Failure behavior:** missing file is silent; malformed JSON logs a `[pi-subagents] Ignoring malformed settings at …` warning to stderr; invalid/out-of-range field values are dropped per-field; write failures downgrade the `/agents` toast to a warning with `(session only; failed to persist)`.
+**Failure behavior:** missing files are silent. Malformed ordinary settings log a warning and fall back to defaults, but a malformed global file or invalid `requiredExtensions` blocks subagent startup because policy enforcement cannot be proven. Invalid ordinary fields are dropped per-field; write failures downgrade the `/agents` toast to a warning with `(session only; failed to persist)`.
 
 ## Events
 

--- a/src/agent-runner.ts
+++ b/src/agent-runner.ts
@@ -25,6 +25,7 @@ import { detectEnv } from "./env.js";
 import { buildMemoryBlock, buildReadOnlyMemoryBlock } from "./memory.js";
 import { createNestedSubagentTools, getMaxSubagentDepth, type NestedAgentManager } from "./nested-tools.js";
 import { buildAgentPrompt, type PromptExtras } from "./prompts.js";
+import { loadRequiredExtensionPaths } from "./settings.js";
 import { preloadSkills } from "./skill-loader.js";
 import type { SubagentType, ThinkingLevel } from "./types.js";
 
@@ -221,8 +222,8 @@ export function parseExtSelectors(entries: string[]): {
  * outlive the `runAgent` call so resumed/steered turns stay scoped. pi's `dispose()`
  * clears `_eventListeners`, so they die with the session rather than leaking.
  *
- * Only meaningful when extensions are loaded — under `noExtensions`/`isolated` the
- * static `allowedToolNames` allowlist already gates the registry itself.
+ * Only meaningful when optional extensions are loaded — under `noExtensions`/`isolated`
+ * the static `allowedToolNames` allowlist gates the registry while required handlers bind.
  */
 export function installExtensionToolScope(
   session: AgentSession,
@@ -232,11 +233,13 @@ export function installExtensionToolScope(
     disallowedSet: Set<string> | undefined;
     extNames: Set<string>;
     narrowing: Map<string, Set<string>>;
+    /** Extensions loaded for handlers only; their tools never enter the child scope. */
+    handlerOnlyPaths: Set<string>;
     /** Opt-in nested-delegation tool names to keep active despite the EXCLUDED strip. */
     nestedToolNames: Set<string>;
   },
 ): void {
-  const { loader, toolNames, disallowedSet, extNames, narrowing, nestedToolNames } = ctx;
+  const { loader, toolNames, disallowedSet, extNames, narrowing, handlerOnlyPaths, nestedToolNames } = ctx;
 
   // The names allowed right now. Mirrors the `ext:` opt-in flip: when any `ext:`
   // selector is present, extension tools become an explicit allowlist — a loaded
@@ -246,6 +249,7 @@ export function installExtensionToolScope(
     const keep = new Set(toolNames.filter((t) => !disallowedSet?.has(t)));
     const optInActive = extNames.size > 0;
     for (const extension of loader.getExtensions().extensions) {
+      if (handlerOnlyPaths.has(resolve(extension.path))) continue;
       const canons = extensionCanonicalNames(extension.path);
       if (optInActive && !canons.some((c) => extNames.has(c))) continue;
       // First alias that carries a narrowing set — a user won't narrow one
@@ -630,6 +634,7 @@ export async function runAgent(
   const noSkills = skills === false || Array.isArray(skills);
 
   const agentDir = getAgentDir();
+  const requiredExtensionPaths = new Set(loadRequiredExtensionPaths(agentDir).map((entry) => resolve(entry)));
 
   // Extension loading:
   // - true  → all default-discovered extensions
@@ -657,7 +662,8 @@ export async function runAgent(
     ? parseExtensionsSpec(extensions, configCwd)
     : undefined;
   const keepNames = extensionsSpec?.names ?? new Set<string>();
-  // `exclude_extensions:` is a denylist applied AFTER the include set — exclude wins.
+  // `exclude_extensions:` is a denylist applied AFTER the optional include set.
+  // Globally required handler extensions cannot be excluded by agent frontmatter.
   // Plain canonical names only (case-insensitive). Note: excluded extensions'
   // factories still run once during reload() (see comment above) — exclusion
   // suppresses handler binding and tool registration; it is not a sandbox.
@@ -667,21 +673,26 @@ export async function runAgent(
   // It's only needed when we're neither loading everything without excludes
   // (`extensions: true` or a `"*"` wildcard) nor nothing (`noExtensions`).
   const loadAll = extensions === true || extensionsSpec?.wildcard === true;
-  const additionalExtensionPaths = extensionsSpec?.paths.length ? extensionsSpec.paths : undefined;
+  const additionalExtensionPaths = [...new Set([
+    ...(extensionsSpec?.paths ?? []),
+    ...requiredExtensionPaths,
+  ])];
   // Pre-filter discovered set, captured by the override — the exclude-typo warning
   // must compare against this, not the surviving set (absence from survivors is
   // an exclude *succeeding*).
   let discoveredNames: Set<string> | undefined;
   const extensionsOverride: ((base: LoadExtensionsResult) => LoadExtensionsResult) | undefined =
-    noExtensions || (loadAll && !hasExcludes)
+    requiredExtensionPaths.size === 0 && (noExtensions || (loadAll && !hasExcludes))
       ? undefined
       : (base) => {
           discoveredNames = new Set(base.extensions.flatMap((e) => extensionCanonicalNames(e.path)));
           return {
             ...base,
             extensions: base.extensions.filter((e) => {
+              if (requiredExtensionPaths.has(resolve(e.path))) return true;
+              if (noExtensions) return false;
               const canons = extensionCanonicalNames(e.path);
-              if (canons.some((n) => excludeNames.has(n))) return false; // exclude wins
+              if (canons.some((n) => excludeNames.has(n))) return false; // exclude wins for optional extensions
               return loadAll || canons.some((n) => keepNames.has(n));
             }),
           };
@@ -690,8 +701,8 @@ export async function runAgent(
   const loader = new DefaultResourceLoader({
     cwd: configCwd,
     agentDir,
-    noExtensions,
-    additionalExtensionPaths,
+    noExtensions: noExtensions && requiredExtensionPaths.size === 0,
+    additionalExtensionPaths: additionalExtensionPaths.length ? additionalExtensionPaths : undefined,
     extensionsOverride,
     noSkills,
     noPromptTemplates: true,
@@ -701,6 +712,11 @@ export async function runAgent(
     appendSystemPromptOverride: () => [],
   });
   await runInChildSessionContext(() => loader.reload());
+  const loadedExtensionPaths = new Set(loader.getExtensions().extensions.map((extension) => resolve(extension.path)));
+  const missingRequiredExtension = [...requiredExtensionPaths].find((entry) => !loadedExtensionPaths.has(entry));
+  if (missingRequiredExtension) {
+    throw new Error(`Required subagent extension failed to load: ${missingRequiredExtension}`);
+  }
 
   // Plain entries in `tools:` are expected to be built-in names (extension tools
   // go through `ext:`), so an unknown name there is unambiguously a typo. Previously
@@ -833,8 +849,8 @@ export async function runAgent(
   //     predicate installed after bind — the active set is what the LLM sees,
   //     so a registry tool that is never activated is invisible and uncallable.
   //
-  // `noExtensions`/`isolated` keeps the historical static allowlist: nothing
-  // async can appear there, and a hard registry gate is the correct boundary.
+  // `noExtensions`/`isolated` keeps the historical static tool allowlist. Required
+  // handler extensions may bind, but their tools cannot enter the registry scope.
   const builtinToolNameSet = new Set(toolNames);
 
   let sessionTools: string[] | undefined;
@@ -929,14 +945,19 @@ export async function runAgent(
   // (e.g. loading credentials, setting up state). Tool gating already happened
   // at session construction via the `tools:` allowlist above — no separate
   // post-bind filter is needed. All ExtensionBindings fields are optional.
+  let requiredBindingError: Error | undefined;
   await session.bindExtensions({
     onError: (err) => {
       options.onToolActivity?.({
         type: "end",
         toolName: `extension-error:${err.extensionPath}`,
       });
+      if (requiredExtensionPaths.has(resolve(err.extensionPath))) {
+        requiredBindingError = new Error(`Required subagent extension failed to bind: ${err.extensionPath}`);
+      }
     },
   });
+  if (requiredBindingError) throw requiredBindingError;
 
   // With `allowedToolNames` unset, the registry is scoped by `excludeTools` but
   // the ACTIVE set still needs managing: pi activates only its four default
@@ -951,6 +972,7 @@ export async function runAgent(
       disallowedSet,
       extNames,
       narrowing,
+      handlerOnlyPaths: requiredExtensionPaths,
       nestedToolNames,
     });
   }

--- a/src/settings.ts
+++ b/src/settings.ts
@@ -3,7 +3,8 @@
 // - Project: <cwd>/.pi/subagents.json — written by /agents → Settings; overrides global on load
 
 import { existsSync, mkdirSync, readFileSync, writeFileSync } from "node:fs";
-import { dirname, join } from "node:path";
+import { homedir } from "node:os";
+import { dirname, isAbsolute, join } from "node:path";
 import { getAgentDir } from "@earendil-works/pi-coding-agent";
 import { NO_FALLBACK } from "./agent-types.js";
 import type { AgentMentionMode, JoinMode, WidgetMode } from "./types.js";
@@ -199,6 +200,11 @@ export interface SubagentsSettings {
   fallbackSubagent?: string;
 }
 
+interface GlobalSubagentsSettings extends SubagentsSettings {
+  /** Handler-only extensions loaded into every child, including isolated agents. */
+  requiredExtensions?: string[];
+}
+
 export type ToolDescriptionMode = "full" | "compact" | "custom";
 
 /** Setter hooks used by applySettings to wire persisted values into in-memory state. */
@@ -240,10 +246,14 @@ const GRACE_TURNS_CEILING = 1_000;
 const SUBAGENT_DEPTH_CEILING = 16;
 
 /** Drop fields that don't match the expected shape. Silent — garbage becomes absent. */
-function sanitize(raw: unknown): SubagentsSettings {
+function sanitize(raw: unknown): GlobalSubagentsSettings {
   if (!raw || typeof raw !== "object") return {};
   const r = raw as Record<string, unknown>;
-  const out: SubagentsSettings = {};
+  const out: GlobalSubagentsSettings = {};
+  if (Array.isArray(r.requiredExtensions)
+    && r.requiredExtensions.every((entry) => typeof entry === "string" && entry.trim())) {
+    out.requiredExtensions = [...new Set(r.requiredExtensions.map((entry) => (entry as string).trim()))];
+  }
   if (
     Number.isInteger(r.maxConcurrent) &&
     (r.maxConcurrent as number) >= 1 &&
@@ -328,8 +338,8 @@ function sanitize(raw: unknown): SubagentsSettings {
   return out;
 }
 
-function globalPath(): string {
-  return join(getAgentDir(), "subagents.json");
+function globalPath(agentDir: string = getAgentDir()): string {
+  return join(agentDir, "subagents.json");
 }
 
 function projectPath(cwd: string): string {
@@ -341,7 +351,7 @@ function projectPath(cwd: string): string {
  * exists but can't be parsed emits a warning to stderr so users aren't
  * silently reverted to defaults — and still returns `{}` so startup proceeds.
  */
-function readSettingsFile(path: string): SubagentsSettings {
+function readSettingsFile(path: string): GlobalSubagentsSettings {
   if (!existsSync(path)) return {};
   try {
     return sanitize(JSON.parse(readFileSync(path, "utf-8")));
@@ -352,9 +362,41 @@ function readSettingsFile(path: string): SubagentsSettings {
   }
 }
 
-/** Load merged settings: global provides defaults, project overrides. */
+/** Load merged settings: global provides defaults, project overrides except the global-only required extensions. */
 export function loadSettings(cwd: string = process.cwd()): SubagentsSettings {
-  return { ...readSettingsFile(globalPath()), ...readSettingsFile(projectPath(cwd)) };
+  const global = { ...readSettingsFile(globalPath()) };
+  const project = { ...readSettingsFile(projectPath(cwd)) };
+  delete global.requiredExtensions;
+  delete project.requiredExtensions;
+  return { ...global, ...project };
+}
+
+function readRequiredExtensions(path: string): string[] {
+  if (!existsSync(path)) return [];
+  let parsed: unknown;
+  try {
+    parsed = JSON.parse(readFileSync(path, "utf-8"));
+  } catch (error) {
+    const reason = error instanceof Error ? error.message : String(error);
+    throw new Error(`Cannot enforce required subagent extensions from ${path}: ${reason}`);
+  }
+  if (!parsed || typeof parsed !== "object" || Array.isArray(parsed)) {
+    throw new Error(`Cannot enforce required subagent extensions: ${path} must contain an object`);
+  }
+  const value = (parsed as Record<string, unknown>).requiredExtensions;
+  if (value === undefined) return [];
+  if (!Array.isArray(value) || value.some((entry) => typeof entry !== "string" || !entry.trim())) {
+    throw new Error(`Cannot enforce required subagent extensions: ${path}.requiredExtensions must contain non-empty strings`);
+  }
+  return [...new Set(value as string[])];
+}
+
+/** Resolve globally required extension paths relative to the Pi agent directory. */
+export function loadRequiredExtensionPaths(agentDir: string = getAgentDir()): string[] {
+  return readRequiredExtensions(globalPath(agentDir)).map((entry) => {
+    if (entry === "~" || entry.startsWith("~/")) return join(homedir(), entry.slice(2));
+    return isAbsolute(entry) ? entry : join(agentDir, entry);
+  });
 }
 
 /**

--- a/test/agent-runner-e2e.test.ts
+++ b/test/agent-runner-e2e.test.ts
@@ -23,7 +23,7 @@
  * provider registers in a different `pi-ai` module instance than the one
  * pi-coding-agent streams through, which is brittle and orthogonal to gating.)
  */
-import { mkdtempSync, rmSync } from "node:fs";
+import { existsSync, mkdirSync, mkdtempSync, rmSync, writeFileSync } from "node:fs";
 import { tmpdir } from "node:os";
 import { join, resolve } from "node:path";
 import { fileURLToPath } from "node:url";
@@ -52,15 +52,22 @@ function makePi() {
 describe("agent-runner end-to-end (real pi-mono session + real extension)", () => {
   let cwd: string;
   let faux: ReturnType<typeof registerFauxProvider>;
+  let originalAgentDir: string | undefined;
 
   beforeEach(() => {
     cwd = mkdtempSync(join(tmpdir(), "subagents-e2e-"));
+    originalAgentDir = process.env.PI_CODING_AGENT_DIR;
+    process.env.PI_CODING_AGENT_DIR = join(cwd, "agent");
+    mkdirSync(process.env.PI_CODING_AGENT_DIR, { recursive: true });
     // Only used as a valid Model object for createAgentSession; we never rely
     // on it actually streaming (we assert on the pre-prompt gated tool set).
     faux = registerFauxProvider({ provider: "faux", models: [{ id: "faux-1", contextWindow: 200_000 }] });
   });
   afterEach(() => {
     faux.unregister();
+    if (originalAgentDir === undefined) delete process.env.PI_CODING_AGENT_DIR;
+    else process.env.PI_CODING_AGENT_DIR = originalAgentDir;
+    delete process.env.PI_SUBAGENT_REQUIRED_MARKER;
     rmSync(cwd, { recursive: true, force: true });
   });
 
@@ -68,7 +75,7 @@ describe("agent-runner end-to-end (real pi-mono session + real extension)", () =
    * Register `cfg` as agent type "e2e", run it through the REAL runAgent, and
    * return the real session's active tool names captured at construction time.
    */
-  async function activeToolsFor(cfg: Partial<AgentConfig>): Promise<string[]> {
+  async function activeToolsFor(cfg: Partial<AgentConfig>, isolated = false, rethrow = false): Promise<string[]> {
     registerAgents(
       new Map([
         [
@@ -106,11 +113,13 @@ describe("agent-runner end-to-end (real pi-mono session + real extension)", () =
       await runAgent(ctx, "e2e", "go", {
         pi: makePi(),
         model,
+        isolated,
         onSessionCreated: (s) => {
           active = s.getActiveToolNames();
         },
       });
-    } catch {
+    } catch (error) {
+      if (rethrow) throw error;
       // A no-op/erroring prompt turn is fine — the gated tool set is fixed at
       // construction, which `onSessionCreated` already captured.
     }
@@ -128,6 +137,27 @@ describe("agent-runner end-to-end (real pi-mono session + real extension)", () =
     const active = await activeToolsFor({ extensions: false });
     expect(active).not.toContain(EXT_TOOL);
     for (const b of BUILTINS) expect(active).toContain(b);
+  });
+
+  it("loads global required handlers into isolated agents without exposing their tools", async () => {
+    const marker = join(cwd, "required-handler-loaded");
+    process.env.PI_SUBAGENT_REQUIRED_MARKER = marker;
+    writeFileSync(
+      join(process.env.PI_CODING_AGENT_DIR!, "subagents.json"),
+      JSON.stringify({ requiredExtensions: [FIXTURE] }),
+    );
+    const active = await activeToolsFor({ extensions: false }, true);
+    expect(existsSync(marker)).toBe(true);
+    expect(active).not.toContain(EXT_TOOL);
+    for (const b of BUILTINS) expect(active).toContain(b);
+  });
+
+  it("fails closed when a globally required extension cannot load", async () => {
+    writeFileSync(
+      join(process.env.PI_CODING_AGENT_DIR!, "subagents.json"),
+      JSON.stringify({ requiredExtensions: [join(cwd, "missing-policy.ts")] }),
+    );
+    await expect(activeToolsFor({ extensions: false }, true, true)).rejects.toThrow("Required subagent extension failed to load");
   });
 
   it("disallowedTools removes a real extension tool from the live session", async () => {

--- a/test/fixtures/e2e-probe-ext.mjs
+++ b/test/fixtures/e2e-probe-ext.mjs
@@ -10,6 +10,11 @@ import { writeFileSync } from "node:fs";
 import { Type } from "@sinclair/typebox";
 
 export default function (pi) {
+  pi.on("session_start", async () => {
+    if (process.env.PI_SUBAGENT_REQUIRED_MARKER) {
+      writeFileSync(process.env.PI_SUBAGENT_REQUIRED_MARKER, "loaded");
+    }
+  });
   pi.registerTool({
     name: "e2e_probe",
     label: "E2E Probe",

--- a/test/settings.test.ts
+++ b/test/settings.test.ts
@@ -5,6 +5,7 @@ import { afterEach, beforeEach, describe, expect, it, vi } from "vitest";
 import {
   applyAndEmitLoaded,
   applySettings,
+  loadRequiredExtensionPaths,
   loadSettings,
   persistToastFor,
   type SettingsAppliers,
@@ -61,6 +62,13 @@ describe("settings persistence", () => {
     expect(loadSettings(projectDir)).toEqual({});
   });
 
+  it("fails closed when global required extension settings are malformed", () => {
+    writeFileSync(globalFile(), "not json {{");
+    expect(() => loadRequiredExtensionPaths()).toThrow("Cannot enforce required subagent extensions");
+    writeGlobal({ requiredExtensions: [""] });
+    expect(() => loadRequiredExtensionPaths()).toThrow("must contain non-empty strings");
+  });
+
   it("loads from global when no project file", () => {
     writeGlobal({ maxConcurrent: 16, graceTurns: 10 });
     expect(loadSettings(projectDir)).toEqual({ maxConcurrent: 16, graceTurns: 10 });
@@ -69,6 +77,16 @@ describe("settings persistence", () => {
   it("loads from project when no global file", () => {
     writeProject({ maxConcurrent: 8, defaultJoinMode: "group" });
     expect(loadSettings(projectDir)).toEqual({ maxConcurrent: 8, defaultJoinMode: "group" });
+  });
+
+  it("keeps required extensions global-only", () => {
+    writeGlobal({ requiredExtensions: ["extensions/policy.ts", "~/shared-policy.ts"] });
+    writeProject({ requiredExtensions: ["./disable-policy.ts"] });
+    expect(loadSettings(projectDir)).not.toHaveProperty("requiredExtensions");
+    expect(loadRequiredExtensionPaths()).toEqual([
+      join(globalDir, "extensions/policy.ts"),
+      join(process.env.HOME!, "shared-policy.ts"),
+    ]);
   });
 
   it("merges global + project with project winning on conflicts", () => {


### PR DESCRIPTION
## Summary

- add global-only `requiredExtensions` settings for permission, audit, and policy handlers
- load those handlers in every child session, including `isolated: true` agents
- keep their registered tools outside the child model tool scope
- fail closed if global policy configuration is malformed or a required handler cannot load or bind

Project-local settings cannot override the global list. This lets security extensions enforce child tool calls without exposing their tools or enabling ordinary optional extensions.

## Testing

- `npm run typecheck`
- `npm test` — 1,312 passed, 4 skipped
- `npm run build`
- Biome checks
- real pi-mono E2E coverage for isolated handler binding, hidden tools, and missing-handler failure