### PR TITLE
fix(ui): close conversation viewer on Ctrl+C

### DIFF
--- a/src/ui/conversation-viewer.ts
+++ b/src/ui/conversation-viewer.ts
@@ -69,7 +69,7 @@ export class ConversationViewer implements Component {
       return;
     }
 
-    if (matchesKey(data, "escape") || matchesKey(data, "q")) {
+    if (matchesKey(data, "escape") || matchesKey(data, "ctrl+c") || matchesKey(data, "q")) {
       this.closed = true;
       this.done(undefined);
       return;

--- a/test/conversation-viewer.test.ts
+++ b/test/conversation-viewer.test.ts
@@ -109,6 +109,18 @@ describe("ConversationViewer cost display", () => {
 });
 
 describe("ConversationViewer", () => {
+  it("closes with Ctrl+C when not composing", () => {
+    const done = vi.fn();
+    const viewer = new ConversationViewer(
+      mockTui(), mockSession(), mockRecord(), undefined, ansiTheme(), done,
+    );
+
+    viewer.handleInput("\x03");
+
+    expect(done).toHaveBeenCalledOnce();
+    expect(done).toHaveBeenCalledWith(undefined);
+  });
+
   describe("render width safety", () => {
     const widths = [40, 80, 120, 216];
 


### PR DESCRIPTION
## Summary

- Close `ConversationViewer` when it receives Ctrl+C outside the steer input.
- Add a regression test for this behavior.

## Why

pi-subagents can be used from pi-web by entering `/agents`. This opens the agents screen, where selecting an agent displays its conversation in `ConversationViewer`.

pi-web shows a Close button above this conversation. In this integration, clicking the button sends Ctrl+C to `ConversationViewer`, which is then responsible for closing itself.

Before this change, `ConversationViewer` only recognized Escape and `q` as close commands. It ignored Ctrl+C, so the visible Close button in pi-web appeared to do nothing even though pressing Escape worked.

Ctrl+C already cancels the steer input when the user is composing a message. The new check runs only after that input has handled the key, preserving the existing layered behavior:

1. Ctrl+C while composing cancels the steer input and returns to the conversation.
2. Ctrl+C from the conversation closes `ConversationViewer`.

## Impact

- The Close button works when viewing an agent conversation through pi-web.
- Ctrl+C closes the conversation when no steer input is active.
- Ctrl+C still cancels the steer input first when composing.
- Existing Escape, `q`, and scrolling behavior is unchanged.
- No changes were made to pi-web, RPC handling, or scroll keybindings.

## Testing

- Biome check passed.
- TypeScript typecheck passed.
- Full test suite passed: 1389 passed, 4 skipped.
- Build passed.
