### PR TITLE
feat(concurrency): maxConcurrentForeground — a separate, opt-in limit for blocking subagents

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -7,6 +7,9 @@ and this project adheres to [Semantic Versioning](https://semver.org/spec/v2.0.0
 
 ## [Unreleased]
 
+### Added
+- **`maxConcurrentForeground` — an opt-in concurrency limit for blocking subagents** ([#253](https://github.com/tintinweb/pi-subagents/issues/253) — thanks [@WinPooh32](https://github.com/WinPooh32)). `maxConcurrent` never covered foreground agents, and pi dispatches a message's tool calls through `Promise.all`, so several `Agent` calls with `run_in_background: false` in one message ran with no ceiling at all — expensive rather than fast on local models, where parallel agents thrash the prompt cache. They now queue in a second pool, deliberately independent of `maxConcurrent`: a foreground agent blocks the parent anyway, so charging it to the background pool would let a saturated pool starve the main session. Default `0` = unlimited, which is the existing behaviour exactly; set it at `/agents → Settings → Max foreground concurrency` or in `subagents.json`, applied live. A waiting agent shows in `/agents` as `queued` and can be stopped there or with Esc. Nested children are exempt — their parent is blocked *awaiting them*, so queueing a child behind its own parent would deadlock — as are detached spawns and foreground `resume`.
+
 ## [0.18.1] - 2026-08-24
 
 ### Added

--- a/README.md
+++ b/README.md
@@ -486,7 +486,7 @@ There are two independent pools.
 
 The two are deliberately **not** one limit. A foreground agent blocks the parent anyway — the parent could have done that work itself without paying a slot — so charging it to the background pool would let a saturated pool starve the main session.
 
-Neither pool bounds `resume`: a foreground resume reuses an existing session and never reaches the spawn path, so several blocking resumes in one message can still run at once.
+The foreground pool does not cover `resume`: a foreground resume reopens an existing session and never reaches the spawn path, so several blocking resumes in one message can still run at once. A *background* resume does take a background slot and queues behind them like any other background agent.
 
 ## Join Strategies
 

--- a/README.md
+++ b/README.md
@@ -340,7 +340,7 @@ allowed_subagents: support-file-finder, support-callsite-tracer   # or `all`
 
 The hard cap is depth 2 by default: main session (0) → subagent (1) → nested child (2). Change it project-wide with `maxSubagentDepth` in `subagents.json` (or `/agents → Settings → Nested depth`); `0` or `1` turns nesting off everywhere. An agent already at the cap gets no nested tools at all — not even `get_subagent_result`, since it can never own a child. A child must independently set `allowed_subagents` to delegate again; isolated agents never receive nested tools.
 
-Nested children don't occupy `maxConcurrent` slots — their parent already holds one, and queueing them behind it would deadlock a parent waiting on its own child. The depth cap bounds how *deep* nesting goes, not how *wide*: a parent's only limit on concurrent children is that each spawn costs it a turn. Pair `allowed_subagents` with a `max_turns` on that agent if you want a hard ceiling on its fan-out.
+Nested children occupy no concurrency slot, in either pool — their parent already holds one, and queueing them behind it would deadlock a parent waiting on its own child. The depth cap bounds how *deep* nesting goes, not how *wide*: a parent's only limit on concurrent children is that each spawn costs it a turn. Pair `allowed_subagents` with a `max_turns` on that agent if you want a hard ceiling on its fan-out.
 
 Because a subagent session never activates this extension (that is what keeps a child from building a second agent manager, and it is why nested tools are injected directly instead), a subagent also gets none of the extension's other surfaces: no `/agents` command, no cross-extension RPC handlers, no `subagents:ready` event.
 
@@ -447,7 +447,7 @@ The `/agents` command opens an interactive menu:
 Running agents (2) — 1 running, 1 done     ← only shown when agents exist
 Agent types (6)                             ← unified list: defaults + custom
 Create new agent                            ← manual wizard or AI-generated
-Settings                                    ← max concurrency, max turns, grace turns, join mode
+Settings                                    ← max concurrency (background + foreground), max turns, grace turns, join mode
 ```
 
 - **Running agents** — select one to open its live conversation viewer. While it's still running, press `Enter` to open the steering composer, then `Enter` again to send a message that redirects the agent (same mechanism as the `steer_subagent` tool; `Esc` or an empty submit returns), or press `x` (then `x` again to confirm) to stop/abort it — including **background** agents, which a global Esc can't unambiguously target (Esc still stops a blocking foreground `Agent` call). A stopped agent reports its partial output flagged as incomplete, not as a completion. `m` cycles how much of the transcript renders as Markdown — see [Viewer markdown](#persistent-settings).
@@ -459,7 +459,7 @@ Settings                                    ← max concurrency, max turns, grac
 - **Eject** — writes the embedded default config as a `.md` file to project or personal location, so you can customize it
 - **Disable/Enable** — toggle agent availability. Disabled agents stay visible in the list (marked `✕`) and can be re-enabled
 - **Create new agent** — choose project/personal location, then manual wizard (step-by-step prompts for name, tools, model, thinking, system prompt) or AI-generated (describe what the agent should do and a sub-agent writes the `.md` file). Any name is allowed, including default agent names (overrides them)
-- **Settings** — configure max concurrency, default max turns, grace turns, and join mode at runtime
+- **Settings** — configure max concurrency (background and foreground), default max turns, grace turns, and join mode at runtime
 
 ## Graceful Max Turns
 
@@ -478,9 +478,15 @@ Instead of hard-aborting at the turn limit, agents get a graceful shutdown:
 
 ## Concurrency
 
-Background agents are subject to a configurable concurrency limit (default: 10). Excess agents are automatically queued and start as running agents complete. The widget shows queued agents as a collapsed count.
+There are two independent pools.
 
-Foreground agents bypass the queue — they block the parent anyway. Since agents run in the background by default, nearly every spawn now takes a slot; the limit was raised from 4 so that ordinary parallel fan-outs don't queue.
+**Background** (`maxConcurrent`, default 10). Excess agents are automatically queued and start as running agents complete. The widget shows queued agents as a collapsed count. Since agents run in the background by default, nearly every spawn takes a slot; the limit was raised from 4 so that ordinary parallel fan-outs don't queue.
+
+**Foreground** (`maxConcurrentForeground`, default `0` = unlimited). Off by default, so nothing changes unless you set it. pi dispatches a message's tool calls through `Promise.all`, so several `Agent` calls with `run_in_background: false` in one message have always started at once — this bounds that. Useful mainly with local models, where parallel agents thrash the prompt cache ([#253](https://github.com/tintinweb/pi-subagents/issues/253)). A queued foreground agent appears in `/agents → Running agents` as `queued` and can be stopped there; its `Agent` call says so while it waits and then returns its result normally.
+
+The two are deliberately **not** one limit. A foreground agent blocks the parent anyway — the parent could have done that work itself without paying a slot — so charging it to the background pool would let a saturated pool starve the main session.
+
+Neither pool bounds `resume`: a foreground resume reuses an existing session and never reaches the spawn path, so several blocking resumes in one message can still run at once.
 
 ## Join Strategies
 
@@ -521,12 +527,12 @@ When on, each subagent spawn's effective model is validated against pi's own `en
 
 ## Persistent Settings
 
-Runtime tuning values set via `/agents` → Settings (max concurrency, default max turns, grace turns, nested depth, fallback agent, default join mode, scheduling on/off, scope models on/off, disable defaults on/off, strict agent files on/off, agent mentions on/off, output transcript on/off, tool description full/compact/custom, widget all/background/off, usage reporting on/off, cost display on/off, model display on/off, viewer markdown off/assistant/all) persist across pi restarts. Two files, merged on load:
+Runtime tuning values set via `/agents` → Settings (max concurrency, max foreground concurrency, default max turns, grace turns, nested depth, fallback agent, default join mode, scheduling on/off, scope models on/off, disable defaults on/off, strict agent files on/off, agent mentions on/off, output transcript on/off, tool description full/compact/custom, widget all/background/off, usage reporting on/off, cost display on/off, model display on/off, viewer markdown off/assistant/all) persist across pi restarts. Two files, merged on load:
 
 - **Global:** `~/.pi/agent/subagents.json` — your machine-wide defaults. Edit by hand; the `/agents` menu never writes here.
 - **Project:** `<cwd>/.pi/subagents.json` — per-project overrides. Written by `/agents` → Settings.
 
-**Precedence:** project overrides global on any field present in both. Missing fields fall back to the hardcoded defaults (max concurrency `10`, default max turns unlimited, grace turns `5`, nested depth `2`, join mode `smart`, defaults enabled).
+**Precedence:** project overrides global on any field present in both. Missing fields fall back to the hardcoded defaults (max concurrency `10`, max foreground concurrency `0` = unlimited, default max turns unlimited, grace turns `5`, nested depth `2`, join mode `smart`, defaults enabled).
 
 **Nested depth** (`maxSubagentDepth`, default `2`): the hard ceiling on [nested delegation](#nested-subagents), counted from the main session (main = 0, its subagents = 1). `0` or `1` disables nesting project-wide regardless of any agent's `allowed_subagents`. Read when a subagent session is built, so a change applies to agents started after it.
 
@@ -699,7 +705,7 @@ pi.events.emit("subagents:rpc:spawn", {
 });
 ```
 
-`options` is the manager's spawn-option object, not the `Agent` tool's parameter schema — the background flag is `isBackground`, and the tool's snake_case `run_in_background` is forwarded verbatim and ignored. Every RPC spawn returns its id immediately and runs detached either way; `isBackground: true` is what makes the agent occupy one of the `maxConcurrent` slots (and queue behind them when they are full) and what `subagents:created` reports. Leaving it unset starts the agent immediately regardless of the limit. A top-level RPC spawn renders in the widget and FleetView while it runs, with the same live tool activity and turn counter an `Agent`-tool spawn gets — only an explicit `isBackground: false` is dropped by the widget's default `background` mode, the way a foreground `Agent` call is. Nested spawns stay hidden from both.
+`options` is the manager's spawn-option object, not the `Agent` tool's parameter schema — the background flag is `isBackground`, and the tool's snake_case `run_in_background` is forwarded verbatim and ignored. Every RPC spawn returns its id immediately and runs detached either way; `isBackground: true` is what makes the agent occupy one of the `maxConcurrent` slots (and queue behind them when they are full) and what `subagents:created` reports. Leaving it unset starts the agent immediately regardless of the limit. `maxConcurrentForeground` never applies here whatever `isBackground` says: it bounds only spawns a caller is blocking on inline, and every RPC spawn is detached. A top-level RPC spawn renders in the widget and FleetView while it runs, with the same live tool activity and turn counter an `Agent`-tool spawn gets — only an explicit `isBackground: false` is dropped by the widget's default `background` mode, the way a foreground `Agent` call is. Nested spawns stay hidden from both.
 
 `options.model` accepts either a `Model` object (e.g. `ctx.model`) or a `"provider/modelId"` string — strings are resolved against `ctx.modelRegistry` at the RPC boundary, so cross-extension callers can forward serializable values without losing auth context.
 

--- a/src/agent-manager.ts
+++ b/src/agent-manager.ts
@@ -806,9 +806,13 @@ export class AgentManager {
       this.onComplete?.(record);
     }
 
-    // Only when a slot actually came free. Foreground runs with the pool off
-    // hold nothing, so this stays the no-drain path it has always been.
-    if (pool !== undefined) this.drainQueue();
+    // `options.isBackground` reproduces the pre-pool condition exactly — a
+    // background settle has always drained, even for a nested child that held
+    // no slot — so that path is unchanged whether or not the foreground pool is
+    // on. The `pool` half only adds the drain a freed FOREGROUND slot needs.
+    // A drain with nothing freed is a no-op anyway, but "no-op" is a claim
+    // about reachability, and matching the old condition needs no such claim.
+    if (options.isBackground || pool !== undefined) this.drainQueue();
   }
 
   /**

--- a/src/agent-manager.ts
+++ b/src/agent-manager.ts
@@ -125,11 +125,8 @@ function occupiesPoolSlot(record: Pick<AgentRecord, "isBackground" | "parentAgen
  * Like the background pool this bounds width at the top level only — a parent's
  * own fan-out is limited by nothing but its turn budget.
  */
-function occupiesForegroundSlot(
-  record: Pick<AgentRecord, "parentAgentId">,
-  blocking: boolean | undefined,
-): boolean {
-  return blocking === true && record.parentAgentId === undefined;
+function occupiesForegroundSlot(record: Pick<AgentRecord, "blocking" | "parentAgentId">): boolean {
+  return !!record.blocking && record.parentAgentId === undefined;
 }
 
 /** Which concurrency pool a spawn is charged to, if any. */
@@ -396,11 +393,9 @@ export class AgentManager {
    * pins them; the observable half — that the default start stays synchronous —
    * is pinned in `test/foreground-concurrency.test.ts`.
    */
-  private poolFor(record: AgentRecord, options: Pick<SpawnOptions, "blocking">): Pool | undefined {
+  private poolFor(record: AgentRecord): Pool | undefined {
     if (occupiesPoolSlot(record)) return "background";
-    if (this.maxConcurrentForeground > 0 && occupiesForegroundSlot(record, options.blocking)) {
-      return "foreground";
-    }
+    if (this.maxConcurrentForeground > 0 && occupiesForegroundSlot(record)) return "foreground";
     return undefined;
   }
 
@@ -459,6 +454,10 @@ export class AgentManager {
       // only filter excludes only explicit `false`, so undefined agents — which
       // have no inline surface — stay visible instead of vanishing.
       isBackground: options.isBackground,
+      // Whether anyone is awaiting this agent is a property of the agent, not
+      // of the call that made it — and both settle paths need it long after
+      // `options` has stopped being the interesting object.
+      blocking: options.blocking,
       invocation: options.invocation,
       depth: options.depth ?? 1,
       parentAgentId: options.parentAgentId,
@@ -475,7 +474,7 @@ export class AgentManager {
 
     const args: SpawnArgs = { pi, ctx, type, prompt, options };
 
-    const pool = this.poolFor(record, options);
+    const pool = this.poolFor(record);
     if (pool !== undefined && !options.bypassQueue && !this.poolHasRoom(pool)) {
       // Queue it — started when a running agent in the same pool completes.
       // Idempotent for background (already "queued"); the flip that matters is
@@ -483,14 +482,13 @@ export class AgentManager {
       record.status = "queued";
       // A queued record never reaches startAgent's signal wiring, so arm the
       // parent abort here or Esc could not release the position.
-      const armed = this.armQueuedAbort(id, options.signal);
-      if (armed === undefined) return id; // already aborted — never enqueued
+      if (!this.armQueuedAbort(id, options.signal)) return id;
       let release!: () => void;
       record.startGate = new Promise<void>(resolve => { release = resolve; });
       this.queue.push({
         id,
         pool,
-        start: () => { armed(); this.startAgent(id, record, args); },
+        start: () => this.startAgent(id, record, args),
         release: () => release(),
       });
       options.onQueued?.(id, this.queue.filter(e => e.pool === pool).length - 1);
@@ -513,25 +511,28 @@ export class AgentManager {
    * `startAgent` does this for running agents, and a queued record never gets
    * there, so without this Esc could not release a queue position.
    *
-   * Returns a detach closure the queue entry calls before `startAgent` installs
-   * its own listener, so the two never coexist — or `undefined` when the signal
-   * is already aborted, in which case the record is stopped here and MUST NOT
-   * be enqueued: `addEventListener` would never fire and a `spawnAndWait` on it
-   * would wait forever, pi having no tool-execution timeout to bail it out.
+   * Returns false when the signal is ALREADY aborted, in which case the record
+   * is stopped here and must not be enqueued: `addEventListener` never fires on
+   * an aborted signal, so a `spawnAndWait` on it would wait forever — pi has no
+   * tool-execution timeout to bail it out.
+   *
+   * The listener is left in place when the agent starts. `startAgent` adds its
+   * own, so both fire on a later abort, but `abort()` on an already-stopped
+   * record is a no-op — so detaching would only be tidiness, and tidiness the
+   * `abortAll`/`dispose` paths could not offer anyway.
    */
-  private armQueuedAbort(id: string, signal?: AbortSignal): (() => void) | undefined {
-    if (signal === undefined) return () => {};
+  private armQueuedAbort(id: string, signal?: AbortSignal): boolean {
+    if (signal === undefined) return true;
     if (signal.aborted) {
       const record = this.agents.get(id);
       if (record) {
         record.status = "stopped";
         record.completedAt = Date.now();
       }
-      return undefined;
+      return false;
     }
-    const onAbort = () => this.abort(id);
-    signal.addEventListener("abort", onAbort, { once: true });
-    return () => signal.removeEventListener("abort", onAbort);
+    signal.addEventListener("abort", () => this.abort(id), { once: true });
+    return true;
   }
 
   /** Actually start an agent (called immediately or from queue drain). */
@@ -576,12 +577,12 @@ export class AgentManager {
     record.startGate = undefined;
     // After the worktree throw point above, so a strict-isolation failure can
     // never leak a slot the run does not hold. Resolved ONCE, here, and carried
-    // to `settlePools` below: `poolFor` reads `maxConcurrentForeground`, which
+    // to `settleRun` below: `poolFor` reads `maxConcurrentForeground`, which
     // the user can change from `/agents → Settings` mid-run, so recomputing it
     // at settle time would decrement a pool this run never charged (counter
     // underflow, limit silently lifted) or skip the decrement for one it did
     // (leaked slot — every later blocking spawn queues forever).
-    const pool = this.poolFor(record, options);
+    const pool = this.poolFor(record);
     if (pool === "background") this.runningBackground++;
     else if (pool === "foreground") this.runningForeground++;
     this.onStart?.(record);
@@ -729,7 +730,7 @@ export class AgentManager {
 
         this.abortOwnedChildren(id);
 
-        this.settlePools(record, options, true, pool);
+        this.settleRun(record, true, pool);
         return responseText;
       })
       .catch((err) => {
@@ -758,7 +759,7 @@ export class AgentManager {
 
         this.abortOwnedChildren(id);
 
-        this.settlePools(record, options, false, pool);
+        this.settleRun(record, false, pool);
         return "";
       });
 
@@ -790,13 +791,8 @@ export class AgentManager {
    *   recomputed, so a mid-run change to `maxConcurrentForeground` can't make
    *   the release disagree with the acquire.
    */
-  private settlePools(
-    record: AgentRecord,
-    options: SpawnOptions,
-    guardCallback: boolean,
-    pool: Pool | undefined,
-  ): void {
-    if (!options.isBackground) record.resultConsumed = true;
+  private settleRun(record: AgentRecord, guardCallback: boolean, pool: Pool | undefined): void {
+    if (!record.isBackground) record.resultConsumed = true;
     if (pool === "background") this.runningBackground--;
     else if (pool === "foreground") this.runningForeground--;
 
@@ -806,13 +802,13 @@ export class AgentManager {
       this.onComplete?.(record);
     }
 
-    // `options.isBackground` reproduces the pre-pool condition exactly — a
+    // The isBackground half reproduces the pre-pool condition exactly — a
     // background settle has always drained, even for a nested child that held
     // no slot — so that path is unchanged whether or not the foreground pool is
     // on. The `pool` half only adds the drain a freed FOREGROUND slot needs.
     // A drain with nothing freed is a no-op anyway, but "no-op" is a claim
     // about reachability, and matching the old condition needs no such claim.
-    if (options.isBackground || pool !== undefined) this.drainQueue();
+    if (record.isBackground || pool !== undefined) this.drainQueue();
   }
 
   /**
@@ -849,7 +845,7 @@ export class AgentManager {
         // Late failure (e.g. strict worktree-isolation) — surface on the record
         // so the user/agent can see it via /agents, then keep draining.
         if (record) {
-          // Mirrors settlePools: an inline caller gets this failure as a throw
+          // Mirrors settleRun: an inline caller gets this failure as a throw
           // out of spawnAndWait, so an unconsumed record would ALSO nudge the
           // session about it — the same failure reported twice.
           if (next.pool === "foreground") record.resultConsumed = true;

--- a/src/agent-manager.ts
+++ b/src/agent-manager.ts
@@ -1,10 +1,17 @@
 /**
  * agent-manager.ts — Tracks agents, background execution, resume support.
  *
- * Background agents are subject to a configurable concurrency limit (default: 4).
- * Excess agents are queued and auto-started as running agents complete.
- * Foreground agents bypass the queue (they block the parent anyway), and so do
- * nested children — see `occupiesPoolSlot`.
+ * There are two independent concurrency pools, never one:
+ *
+ * - Background (`maxConcurrent`, default 10) bounds detached agents.
+ * - Foreground (`maxConcurrentForeground`, default 0 = unlimited) bounds
+ *   agents a caller is blocking on inline — `spawnAndWait`.
+ *
+ * Independent by design: a foreground agent blocks the parent anyway, so
+ * charging it to the background pool would let a saturated pool starve the main
+ * session of work it could have done itself. Excess agents in either pool are
+ * queued and auto-started as slots free up. Nested children take no slot in
+ * either — see `occupiesPoolSlot` / `occupiesForegroundSlot`.
  */
 
 import { randomUUID } from "node:crypto";
@@ -45,6 +52,18 @@ export type CompactionInfo = { reason: "manual" | "threshold" | "overflow"; toke
  * tool description tells the model to send.
  */
 const DEFAULT_MAX_CONCURRENT = 10;
+
+/**
+ * Default max concurrent foreground (blocking) agents — `0` = unlimited, the
+ * extension's existing convention for "no ceiling" (`defaultMaxTurns`).
+ *
+ * Off by default because nothing here ever bounded foreground work, and pi
+ * dispatches a message's tool calls through `Promise.all`, so an unqualified
+ * fan-out of blocking `Agent` calls has always run all at once. Users who want
+ * it bounded — chiefly local models, where parallel agents thrash the prompt
+ * cache (#253) — opt in; everyone else keeps today's behaviour exactly.
+ */
+const DEFAULT_MAX_CONCURRENT_FOREGROUND = 0;
 
 /**
  * How many evicted agents stay addressable by name. Only a bound on memory —
@@ -88,6 +107,34 @@ function occupiesPoolSlot(record: Pick<AgentRecord, "isBackground" | "parentAgen
   return !!record.isBackground && record.parentAgentId === undefined;
 }
 
+/**
+ * Whether a record occupies one of the `maxConcurrentForeground` slots.
+ *
+ * Keyed on `blocking` — a caller awaiting this record inline — rather than on
+ * `isBackground === false`, because `spawn()` is also the funnel for DETACHED
+ * starts (cross-extension RPC, `@handle` mentions, the registry) that may pass
+ * `isBackground: false` and are documented to run immediately regardless. Those
+ * block nobody, so bounding them buys nothing and would park a record with no
+ * one waiting to release it.
+ *
+ * Nested children are excluded for the same reason as `occupiesPoolSlot`, and
+ * more sharply: their parent is blocked *awaiting them*, so queueing a child
+ * behind its own parent is a guaranteed deadlock rather than a possible one.
+ * Enforced here rather than at the call site so no caller can reintroduce it.
+ *
+ * Like the background pool this bounds width at the top level only — a parent's
+ * own fan-out is limited by nothing but its turn budget.
+ */
+function occupiesForegroundSlot(
+  record: Pick<AgentRecord, "parentAgentId">,
+  blocking: boolean | undefined,
+): boolean {
+  return blocking === true && record.parentAgentId === undefined;
+}
+
+/** Which concurrency pool a spawn is charged to, if any. */
+type Pool = "background" | "foreground";
+
 interface SpawnArgs {
   pi: ExtensionAPI;
   ctx: ExtensionContext;
@@ -130,11 +177,23 @@ interface SpawnOptions {
   thinkingLevel?: ThinkingLevel;
   isBackground?: boolean;
   /**
-   * Skip the maxConcurrent queue check for this spawn — start immediately even
-   * if the configured concurrency limit would otherwise queue it. Used by the
-   * scheduler so a fired job can't be deferred past its trigger window.
+   * Skip whichever pool's queue check applies to this spawn — start immediately
+   * even if the configured concurrency limit would otherwise queue it. The slot
+   * is still COUNTED once the run starts, so a bypassing spawn transiently
+   * exceeds the limit rather than being invisible to it.
+   *
+   * Used by the scheduler, so a fired job can't be deferred past its trigger
+   * window, and by the `/agents` agent-file generator, which has no way to
+   * cancel a wait (see its call site).
    */
   bypassQueue?: boolean;
+  /**
+   * A caller is awaiting this record inline (`spawnAndWait`) — what
+   * `maxConcurrentForeground` bounds. Set only by `spawnAndWait`; stripped from
+   * caller-supplied options by `spawnTopLevel`, since a forged `blocking` would
+   * defer a detached start behind a queue its caller cannot see or release.
+   */
+  blocking?: boolean;
   /** Isolation mode — "worktree" creates a temp git worktree for the agent. */
   isolation?: IsolationMode;
   /**
@@ -150,6 +209,22 @@ interface SpawnOptions {
   invocation?: AgentInvocation;
   /** Parent abort signal — when aborted, the subagent is also stopped. */
   signal?: AbortSignal;
+  /**
+   * Called synchronously once the record is in the map and its promise is set,
+   * before `onSessionCreated` fires — where callers attach the output file.
+   *
+   * Carried on the options rather than parked on the manager for the duration
+   * of a spawn: with a foreground queue, `startAgent` can run at drain time,
+   * long after any such field would have been restored, and the callback would
+   * silently never fire (or fire into an unrelated caller's closure).
+   */
+  onSpawned?: (id: string) => void;
+  /**
+   * Called synchronously when the spawn is queued instead of started, with how
+   * many entries in its own pool are ahead of it. The foreground UI uses it to
+   * say so while it waits; nothing else needs it.
+   */
+  onQueued?: (id: string, ahead: number) => void;
   /** Called on tool start/end with activity info (for streaming progress to UI). */
   onToolActivity?: (activity: ToolActivity) => void;
   /** Called on streaming text deltas from the assistant response. */
@@ -239,6 +314,7 @@ export class AgentManager {
   private onCompact?: OnAgentCompact;
   private onUsage?: OnAgentUsage;
   private maxConcurrent: number;
+  private maxConcurrentForeground = DEFAULT_MAX_CONCURRENT_FOREGROUND;
   /** Base repos worktrees were created from — so dispose() can prune them all,
    *  not just the parent repo (caller-supplied cwd can target other repos). */
   private worktreeRepos = new Set<string>();
@@ -251,10 +327,21 @@ export class AgentManager {
    */
   private tombstones = new Map<string, AgentTombstone>();
 
-  /** Queue of background agents waiting to start. */
-  private queue: { id: string; start: () => void }[] = [];
+  /**
+   * Agents waiting to start, tagged with the pool they wait on. One queue for
+   * both pools: `drainQueue` picks the earliest entry whose own pool has room,
+   * so neither can head-of-line-block the other, and every removal path
+   * (`abort`, `abortAll`, `dispose`) stays a single filter.
+   *
+   * `release` wakes a caller blocked in `spawnAndWait`. Removing an entry from
+   * this array MUST release it — a queued record has no promise to await, and
+   * pi has no tool-execution timeout to bail the caller out.
+   */
+  private queue: { id: string; pool: Pool; start: () => void; release: () => void }[] = [];
   /** Number of currently running background agents. */
   private runningBackground = 0;
+  /** Number of currently running foreground (blocking) agents. */
+  private runningForeground = 0;
 
   constructor(
     onComplete?: OnAgentComplete,
@@ -282,6 +369,45 @@ export class AgentManager {
 
   getMaxConcurrent(): number {
     return this.maxConcurrent;
+  }
+
+  /** Update the max concurrent foreground (blocking) agents limit. 0 = unlimited. */
+  setMaxConcurrentForeground(n: number) {
+    // Floor 0, not 1: unlimited is a meaningful value here and the default.
+    this.maxConcurrentForeground = Math.max(0, n);
+    // Start queued agents if the new limit allows — including everything, when
+    // the limit is cleared back to unlimited mid-run.
+    this.drainQueue();
+  }
+
+  getMaxConcurrentForeground(): number {
+    return this.maxConcurrentForeground;
+  }
+
+  /**
+   * Which pool a spawn is charged to, or undefined for one that is charged to
+   * neither (nested children, detached non-background spawns).
+   *
+   * Nothing here queues when the limit is unset — `poolHasRoom` reports an
+   * unlimited pool as always having room, so that alone is what keeps the
+   * default path identical. The `> 0` guard is belt and braces on top: it also
+   * keeps the counter from churning and the settle path from calling a drain
+   * that would find nothing to do. Both are unobservable, which is why no test
+   * pins them; the observable half — that the default start stays synchronous —
+   * is pinned in `test/foreground-concurrency.test.ts`.
+   */
+  private poolFor(record: AgentRecord, options: Pick<SpawnOptions, "blocking">): Pool | undefined {
+    if (occupiesPoolSlot(record)) return "background";
+    if (this.maxConcurrentForeground > 0 && occupiesForegroundSlot(record, options.blocking)) {
+      return "foreground";
+    }
+    return undefined;
+  }
+
+  private poolHasRoom(pool: Pool): boolean {
+    return pool === "background"
+      ? this.runningBackground < this.maxConcurrent
+      : this.maxConcurrentForeground === 0 || this.runningForeground < this.maxConcurrentForeground;
   }
 
   /**
@@ -318,6 +444,9 @@ export class AgentManager {
       // see the handle this record just took, since both come out of the same
       // namespace.
       alias: options.parentAgentId === undefined ? options.reclaim?.alias : undefined,
+      // Overwritten below when the spawn is actually queued; a foreground spawn
+      // that queues flips to "queued" there rather than being guessed at here,
+      // since the pool decision needs the finished record.
       status: options.isBackground ? "queued" : "running",
       toolUses: 0,
       startedAt: Date.now(),
@@ -346,9 +475,25 @@ export class AgentManager {
 
     const args: SpawnArgs = { pi, ctx, type, prompt, options };
 
-    if (occupiesPoolSlot(record) && !options.bypassQueue && this.runningBackground >= this.maxConcurrent) {
-      // Queue it — will be started when a running agent completes
-      this.queue.push({ id, start: () => this.startAgent(id, record, args) });
+    const pool = this.poolFor(record, options);
+    if (pool !== undefined && !options.bypassQueue && !this.poolHasRoom(pool)) {
+      // Queue it — started when a running agent in the same pool completes.
+      // Idempotent for background (already "queued"); the flip that matters is
+      // a blocking foreground spawn, optimistically marked "running" above.
+      record.status = "queued";
+      // A queued record never reaches startAgent's signal wiring, so arm the
+      // parent abort here or Esc could not release the position.
+      const armed = this.armQueuedAbort(id, options.signal);
+      if (armed === undefined) return id; // already aborted — never enqueued
+      let release!: () => void;
+      record.startGate = new Promise<void>(resolve => { release = resolve; });
+      this.queue.push({
+        id,
+        pool,
+        start: () => { armed(); this.startAgent(id, record, args); },
+        release: () => release(),
+      });
+      options.onQueued?.(id, this.queue.filter(e => e.pool === pool).length - 1);
       return id;
     }
 
@@ -361,6 +506,32 @@ export class AgentManager {
       throw err;
     }
     return id;
+  }
+
+  /**
+   * Wire a parent abort signal for a record that is about to be QUEUED.
+   * `startAgent` does this for running agents, and a queued record never gets
+   * there, so without this Esc could not release a queue position.
+   *
+   * Returns a detach closure the queue entry calls before `startAgent` installs
+   * its own listener, so the two never coexist — or `undefined` when the signal
+   * is already aborted, in which case the record is stopped here and MUST NOT
+   * be enqueued: `addEventListener` would never fire and a `spawnAndWait` on it
+   * would wait forever, pi having no tool-execution timeout to bail it out.
+   */
+  private armQueuedAbort(id: string, signal?: AbortSignal): (() => void) | undefined {
+    if (signal === undefined) return () => {};
+    if (signal.aborted) {
+      const record = this.agents.get(id);
+      if (record) {
+        record.status = "stopped";
+        record.completedAt = Date.now();
+      }
+      return undefined;
+    }
+    const onAbort = () => this.abort(id);
+    signal.addEventListener("abort", onAbort, { once: true });
+    return () => signal.removeEventListener("abort", onAbort);
   }
 
   /** Actually start an agent (called immediately or from queue drain). */
@@ -402,15 +573,31 @@ export class AgentManager {
 
     record.status = "running";
     record.startedAt = Date.now();
-    if (occupiesPoolSlot(record)) this.runningBackground++;
+    record.startGate = undefined;
+    // After the worktree throw point above, so a strict-isolation failure can
+    // never leak a slot the run does not hold. Resolved ONCE, here, and carried
+    // to `settlePools` below: `poolFor` reads `maxConcurrentForeground`, which
+    // the user can change from `/agents → Settings` mid-run, so recomputing it
+    // at settle time would decrement a pool this run never charged (counter
+    // underflow, limit silently lifted) or skip the decrement for one it did
+    // (leaked slot — every later blocking spawn queues forever).
+    const pool = this.poolFor(record, options);
+    if (pool === "background") this.runningBackground++;
+    else if (pool === "foreground") this.runningForeground++;
     this.onStart?.(record);
 
     // Wire parent abort signal to stop the subagent when the parent is interrupted
     let detachParentSignal: (() => void) | undefined;
     if (options.signal) {
-      const onParentAbort = () => this.abort(id);
-      options.signal.addEventListener("abort", onParentAbort, { once: true });
-      detachParentSignal = () => options.signal!.removeEventListener("abort", onParentAbort);
+      // A queued spawn can start minutes after the caller handed us its signal,
+      // by which time it may already be aborted — and `addEventListener` would
+      // never fire, leaving a child the parent can no longer reach.
+      if (options.signal.aborted) this.abort(id);
+      else {
+        const onParentAbort = () => this.abort(id);
+        options.signal.addEventListener("abort", onParentAbort, { once: true });
+        detachParentSignal = () => options.signal!.removeEventListener("abort", onParentAbort);
+      }
     }
     const detach = () => { detachParentSignal?.(); detachParentSignal = undefined; };
 
@@ -542,16 +729,7 @@ export class AgentManager {
 
         this.abortOwnedChildren(id);
 
-        // Fire onComplete for foreground agents too — lifecycle symmetry.
-        // Mark resultConsumed so the callback skips notifications (result returned inline).
-        if (!options.isBackground) {
-          record.resultConsumed = true;
-          try { this.onComplete?.(record); } catch { /* ignore completion side-effect errors */ }
-        } else {
-          if (occupiesPoolSlot(record)) this.runningBackground--;
-          try { this.onComplete?.(record); } catch { /* ignore completion side-effect errors */ }
-          this.drainQueue();
-        }
+        this.settlePools(record, options, true, pool);
         return responseText;
       })
       .catch((err) => {
@@ -580,16 +758,7 @@ export class AgentManager {
 
         this.abortOwnedChildren(id);
 
-        // Fire onComplete for foreground agents too — lifecycle symmetry.
-        // Mark resultConsumed so the callback skips notifications (result returned inline).
-        if (!options.isBackground) {
-          record.resultConsumed = true;
-          this.onComplete?.(record);
-        } else {
-          if (occupiesPoolSlot(record)) this.runningBackground--;
-          this.onComplete?.(record);
-          this.drainQueue();
-        }
+        this.settlePools(record, options, false, pool);
         return "";
       });
 
@@ -597,8 +766,49 @@ export class AgentManager {
 
     // Notify caller that spawn is complete (record is in the map, promise is set).
     // Called synchronously — onSessionCreated fires asynchronously inside runAgent.
-    // Used by spawnAndWait to let the caller set up output files before streaming starts.
-    this.onSpawned?.(id);
+    // Used by spawnAndWait to let the caller set up output files before streaming
+    // starts. Read off the options, so a spawn that started from a queue drain
+    // still reaches the caller that queued it.
+    options.onSpawned?.(id);
+  }
+
+  /**
+   * The shared tail of both settle paths: release whatever pool slot the run
+   * held, notify, and let the queue drain into the freed slot.
+   *
+   * The decrement lives HERE and nowhere else. `abort()` on a running record
+   * only fires its controller and leaves the run to settle normally, so
+   * decrementing there too would double-free — permanently lifting the limit.
+   *
+   * Foreground agents fire `onComplete` for lifecycle symmetry, with
+   * `resultConsumed` set so the callback skips notifications the inline result
+   * already delivered.
+   *
+   * @param guardCallback swallow a throwing `onComplete` (the success path does;
+   *   the error path historically did not, and keeps not doing so).
+   * @param pool the pool this run was CHARGED TO at start time — passed in, not
+   *   recomputed, so a mid-run change to `maxConcurrentForeground` can't make
+   *   the release disagree with the acquire.
+   */
+  private settlePools(
+    record: AgentRecord,
+    options: SpawnOptions,
+    guardCallback: boolean,
+    pool: Pool | undefined,
+  ): void {
+    if (!options.isBackground) record.resultConsumed = true;
+    if (pool === "background") this.runningBackground--;
+    else if (pool === "foreground") this.runningForeground--;
+
+    if (guardCallback) {
+      try { this.onComplete?.(record); } catch { /* ignore completion side-effect errors */ }
+    } else {
+      this.onComplete?.(record);
+    }
+
+    // Only when a slot actually came free. Foreground runs with the pool off
+    // hold nothing, so this stays the no-drain path it has always been.
+    if (pool !== undefined) this.drainQueue();
   }
 
   /**
@@ -613,35 +823,61 @@ export class AgentManager {
     }
   }
 
-  /** Start queued agents up to the concurrency limit. */
+  /**
+   * Start queued agents up to each pool's concurrency limit.
+   *
+   * `findIndex` on the entry's OWN pool rather than `shift`: with one queue
+   * serving two independent limits, a saturated foreground pool at the head
+   * would otherwise stall every background agent behind it. Taking the earliest
+   * eligible entry keeps FIFO within each pool, which is what callers see.
+   */
   private drainQueue() {
-    while (this.queue.length > 0 && this.runningBackground < this.maxConcurrent) {
-      const next = this.queue.shift()!;
+    for (;;) {
+      const i = this.queue.findIndex(e => this.poolHasRoom(e.pool));
+      if (i === -1) return;
+      const [next] = this.queue.splice(i, 1);
       const record = this.agents.get(next.id);
-      if (!record || record.status !== "queued") continue;
       try {
-        next.start();
+        // Stale entries (aborted while queued) are skipped, not started — but
+        // still released below, since nothing else will.
+        if (record && record.status === "queued") next.start();
       } catch (err) {
         // Late failure (e.g. strict worktree-isolation) — surface on the record
         // so the user/agent can see it via /agents, then keep draining.
-        record.status = "error";
-        record.error = err instanceof Error ? err.message : String(err);
-        record.completedAt = Date.now();
-        this.onComplete?.(record);
+        if (record) {
+          // Mirrors settlePools: an inline caller gets this failure as a throw
+          // out of spawnAndWait, so an unconsumed record would ALSO nudge the
+          // session about it — the same failure reported twice.
+          if (next.pool === "foreground") record.resultConsumed = true;
+          record.status = "error";
+          record.error = err instanceof Error ? err.message : String(err);
+          record.completedAt = Date.now();
+          this.onComplete?.(record);
+        }
+      } finally {
+        next.release();
       }
     }
   }
 
   /**
-   * Called synchronously right after spawn, before onSessionCreated fires.
-   * Lets the caller set up the output file path on the record.
-   * The record is guaranteed to be in this.agents at this point.
+   * Remove queued entries and wake anyone blocked on them. The single point
+   * that enforces "leaving the queue releases the waiter" — a missed release is
+   * an unbounded hang, not a failed call.
    */
-  private onSpawned?: (id: string) => void;
+  private dequeue(pred: (entry: { id: string; pool: Pool }) => boolean): void {
+    const kept: typeof this.queue = [];
+    for (const entry of this.queue) {
+      if (pred(entry)) entry.release();
+      else kept.push(entry);
+    }
+    this.queue = kept;
+  }
 
   /**
    * Spawn an agent and wait for completion (foreground use).
-   * Foreground agents bypass the concurrency queue.
+   * Charged to the foreground pool (`maxConcurrentForeground`), which is
+   * unlimited by default; never to the background one.
    * Returns { id, record } so callers can access the agent ID.
    *
    * @param onSpawned - Called synchronously after spawn(), before onSessionCreated fires.
@@ -655,20 +891,35 @@ export class AgentManager {
     options: Omit<SpawnOptions, "isBackground">,
     onSpawned?: (id: string) => void,
   ): Promise<{ id: string; record: AgentRecord }> {
-    // Temporarily register the onSpawned hook so startAgent can call it.
-    const prevOnSpawned = this.onSpawned;
-    this.onSpawned = onSpawned;
-    let id: string;
-    try {
-      // spawn() invokes onSpawned synchronously before returning. Restore the
-      // shared hook immediately so unrelated concurrent spawns cannot inherit
-      // this foreground caller's callback while its run is awaited.
-      id = this.spawn(pi, ctx, type, prompt, { ...options, isBackground: false });
-    } finally {
-      this.onSpawned = prevOnSpawned;
-    }
+    // `blocking` is what maxConcurrentForeground bounds, and this is its only
+    // source. onSpawned rides on the options rather than on a field of this
+    // manager: a queued spawn starts at drain time, long after any install/
+    // restore pair around this call would have put the field back.
+    const id = this.spawn(pi, ctx, type, prompt, {
+      ...options,
+      isBackground: false,
+      blocking: true,
+      onSpawned,
+    });
     const record = this.agents.get(id)!;
-    await record.promise;
+
+    // Queued: nothing to await yet — the promise appears when the drain starts
+    // it. The gate resolves (never rejects) on every path out of the queue,
+    // start and abort alike, so a rejection can never escape into the caller's
+    // tool `execute` and take down pi's whole Promise.all tool batch.
+    if (record.status === "queued") await record.startGate;
+
+    // undefined when it was aborted while queued and so never ran — the record
+    // is already "stopped" with a completedAt, which is what the caller renders.
+    if (record.promise) await record.promise;
+
+    // A record that ended "error" without ever getting a promise never ran: the
+    // same startup failure spawn() rethrows on the immediate path (#179). Keep
+    // one contract rather than letting queue pressure decide whether a strict
+    // worktree failure throws or returns as a result.
+    if (record.promise === undefined && record.status === "error") {
+      throw new Error(record.error ?? "Agent failed to start");
+    }
     return { id, record };
   }
 
@@ -710,9 +961,10 @@ export class AgentManager {
       record.status = "queued";
 
       const start = () => this.startResume(id, record, prompt, signal, options);
-      if (occupiesPoolSlot(record) && this.runningBackground >= this.maxConcurrent) {
-        // At the concurrency limit — queue it, drains when a slot frees.
-        this.queue.push({ id, start });
+      if (occupiesPoolSlot(record) && !this.poolHasRoom("background")) {
+        // At the concurrency limit — queue it, drains when a slot frees. A
+        // detached resume has no inline caller, hence nothing to release.
+        this.queue.push({ id, pool: "background", start, release: () => {} });
       } else {
         start();
       }
@@ -961,9 +1213,11 @@ export class AgentManager {
     const record = this.agents.get(id);
     if (!record) return false;
 
-    // Remove from queue if queued
+    // Remove from queue if queued. No decrement — the slot was never taken —
+    // and no onComplete, matching what a queued background abort has always
+    // done; a blocking caller learns of the stop from its own tool result.
     if (record.status === "queued") {
-      this.queue = this.queue.filter(q => q.id !== id);
+      this.dequeue(q => q.id === id);
       record.status = "stopped";
       record.completedAt = Date.now();
       return true;
@@ -1064,7 +1318,7 @@ export class AgentManager {
         count++;
       }
     }
-    this.queue = [];
+    this.dequeue(() => true);
     // Abort running agents
     for (const record of this.agents.values()) {
       if (record.status === "running") {
@@ -1083,6 +1337,11 @@ export class AgentManager {
     // agents finish they start queued ones, which need awaiting too.
     while (true) {
       this.drainQueue();
+      // filter(Boolean) drops queued records, which have no promise yet. Safe by
+      // invariant, not by construction: a slot can only be HELD by a running
+      // record, which does have one, so `pending` is never empty while anything
+      // is queued. If record.promise ever starts being assigned later than
+      // startAgent, this becomes a silent early return.
       const pending = [...this.agents.values()]
         .filter(r => r.status === "running" || r.status === "queued")
         .map(r => r.promise)
@@ -1094,8 +1353,9 @@ export class AgentManager {
 
   async dispose(): Promise<void> {
     clearInterval(this.cleanupInterval);
-    // Clear queue
-    this.queue = [];
+    // Clear queue — via dequeue, so anyone blocked in spawnAndWait is woken
+    // rather than left awaiting a gate nothing will ever resolve.
+    this.dequeue(() => true);
     const sessions = [...this.agents.values()].map(record => record.session);
     this.agents.clear();
     // Awaited, unlike the eviction path: pi awaits this extension's `session_shutdown`

--- a/src/index.ts
+++ b/src/index.ts
@@ -661,6 +661,10 @@ export default function (pi: ExtensionAPI) {
     // Bypasses handle allocation, so a forged value would duplicate a live
     // agent's name and make `@handle` ambiguous. Same rule: dispatcher only.
     delete safeOptions.reclaim;
+    // Every spawn through here is DETACHED — the caller gets an id back and
+    // awaits nothing. A forged `blocking` would charge it to the foreground
+    // pool and could defer it behind a queue whose gate nobody is holding.
+    delete safeOptions.blocking;
     return spawnResolved(piRef, ctxRef, type, prompt, safeOptions);
   };
 
@@ -1302,6 +1306,7 @@ export default function (pi: ExtensionAPI) {
   applyAndEmitLoaded(
     {
       setMaxConcurrent: (n) => manager.setMaxConcurrent(n),
+      setMaxConcurrentForeground: (n) => manager.setMaxConcurrentForeground(n),
       setDefaultMaxTurns,
       setGraceTurns,
       setDefaultJoinMode,
@@ -2018,6 +2023,10 @@ Terse command-style prompts produce shallow, generic work.
       let spinnerFrame = 0;
       const startedAt = Date.now();
       let fgId: string | undefined;
+      // Set only while the spawn is parked on a foreground concurrency slot
+      // (maxConcurrentForeground); undefined the rest of the time, including
+      // always when the limit is unset.
+      let queuedAhead: number | undefined;
 
       const streamUpdate = () => {
         // Spend from the record, everything else from the live tracker. `fgId`
@@ -2032,8 +2041,15 @@ Terse command-style prompts produce shallow, generic work.
           turnCount: fgState.turnCount,
           maxTurns: fgState.maxTurns,
           durationMs: Date.now() - startedAt,
+          // Deliberately still "running" while queued: the renderer routes any
+          // status it doesn't know to raw text (see the catch-all below), which
+          // would drop the spinner and read as hung. Only the activity line
+          // changes — "thinking…" would be a lie for an agent that has not
+          // started and may not for minutes.
           status: "running",
-          activity: describeActivity(fgState.activeTools, fgState.responseText),
+          activity: queuedAhead === undefined
+            ? describeActivity(fgState.activeTools, fgState.responseText)
+            : `queued — waiting for a foreground slot${queuedAhead > 0 ? ` (${queuedAhead} ahead)` : ""}`,
           spinnerFrame: spinnerFrame % SPINNER.length,
         };
         onUpdate?.({
@@ -2050,6 +2066,13 @@ Terse command-style prompts produce shallow, generic work.
       const origOnSession = fgCallbacks.onSessionCreated;
       fgCallbacks.onSessionCreated = (session: any) => {
         origOnSession(session);
+        // It really started — stop reporting it as queued, and repaint now
+        // rather than leaving the stale line up for the next spinner tick.
+        // Guarded, so a spawn that never queued emits no extra update.
+        if (queuedAhead !== undefined) {
+          queuedAhead = undefined;
+          streamUpdate();
+        }
         for (const a of manager.listAgents()) {
           if (a.session === session) {
             fgId = a.id;
@@ -2091,6 +2114,10 @@ Terse command-style prompts produce shallow, generic work.
           invocation: agentInvocation,
           signal,
           rootSessionId: ctx.sessionManager.getSessionId(),
+          // Deliberately does NOT set fgId: that drives agentActivity, the
+          // widget and the `finally` cleanup below, none of which should see an
+          // agent that has no session and may never get one.
+          onQueued: (_id, ahead) => { queuedAhead = ahead; streamUpdate(); },
           ...fgCallbacks,
         }, (fgAgentId) => {
           // onSpawned: called synchronously after spawn, before onSessionCreated fires.
@@ -2766,6 +2793,12 @@ Write the file using the write tool. Only write the file, nothing else.`;
     const { record } = await manager.spawnAndWait(pi, ctx, "general-purpose", generatePrompt, {
       description: `Generate ${name} agent`,
       maxTurns: 5,
+      // Exempt from maxConcurrentForeground. This runs from a modal wizard, not
+      // a tool call: it passes no signal, and Esc in `ctx.ui` never reaches the
+      // manager — so a user waiting behind a full pool would have no way to
+      // cancel at all. It is also one human action that cannot fan out, which
+      // is what the limit exists to bound. It still counts once started.
+      bypassQueue: true,
     });
 
     if (record.status === "error") {
@@ -2869,6 +2902,8 @@ Write the file using the write tool. Only write the file, nothing else.`;
   function snapshotSettings() {
     return {
       maxConcurrent: manager.getMaxConcurrent(),
+      // 0 = unlimited, and the default — see SubagentsSettings.
+      maxConcurrentForeground: manager.getMaxConcurrentForeground(),
       // 0 = unlimited — per SubagentsSettings.defaultMaxTurns docstring and
       // normalizeMaxTurns() in agent-runner.ts (which maps 0 → undefined).
       defaultMaxTurns: getDefaultMaxTurns() ?? 0,
@@ -2910,11 +2945,14 @@ Write the file using the write tool. Only write the file, nothing else.`;
   const _settingsSnapshotIsComplete: _NoMissingSettingsKeys = true;
   void _settingsSnapshotIsComplete;
 
-  const NUMERIC_IDS = new Set(["maxConcurrent", "defaultMaxTurns", "graceTurns", "maxSubagentDepth"]);
+  const NUMERIC_IDS = new Set([
+    "maxConcurrent", "maxConcurrentForeground", "defaultMaxTurns", "graceTurns", "maxSubagentDepth",
+  ]);
 
   async function showSettings(ctx: ExtensionCommandContext) {
     function buildItems(): SettingItem[] {
       const mc = manager.getMaxConcurrent();
+      const mcf = manager.getMaxConcurrentForeground();
       const dmt = getDefaultMaxTurns() ?? 0;
       const gt = getGraceTurns();
       const msd = getMaxSubagentDepth();
@@ -2933,6 +2971,13 @@ Write the file using the write tool. Only write the file, nothing else.`;
           description: "Max concurrent background agents (Enter to type)",
           currentValue: String(mc),
           values: [String(mc)],
+        },
+        {
+          id: "maxConcurrentForeground",
+          label: "Max foreground concurrency",
+          description: "Max concurrent foreground (blocking) agents (0 = unlimited, Enter to type)",
+          currentValue: String(mcf),
+          values: [String(mcf)],
         },
         {
           id: "defaultMaxTurns",
@@ -3095,6 +3140,15 @@ Write the file using the write tool. Only write the file, nothing else.`;
         if (n >= 1) {
           manager.setMaxConcurrent(n);
           notifyApplied(ctx, `Max concurrency set to ${n}`);
+        }
+      } else if (id === "maxConcurrentForeground") {
+        // 0 is meaningful here, unlike maxConcurrent above: it means unlimited.
+        const n = parseInt(value, 10);
+        if (n >= 0) {
+          manager.setMaxConcurrentForeground(n);
+          notifyApplied(ctx, n === 0
+            ? "Max foreground concurrency set to unlimited"
+            : `Max foreground concurrency set to ${n}`);
         }
       } else if (id === "defaultMaxTurns") {
         const n = parseInt(value, 10);
@@ -3275,19 +3329,23 @@ Write the file using the write tool. Only write the file, nothing else.`;
     if (result && NUMERIC_IDS.has(result)) {
       const current = result === "maxConcurrent"
         ? String(manager.getMaxConcurrent())
-        : result === "defaultMaxTurns"
-          ? String(getDefaultMaxTurns() ?? 0)
-          : result === "maxSubagentDepth"
-            ? String(getMaxSubagentDepth())
-            : String(getGraceTurns());
+        : result === "maxConcurrentForeground"
+          ? String(manager.getMaxConcurrentForeground())
+          : result === "defaultMaxTurns"
+            ? String(getDefaultMaxTurns() ?? 0)
+            : result === "maxSubagentDepth"
+              ? String(getMaxSubagentDepth())
+              : String(getGraceTurns());
 
       const label = result === "maxConcurrent"
         ? "Max concurrency (1+)"
-        : result === "defaultMaxTurns"
-          ? "Default max turns (0 = unlimited)"
-          : result === "maxSubagentDepth"
-            ? "Nested depth (0/1 = nesting off)"
-            : "Grace turns (1+)";
+        : result === "maxConcurrentForeground"
+          ? "Max foreground concurrency (0 = unlimited)"
+          : result === "defaultMaxTurns"
+            ? "Default max turns (0 = unlimited)"
+            : result === "maxSubagentDepth"
+              ? "Nested depth (0/1 = nesting off)"
+              : "Grace turns (1+)";
 
       // Loop until user enters a valid integer or cancels (Esc / null).
       // Silently trims whitespace; rejects non-numeric input by re-prompting.

--- a/src/settings.ts
+++ b/src/settings.ts
@@ -11,6 +11,28 @@ import type { AgentMentionMode, JoinMode, ViewerMarkdownMode, WidgetMode } from 
 export interface SubagentsSettings {
   maxConcurrent?: number;
   /**
+   * Max concurrent FOREGROUND (blocking) agents — `0` = unlimited, the default,
+   * which preserves the behaviour that has always applied: nothing bounded
+   * foreground work, and pi dispatches a message's tool calls through
+   * `Promise.all`, so an unqualified fan-out of blocking `Agent` calls runs all
+   * at once. Set it to bound that (#253 — on local models, parallel agents
+   * thrash the prompt cache).
+   *
+   * Deliberately independent of `maxConcurrent` rather than folded into it: a
+   * foreground agent blocks the parent anyway, so charging it to the background
+   * pool would let a saturated pool starve the main session of work it could
+   * have done itself.
+   *
+   * Bounds only spawns a caller is blocking on inline. Nested children are
+   * exempt — their parent is blocked awaiting them, so queueing a child behind
+   * its own parent would deadlock — and so are detached spawns from
+   * cross-extension RPC or `@handle` mentions, which block nobody and are
+   * documented to start immediately. Foreground `resume` is also outside the
+   * pool: it reuses an existing session and never reaches the spawn path, so
+   * several blocking resumes in one message can still exceed the limit.
+   */
+  maxConcurrentForeground?: number;
+  /**
    * 0 = unlimited — the extension's single source of truth for that convention:
    * `normalizeMaxTurns()` in agent-runner.ts treats 0 → `undefined`, and the
    * `/agents` → Settings input prompt explicitly says "0 = unlimited".
@@ -266,6 +288,7 @@ export type ToolDescriptionMode = "full" | "compact" | "custom";
 /** Setter hooks used by applySettings to wire persisted values into in-memory state. */
 export interface SettingsAppliers {
   setMaxConcurrent: (n: number) => void;
+  setMaxConcurrentForeground: (n: number) => void;
   setDefaultMaxTurns: (n: number) => void;
   setGraceTurns: (n: number) => void;
   setDefaultJoinMode: (mode: JoinMode) => void;
@@ -317,6 +340,15 @@ function sanitize(raw: unknown): SubagentsSettings {
     (r.maxConcurrent as number) <= MAX_CONCURRENT_CEILING
   ) {
     out.maxConcurrent = r.maxConcurrent as number;
+  }
+  // Floor 0, not 1 like maxConcurrent above: 0 is the documented "unlimited"
+  // value and the default, so dropping it would silently be unrepresentable.
+  if (
+    Number.isInteger(r.maxConcurrentForeground) &&
+    (r.maxConcurrentForeground as number) >= 0 &&
+    (r.maxConcurrentForeground as number) <= MAX_CONCURRENT_CEILING
+  ) {
+    out.maxConcurrentForeground = r.maxConcurrentForeground as number;
   }
   if (
     Number.isInteger(r.defaultMaxTurns) &&
@@ -455,6 +487,9 @@ export function saveSettings(s: SubagentsSettings, cwd: string = process.cwd()):
 /** Apply persisted settings to the in-memory state via caller-supplied setters. */
 export function applySettings(s: SubagentsSettings, appliers: SettingsAppliers): void {
   if (typeof s.maxConcurrent === "number") appliers.setMaxConcurrent(s.maxConcurrent);
+  if (typeof s.maxConcurrentForeground === "number") {
+    appliers.setMaxConcurrentForeground(s.maxConcurrentForeground);
+  }
   if (typeof s.defaultMaxTurns === "number") appliers.setDefaultMaxTurns(s.defaultMaxTurns);
   if (typeof s.graceTurns === "number") appliers.setGraceTurns(s.graceTurns);
   if (typeof s.maxSubagentDepth === "number") appliers.setMaxSubagentDepth(s.maxSubagentDepth);

--- a/src/types.ts
+++ b/src/types.ts
@@ -181,6 +181,14 @@ export interface AgentRecord {
   abortController?: AbortController;
   promise?: Promise<string>;
   /**
+   * A caller is awaiting this agent inline (`spawnAndWait`) — what
+   * `maxConcurrentForeground` bounds. Distinct from `isBackground === false`,
+   * which says only that the agent has an inline result surface: a detached
+   * cross-extension RPC spawn is foreground by that measure and yet blocks
+   * nobody, so it takes no slot.
+   */
+  blocking?: boolean;
+  /**
    * Present only while the record is "queued": resolves when it leaves the
    * queue, started or aborted. `spawnAndWait` waits on this because a queued
    * record has no `promise` yet. Always resolves, never rejects — a rejection

--- a/src/types.ts
+++ b/src/types.ts
@@ -180,6 +180,14 @@ export interface AgentRecord {
   session?: AgentSession;
   abortController?: AbortController;
   promise?: Promise<string>;
+  /**
+   * Present only while the record is "queued": resolves when it leaves the
+   * queue, started or aborted. `spawnAndWait` waits on this because a queued
+   * record has no `promise` yet. Always resolves, never rejects — a rejection
+   * would escape into the caller's tool `execute` and take down pi's whole
+   * Promise.all tool batch.
+   */
+  startGate?: Promise<void>;
   groupId?: string;
   joinMode?: JoinMode;
   /** Set when result was already consumed via get_subagent_result — suppresses completion notification. */

--- a/test/documented-defaults.test.ts
+++ b/test/documented-defaults.test.ts
@@ -51,6 +51,19 @@ describe("documented defaults (README:441)", () => {
     }
   });
 
+  // Off, not a number: nothing here ever bounded foreground work, and pi runs a
+  // message's tool calls through Promise.all, so any default above 0 would be a
+  // behaviour change for everyone rather than an opt-in for #253's reporter.
+  it("foreground concurrency is unlimited by default", async () => {
+    const { AgentManager } = await import("../src/agent-manager.js");
+    const manager = new AgentManager();
+    try {
+      expect(manager.getMaxConcurrentForeground()).toBe(0);
+    } finally {
+      manager.dispose();
+    }
+  });
+
   it("top-level spawns default to background, nested spawns to foreground", async () => {
     const { resolveAgentInvocationConfig } = await import("../src/invocation-config.js");
     // The setting's default (true) is what index.ts passes for top-level calls.

--- a/test/foreground-concurrency-print-mode-e2e.test.ts
+++ b/test/foreground-concurrency-print-mode-e2e.test.ts
@@ -1,0 +1,136 @@
+/**
+ * foreground-concurrency-print-mode-e2e.test.ts — does `maxConcurrentForeground`
+ * actually serialize a turn's blocking `Agent` calls, end to end?
+ *
+ * The unit and wiring tests call the tool's `execute` directly, twice, without
+ * awaiting the first. That MODELS pi's parallel dispatch; it does not prove the
+ * real agent loop behaves that way. This drives a real headless pi session, a
+ * real assistant turn emitting TWO `Agent` tool calls in ONE message, and lets
+ * pi's own `executeToolCallsParallel` dispatch them through `Promise.all`.
+ *
+ * Overlap is measured, not inferred: each child's faux model call increments an
+ * in-flight counter, holds for a real interval, then decrements. Two agents
+ * running at once drive `maxInFlight` to 2; serialized ones leave it at 1.
+ *
+ * The unlimited control case is what makes the limited one meaningful — it
+ * proves the detector can see parallelism at all, so `maxInFlight === 1` is a
+ * result rather than a broken probe.
+ */
+import { mkdirSync, mkdtempSync, rmSync, writeFileSync } from "node:fs";
+import { tmpdir } from "node:os";
+import { join } from "node:path";
+import type { Context } from "@earendil-works/pi-ai";
+import { afterEach, describe, expect, it, vi } from "vitest";
+import {
+  agentCall,
+  agentToolResults,
+  type PrintModeRun,
+  runPrintMode,
+} from "./helpers/print-mode-runner.js";
+
+// Real pi-mono: loader, dynamic extension import, three live sessions.
+vi.setConfig({ testTimeout: 60_000 });
+
+const LIVE = /^(1|true|yes)$/i.test(process.env.PI_E2E_LIVE ?? "");
+
+/** How long each child holds the model call — long enough to overlap detectably. */
+const CHILD_HOLD_MS = 120;
+
+describe.skipIf(LIVE)("maxConcurrentForeground e2e (real pi agent loop)", () => {
+  let run: PrintModeRun | undefined;
+  const tmpDirs: string[] = [];
+
+  afterEach(async () => {
+    await run?.dispose();
+    run = undefined;
+    for (const d of tmpDirs.splice(0)) rmSync(d, { recursive: true, force: true });
+  });
+
+  function projectDir(settings: Record<string, unknown>): string {
+    const dir = mkdtempSync(join(tmpdir(), "pi-fgconc-e2e-"));
+    tmpDirs.push(dir);
+    mkdirSync(join(dir, ".pi"), { recursive: true });
+    writeFileSync(
+      join(dir, ".pi", "subagents.json"),
+      JSON.stringify({ outputTranscript: false, ...settings }),
+    );
+    return dir;
+  }
+
+  /**
+   * One parent turn emitting two BLOCKING Agent calls in a single message —
+   * the shape pi dispatches through Promise.all — plus a child responder that
+   * measures how many children are in flight at once.
+   */
+  async function twoBlockingAgents(settings: Record<string, unknown>) {
+    let inFlight = 0;
+    let maxInFlight = 0;
+    const order: string[] = [];
+
+    run = await runPrintMode({
+      prompt: "Delegate two independent jobs and report both.",
+      cwd: projectDir(settings),
+      live: false, // scripted on purpose: a real model may not emit both calls
+      respond: async (context: Context) => {
+        const isParent = (context.tools ?? []).some(t => t.name === "Agent");
+        if (isParent) {
+          const alreadySpawned = context.messages.some(
+            m => m.role === "toolResult" && (m as { toolName?: string }).toolName === "Agent",
+          );
+          if (alreadySpawned) return "Both jobs are done.";
+          // TWO tool calls, ONE assistant message — exactly what the Agent tool
+          // description tells the model to send for parallel work.
+          return [
+            agentCall({ prompt: "JOB-ALPHA", description: "alpha", run_in_background: false }),
+            agentCall({ prompt: "JOB-BETA", description: "beta", run_in_background: false }),
+          ];
+        }
+
+        // A child. Hold the model call so genuine overlap is observable.
+        const label = JSON.stringify(context.messages).includes("JOB-ALPHA") ? "alpha" : "beta";
+        inFlight++;
+        maxInFlight = Math.max(maxInFlight, inFlight);
+        order.push(`start:${label}`);
+        await new Promise(r => setTimeout(r, CHILD_HOLD_MS));
+        order.push(`end:${label}`);
+        inFlight--;
+        return `${label.toUpperCase()}-RESULT`;
+      },
+    });
+
+    return { maxInFlight, order };
+  }
+
+  it("runs a turn's two blocking Agent calls one at a time when the limit is 1", async () => {
+    const { maxInFlight, order } = await twoBlockingAgents({ maxConcurrentForeground: 1 });
+
+    expect(maxInFlight).toBe(1);
+    // Strictly serialized: the first child ends before the second begins.
+    expect(order).toHaveLength(4);
+    expect(order[1]).toBe(order[0].replace("start:", "end:"));
+
+    // Serialization must not cost anyone their result — each call still returns
+    // its own agent's output to the parent.
+    const results = agentToolResults(run!.parentSession).join("\n");
+    expect(results).toContain("ALPHA-RESULT");
+    expect(results).toContain("BETA-RESULT");
+
+    // And the turn itself finished — the parent answered after both returned,
+    // rather than the second call being left parked on a slot nobody freed.
+    expect(run!.responseText).toContain("Both jobs are done.");
+  });
+
+  // The control. Without this, the assertion above could pass on a detector
+  // that never observes overlap in the first place.
+  it("runs them concurrently when the limit is unset — the detector works", async () => {
+    const { maxInFlight, order } = await twoBlockingAgents({ maxConcurrentForeground: 0 });
+
+    expect(maxInFlight).toBe(2);
+    // Interleaved: both start before either ends.
+    expect(order.slice(0, 2).every(e => e.startsWith("start:"))).toBe(true);
+
+    const results = agentToolResults(run!.parentSession).join("\n");
+    expect(results).toContain("ALPHA-RESULT");
+    expect(results).toContain("BETA-RESULT");
+  });
+});

--- a/test/foreground-concurrency-wiring.test.ts
+++ b/test/foreground-concurrency-wiring.test.ts
@@ -1,0 +1,177 @@
+/**
+ * foreground-concurrency-wiring.test.ts — `maxConcurrentForeground` (#253)
+ * through the REAL extension, at the layer the setting exists to serve.
+ *
+ * pi's agent loop runs a message's tool calls through `Promise.all`, so two
+ * blocking `Agent` calls in one message start within microseconds of each
+ * other. These tests dispatch them the same way — two `execute()` calls without
+ * awaiting the first — because that is the only shape in which the queue is
+ * reachable, and it is the shape that constrains everything else here:
+ *
+ *   a tool `execute` that REJECTS rejects that whole Promise.all, killing
+ *   unrelated tool calls in the same batch.
+ *
+ * So the Esc case below asserts `.resolves`, deliberately, not `.rejects`.
+ */
+import { afterEach, beforeEach, describe, expect, it, vi } from "vitest";
+
+vi.mock("../src/agent-runner.js", async () => {
+  const actual = await vi.importActual<typeof import("../src/agent-runner.js")>("../src/agent-runner.js");
+  return { ...actual, runAgent: vi.fn(), resumeAgent: vi.fn() };
+});
+
+import { runAgent } from "../src/agent-runner.js";
+import subagentsExtension from "../src/index.js";
+import { ctx, flush, type Hermetic, hermeticDir, makePi, textOf } from "./helpers/boot-extension.js";
+
+let hermetic: Hermetic | undefined;
+let booted: Map<string, any> | undefined;
+
+beforeEach(() => {
+  vi.mocked(runAgent).mockReset();
+});
+
+afterEach(async () => {
+  await booted?.get("session_shutdown")?.();
+  // The manager registry is a globalThis symbol released only on shutdown; a
+  // test that threw first would leave the next one reading a dead manager.
+  delete (globalThis as any)[Symbol.for("pi-subagents:manager")];
+  booted = undefined;
+  hermetic?.restore();
+  hermetic = undefined;
+});
+
+/** Boot the real extension with foreground concurrency pinned to one slot. */
+function boot(settings: Record<string, unknown> = {}) {
+  hermetic = hermeticDir({
+    settings: { outputTranscript: false, maxConcurrentForeground: 1, ...settings },
+  });
+  const b = makePi();
+  subagentsExtension(b.pi);
+  booted = b.lifecycle;
+  return b;
+}
+
+/** Runs that settle only when their resolver is called, keyed by prompt. */
+function controllableRuns() {
+  const resolvers = new Map<string, () => void>();
+  vi.mocked(runAgent).mockImplementation(
+    (_c: any, _t: any, prompt: any, opts: any) =>
+      new Promise<any>(resolve => {
+        opts.onSessionCreated?.({
+          dispose: vi.fn(),
+          subscribe: vi.fn(() => () => {}),
+          messages: [],
+          getActiveToolNames: vi.fn(() => []),
+        });
+        resolvers.set(prompt as string, () => resolve({
+          responseText: `${prompt}-RESULT`,
+          session: { dispose: vi.fn() },
+          aborted: false,
+          steered: false,
+        }));
+      }) as any,
+  );
+  return resolvers;
+}
+
+/** Dispatch a blocking Agent call the way pi does — without awaiting it. */
+function callForeground(tools: Map<string, any>, prompt: string, opts: {
+  signal?: AbortSignal;
+  onUpdate?: (u: any) => void;
+} = {}) {
+  return tools.get("Agent").execute(
+    `tc-${prompt}`,
+    { prompt, description: prompt, subagent_type: "general-purpose", run_in_background: false },
+    opts.signal,
+    opts.onUpdate,
+    ctx(),
+  );
+}
+
+describe("maxConcurrentForeground, through the Agent tool", () => {
+  it("runs blocking calls one at a time and returns each its own result", async () => {
+    const { tools } = boot();
+    const resolvers = controllableRuns();
+
+    const first = callForeground(tools, "alpha");
+    const second = callForeground(tools, "beta");
+    await flush();
+
+    // Only one started; "beta" is parked on the pool.
+    expect(runAgent).toHaveBeenCalledTimes(1);
+
+    resolvers.get("alpha")!();
+    expect(textOf(await first)).toContain("alpha-RESULT");
+
+    await flush();
+    expect(runAgent).toHaveBeenCalledTimes(2);
+    resolvers.get("beta")!();
+    expect(textOf(await second)).toContain("beta-RESULT");
+  });
+
+  // The Promise.all constraint. A queued agent aborted by Esc must come back as
+  // an ordinary stopped result, not as a throw that would take the batch down.
+  it("resolves a queued call as STOPPED when the turn is interrupted", async () => {
+    const { tools } = boot();
+    const resolvers = controllableRuns();
+
+    const controller = new AbortController();
+    const first = callForeground(tools, "alpha");
+    const second = callForeground(tools, "beta", { signal: controller.signal });
+    await flush();
+
+    controller.abort();
+
+    const result = await second; // resolves — never rejects
+    expect(textOf(result)).toContain("STOPPED BY THE USER");
+    expect(result.isError).toBeFalsy();
+
+    // Freeing the slot must not start the agent the user just stopped.
+    resolvers.get("alpha")!();
+    await first;
+    await flush();
+    expect(runAgent).toHaveBeenCalledTimes(1);
+  });
+
+  // "thinking…" would be a lie for an agent that has not started and may not
+  // for minutes. The row keeps its spinner either way — a status the renderer
+  // does not know falls through to raw text and reads as hung.
+  it("says it is queued in the live tool result, then stops saying it", async () => {
+    const { tools } = boot();
+    const resolvers = controllableRuns();
+
+    const firstUpdates: any[] = [];
+    const secondUpdates: any[] = [];
+    const first = callForeground(tools, "alpha", { onUpdate: u => firstUpdates.push(u) });
+    const second = callForeground(tools, "beta", { onUpdate: u => secondUpdates.push(u) });
+    await flush();
+
+    const queuedActivity = secondUpdates.map(u => u.details?.activity);
+    expect(queuedActivity.some((a: string) => a?.includes("waiting for a foreground slot"))).toBe(true);
+    expect(secondUpdates.at(-1)?.details?.status).toBe("running");
+    // The agent that actually started never claims to be queued.
+    expect(firstUpdates.every((u: any) => !u.details?.activity?.includes("queued"))).toBe(true);
+
+    resolvers.get("alpha")!();
+    await first;
+    await flush();
+
+    const afterStart = secondUpdates.at(-1)?.details?.activity;
+    expect(afterStart).not.toContain("waiting for a foreground slot");
+
+    resolvers.get("beta")!();
+    await second;
+  });
+
+  it("leaves blocking calls unbounded when the setting is unset", async () => {
+    const { tools } = boot({ maxConcurrentForeground: 0 });
+    const resolvers = controllableRuns();
+
+    const calls = ["a", "b", "c"].map(p => callForeground(tools, p));
+    await flush();
+    expect(runAgent).toHaveBeenCalledTimes(3);
+    for (const p of ["a", "b", "c"]) resolvers.get(p)!();
+    await Promise.all(calls);
+  });
+});

--- a/test/foreground-concurrency.test.ts
+++ b/test/foreground-concurrency.test.ts
@@ -259,6 +259,24 @@ describe("maxConcurrentForeground", () => {
       expect(runAgent).toHaveBeenCalledTimes(1);
     });
 
+    // The one behaviour change that is NOT gated on the setting. Before the
+    // pool, an already-aborted signal was still wired with addEventListener —
+    // which never fires — so the agent ran to completion beyond the reach of
+    // Esc or /agents. A queued spawn made that reachable often enough to fix;
+    // this pins it for the UNQUEUED path too, with the pool off.
+    it("stops an immediate spawn whose signal is already aborted, pool off", async () => {
+      controllableRuns();
+      manager = new AgentManager();
+      expect(manager.getMaxConcurrentForeground()).toBe(0);
+
+      const controller = new AbortController();
+      controller.abort();
+      void fg(manager, "doomed", { signal: controller.signal });
+
+      expect(recordFor(manager, "doomed").status).toBe("stopped");
+      expect(recordFor(manager, "doomed").abortController?.signal.aborted).toBe(true);
+    });
+
     it("releases queued waiters on abortAll()", async () => {
       controllableRuns();
       manager = new AgentManager();

--- a/test/foreground-concurrency.test.ts
+++ b/test/foreground-concurrency.test.ts
@@ -1,0 +1,510 @@
+// maxConcurrentForeground (#253) — a second, independent concurrency pool for
+// agents a caller is blocking on inline (`spawnAndWait`).
+//
+// pi dispatches a message's tool calls through `Promise.all`, so N blocking
+// `Agent` calls in one message have always started at once. This pool bounds
+// that. It is OFF by default, and the first test in this file is what keeps it
+// off: it fails the moment the default path grows an await, a counter or a
+// queue entry.
+//
+// The hangs are the dangerous failures here, not the assertion failures: a
+// queued record has no promise to await, and pi has no tool-execution timeout
+// anywhere, so a release() that never fires waits forever. Every test that
+// exercises a path out of the queue therefore asserts the waiter RESOLVES.
+
+import { afterEach, beforeEach, describe, expect, it, vi } from "vitest";
+import { AgentManager } from "../src/agent-manager.js";
+
+vi.mock("../src/agent-runner.js", () => ({
+  runAgent: vi.fn(),
+  resumeAgent: vi.fn(),
+}));
+
+vi.mock("../src/worktree.js", () => ({
+  createWorktree: vi.fn(),
+  cleanupWorktree: vi.fn(() => ({ hasChanges: false })),
+  pruneWorktrees: vi.fn(),
+  isWorktreeIsolationEnabled: vi.fn(() => true),
+}));
+
+import { runAgent } from "../src/agent-runner.js";
+import { createWorktree } from "../src/worktree.js";
+
+const mockPi = {} as any;
+const mockCtx = { cwd: "/tmp" } as any;
+const mockSession = () => ({ dispose: vi.fn() }) as any;
+
+/** Runs that settle only when their returned resolver is called, keyed by prompt. */
+function controllableRuns() {
+  const resolvers = new Map<string, () => void>();
+  // History, not just the implementation: these tests assert on call COUNTS,
+  // and vitest shares the module mock across the file.
+  vi.mocked(runAgent).mockClear();
+  vi.mocked(runAgent).mockImplementation((_ctx: any, _type: any, prompt: any) =>
+    new Promise<any>(resolve => {
+      resolvers.set(prompt as string, () => resolve({
+        responseText: `${prompt}-result`,
+        session: mockSession(),
+        aborted: false,
+        steered: false,
+      }));
+    }),
+  );
+  return resolvers;
+}
+
+/** Let queued microtasks (gate resolution, settle handlers) run. */
+const flush = () => new Promise<void>(resolve => setTimeout(resolve, 0));
+
+const fg = (manager: AgentManager, prompt: string, options: any = {}) =>
+  manager.spawnAndWait(mockPi, mockCtx, "general-purpose", prompt, {
+    description: prompt,
+    ...options,
+  });
+
+const bg = (manager: AgentManager, prompt: string, options: any = {}) =>
+  manager.spawn(mockPi, mockCtx, "general-purpose", prompt, {
+    description: prompt,
+    isBackground: true,
+    ...options,
+  });
+
+/** The record a spawnAndWait created, before it has necessarily started. */
+const recordFor = (manager: AgentManager, prompt: string) =>
+  manager.listAgents().find(a => a.description === prompt)!;
+
+describe("maxConcurrentForeground", () => {
+  let manager: AgentManager;
+
+  beforeEach(() => {
+    vi.mocked(runAgent).mockClear();
+  });
+
+  afterEach(() => {
+    manager?.dispose();
+    vi.mocked(createWorktree).mockReset();
+  });
+
+  // The governing constraint: a user who never sets this must see exactly the
+  // behaviour that shipped before it existed.
+  it("is unlimited by default, and the default path stays synchronous", () => {
+    controllableRuns();
+    manager = new AgentManager();
+
+    expect(manager.getMaxConcurrentForeground()).toBe(0);
+
+    void fg(manager, "a");
+    void fg(manager, "b");
+    void fg(manager, "c");
+
+    // Synchronously — not after a flush. A gate, a counter check that awaits,
+    // or a queue entry would all defer at least one of these. (The `> 0` guard
+    // inside poolFor is deliberately NOT pinned here: it is a belt-and-braces
+    // optimisation with no observable effect, since an unlimited pool always
+    // reports room anyway.)
+    expect(runAgent).toHaveBeenCalledTimes(3);
+    for (const p of ["a", "b", "c"]) expect(recordFor(manager, p).status).toBe("running");
+  });
+
+  it("queues blocking spawns past the limit and starts them as slots free, in order", async () => {
+    const resolvers = controllableRuns();
+    manager = new AgentManager();
+    manager.setMaxConcurrentForeground(1);
+
+    const first = fg(manager, "a");
+    const second = fg(manager, "b");
+    const third = fg(manager, "c");
+
+    expect(runAgent).toHaveBeenCalledTimes(1);
+    expect(recordFor(manager, "b").status).toBe("queued");
+    expect(recordFor(manager, "c").status).toBe("queued");
+
+    resolvers.get("a")!();
+    expect(await first).toMatchObject({ record: { status: "completed", result: "a-result" } });
+
+    // FIFO: "b" was queued first, so "b" runs — not "c".
+    expect(recordFor(manager, "b").status).toBe("running");
+    expect(recordFor(manager, "c").status).toBe("queued");
+
+    resolvers.get("b")!();
+    expect(await second).toMatchObject({ record: { result: "b-result" } });
+    resolvers.get("c")!();
+    expect(await third).toMatchObject({ record: { result: "c-result" } });
+  });
+
+  // The deadlock guard. A nested child's parent is blocked AWAITING it, so
+  // queueing the child behind its own parent can never make progress. Remove
+  // the parentAgentId clause from occupiesForegroundSlot and this test hangs.
+  it("never queues a nested child, however full the pool is", async () => {
+    controllableRuns();
+    manager = new AgentManager();
+    manager.setMaxConcurrentForeground(1);
+
+    void fg(manager, "parent");
+    expect(recordFor(manager, "parent").status).toBe("running");
+
+    void fg(manager, "child", { parentAgentId: recordFor(manager, "parent").id, depth: 2 });
+
+    expect(recordFor(manager, "child").status).toBe("running");
+    expect(runAgent).toHaveBeenCalledTimes(2);
+  });
+
+  // The requirement from #253: the two pools must not be able to starve each
+  // other. The whole reason foreground was exempt from maxConcurrent is that a
+  // full background pool must never block the main session's blocking work.
+  it("is independent of the background pool, in both directions", async () => {
+    controllableRuns();
+    manager = new AgentManager(undefined, 1); // maxConcurrent = 1
+    manager.setMaxConcurrentForeground(1);
+
+    bg(manager, "bg1");
+    bg(manager, "bg2");
+    expect(recordFor(manager, "bg1").status).toBe("running");
+    expect(recordFor(manager, "bg2").status).toBe("queued"); // background pool full
+
+    // A blocking spawn is not charged to the saturated background pool.
+    void fg(manager, "fg1");
+    expect(recordFor(manager, "fg1").status).toBe("running");
+
+    // ...and the now-saturated foreground pool does not queue anything else.
+    void fg(manager, "fg2");
+    expect(recordFor(manager, "fg2").status).toBe("queued");
+    expect(recordFor(manager, "bg2").status).toBe("queued"); // still only bg1's slot
+  });
+
+  // Detached spawns block nobody, so bounding them buys nothing — and would
+  // park a record with no one waiting to release it. README documents RPC
+  // spawns as starting immediately whatever isBackground says.
+  it("does not queue a detached spawn, even one flagged isBackground: false", () => {
+    controllableRuns();
+    manager = new AgentManager();
+    manager.setMaxConcurrentForeground(1);
+
+    void fg(manager, "holder");
+    manager.spawn(mockPi, mockCtx, "general-purpose", "rpc", {
+      description: "rpc",
+      isBackground: false,
+    });
+
+    expect(recordFor(manager, "rpc").status).toBe("running");
+  });
+
+  it("starts a bypassQueue spawn at the limit, and still counts its slot", async () => {
+    controllableRuns();
+    manager = new AgentManager();
+    manager.setMaxConcurrentForeground(1);
+
+    void fg(manager, "holder");
+    void fg(manager, "scheduled", { bypassQueue: true });
+    expect(recordFor(manager, "scheduled").status).toBe("running");
+
+    // Counted, not invisible: the pool is now over its limit, so the next
+    // ordinary blocking spawn queues.
+    void fg(manager, "next");
+    expect(recordFor(manager, "next").status).toBe("queued");
+  });
+
+  describe("cancellation", () => {
+    // A rejection here would escape into the caller's tool `execute` and reject
+    // pi's Promise.all for the entire tool batch, killing unrelated tool calls.
+    it("resolves — never rejects — when a queued agent is aborted", async () => {
+      const resolvers = controllableRuns();
+      manager = new AgentManager();
+      manager.setMaxConcurrentForeground(1);
+
+      void fg(manager, "holder");
+      const queued = fg(manager, "victim");
+      const victimId = recordFor(manager, "victim").id;
+
+      expect(manager.abort(victimId)).toBe(true);
+
+      const { record } = await queued;
+      expect(record.status).toBe("stopped");
+      expect(record.promise).toBeUndefined();
+      expect(record.completedAt).toBeDefined();
+
+      // Freeing the slot must not resurrect it.
+      resolvers.get("holder")!();
+      await flush();
+      expect(runAgent).toHaveBeenCalledTimes(1);
+    });
+
+    it("releases a queued agent when the caller's signal aborts (Esc)", async () => {
+      controllableRuns();
+      manager = new AgentManager();
+      manager.setMaxConcurrentForeground(1);
+
+      void fg(manager, "holder");
+      const controller = new AbortController();
+      const queued = fg(manager, "victim", { signal: controller.signal });
+      expect(recordFor(manager, "victim").status).toBe("queued");
+
+      controller.abort();
+      expect((await queued).record.status).toBe("stopped");
+    });
+
+    // addEventListener never fires on an already-aborted signal, so enqueueing
+    // here would wait forever — pi has no tool-execution timeout to bail out.
+    it("never enqueues a spawn whose signal is already aborted", async () => {
+      controllableRuns();
+      manager = new AgentManager();
+      manager.setMaxConcurrentForeground(1);
+
+      void fg(manager, "holder");
+      const controller = new AbortController();
+      controller.abort();
+
+      const { record } = await fg(manager, "victim", { signal: controller.signal });
+      expect(record.status).toBe("stopped");
+      expect(runAgent).toHaveBeenCalledTimes(1);
+    });
+
+    it("releases queued waiters on abortAll()", async () => {
+      controllableRuns();
+      manager = new AgentManager();
+      manager.setMaxConcurrentForeground(1);
+
+      void fg(manager, "holder");
+      const queued = fg(manager, "victim");
+
+      manager.abortAll();
+      expect((await queued).record.status).toBe("stopped");
+    });
+
+    // Without this, `afterEach(() => manager.dispose())` turns any failing test
+    // in this file into a hung suite instead of a red one.
+    it("releases queued waiters on dispose()", async () => {
+      controllableRuns();
+      manager = new AgentManager();
+      manager.setMaxConcurrentForeground(1);
+
+      void fg(manager, "holder");
+      const queued = fg(manager, "victim");
+
+      await manager.dispose();
+      await expect(queued).resolves.toBeDefined();
+    });
+  });
+
+  describe("slot accounting", () => {
+    it("frees the slot when a foreground agent fails", async () => {
+      const rejectors = new Map<string, (e: unknown) => void>();
+      vi.mocked(runAgent).mockImplementation((_c: any, _t: any, prompt: any) =>
+        new Promise<any>((_resolve, reject) => { rejectors.set(prompt as string, reject); }),
+      );
+      manager = new AgentManager();
+      manager.setMaxConcurrentForeground(1);
+
+      const first = fg(manager, "a");
+      void fg(manager, "b");
+      expect(recordFor(manager, "b").status).toBe("queued");
+
+      rejectors.get("a")!(new Error("boom"));
+      expect((await first).record.status).toBe("error");
+      expect(recordFor(manager, "b").status).toBe("running");
+    });
+
+    // Decrementing in abort() as well as in the settle path is a double-free
+    // that permanently lifts the limit. Three at a limit of one catches it: a
+    // double-free would start the third immediately.
+    it("frees the slot exactly once when a running agent is aborted", async () => {
+      const resolvers = controllableRuns();
+      manager = new AgentManager();
+      manager.setMaxConcurrentForeground(1);
+
+      const first = fg(manager, "a");
+      void fg(manager, "b");
+      void fg(manager, "c");
+
+      manager.abort(recordFor(manager, "a").id);
+      resolvers.get("a")!(); // the aborted run still settles normally
+      await first;
+
+      expect(recordFor(manager, "b").status).toBe("running");
+      expect(recordFor(manager, "c").status).toBe("queued");
+    });
+  });
+
+  // #179: a strict worktree-isolation failure throws out of spawnAndWait on the
+  // immediate path. Queue pressure must not silently turn that into a result.
+  it("rethrows a drain-time startup failure, and keeps draining", async () => {
+    const resolvers = controllableRuns();
+    manager = new AgentManager();
+    manager.setMaxConcurrentForeground(1);
+
+    vi.mocked(createWorktree).mockReturnValue(undefined as any);
+
+    const first = fg(manager, "holder");
+    const doomed = fg(manager, "doomed", { isolation: "worktree" });
+    const after = fg(manager, "after");
+    expect(recordFor(manager, "doomed").status).toBe("queued");
+
+    resolvers.get("holder")!();
+    await first;
+
+    await expect(doomed).rejects.toThrow(/worktree/i);
+    expect(recordFor(manager, "doomed").status).toBe("error");
+    // The throw above IS the caller's report. Left unconsumed, the record would
+    // also nudge the session — the same failure delivered twice, and only for
+    // spawns unlucky enough to have queued.
+    expect(recordFor(manager, "doomed").resultConsumed).toBe(true);
+
+    // The failure freed nothing, but it also blocked nothing.
+    expect(recordFor(manager, "after").status).toBe("running");
+    resolvers.get("after")!();
+    await after;
+  });
+
+  it("drains immediately when the limit is raised or cleared", async () => {
+    controllableRuns();
+    manager = new AgentManager();
+    manager.setMaxConcurrentForeground(1);
+
+    void fg(manager, "a");
+    void fg(manager, "b");
+    void fg(manager, "c");
+    expect(runAgent).toHaveBeenCalledTimes(1);
+
+    manager.setMaxConcurrentForeground(0); // back to unlimited
+    expect(runAgent).toHaveBeenCalledTimes(3);
+  });
+
+  // The acquire/release pair must agree even though the limit between them is
+  // user-editable at runtime (`/agents → Settings`, and applySettings on load).
+  // Recomputing the pool at settle time made the release disagree with the
+  // acquire in both directions.
+  describe("a limit changed mid-run", () => {
+    it("releases the slot a cleared limit no longer describes", async () => {
+      const resolvers = controllableRuns();
+      manager = new AgentManager();
+      manager.setMaxConcurrentForeground(1);
+
+      const a = fg(manager, "a");
+      manager.setMaxConcurrentForeground(0); // unlimited, while "a" holds a slot
+      resolvers.get("a")!();
+      await a;
+      await flush();
+
+      // The slot must have come back. If it leaked, nothing can ever free it
+      // again and every later blocking spawn queues forever.
+      manager.setMaxConcurrentForeground(1);
+      void fg(manager, "b");
+      await flush();
+      expect(recordFor(manager, "b").status).toBe("running");
+    });
+
+    it("does not release a slot a newly-set limit was never charged", async () => {
+      const resolvers = controllableRuns();
+      manager = new AgentManager();
+
+      const a = fg(manager, "a"); // unlimited — takes no slot
+      manager.setMaxConcurrentForeground(1);
+      resolvers.get("a")!();
+      await a;
+      await flush();
+
+      // The counter must still be 0, not -1: a -1 silently lifts the limit by one.
+      void fg(manager, "b");
+      void fg(manager, "c");
+      await flush();
+      expect(recordFor(manager, "b").status).toBe("running");
+      expect(recordFor(manager, "c").status).toBe("queued");
+    });
+  });
+
+  it("clamps a negative limit to unlimited rather than to 1", () => {
+    controllableRuns();
+    manager = new AgentManager();
+    manager.setMaxConcurrentForeground(-3);
+    expect(manager.getMaxConcurrentForeground()).toBe(0);
+  });
+
+  it("counts a queued foreground agent as active, and waitForAll waits it out", async () => {
+    const resolvers = controllableRuns();
+    manager = new AgentManager();
+    manager.setMaxConcurrentForeground(1);
+
+    void fg(manager, "a");
+    void fg(manager, "b");
+    expect(manager.hasRunning()).toBe(true);
+
+    const all = manager.waitForAll();
+    resolvers.get("a")!();
+    await flush();
+    resolvers.get("b")!();
+    await all;
+
+    expect(recordFor(manager, "b").status).toBe("completed");
+  });
+
+  // spawnAndWait used to park this callback on the manager and restore it in a
+  // `finally` right after spawn() — which only worked because spawn() reached
+  // startAgent() synchronously. A deferred start would fire it into whatever
+  // hook happened to be installed at drain time, or into none at all, silently
+  // costing the caller its output transcript.
+  it("fires each caller's onSpawned hook when its own deferred spawn starts", async () => {
+    const resolvers = controllableRuns();
+    manager = new AgentManager();
+    manager.setMaxConcurrentForeground(1);
+
+    const firstHook = vi.fn();
+    const secondHook = vi.fn();
+
+    const first = manager.spawnAndWait(
+      mockPi, mockCtx, "general-purpose", "a", { description: "a" }, firstHook,
+    );
+    const second = manager.spawnAndWait(
+      mockPi, mockCtx, "general-purpose", "b", { description: "b" }, secondHook,
+    );
+
+    expect(firstHook).toHaveBeenCalledTimes(1);
+    expect(secondHook).not.toHaveBeenCalled();
+
+    resolvers.get("a")!();
+    await first;
+
+    expect(secondHook).toHaveBeenCalledTimes(1);
+    expect(secondHook).toHaveBeenCalledWith(recordFor(manager, "b").id);
+    expect(firstHook).toHaveBeenCalledTimes(1);
+
+    resolvers.get("b")!();
+    await second;
+  });
+
+  it("reports how many are ahead when a spawn is queued", () => {
+    controllableRuns();
+    manager = new AgentManager();
+    manager.setMaxConcurrentForeground(1);
+
+    const onQueued = vi.fn();
+    void fg(manager, "holder");
+    void fg(manager, "b", { onQueued });
+    void fg(manager, "c", { onQueued });
+
+    expect(onQueued).toHaveBeenNthCalledWith(1, recordFor(manager, "b").id, 0);
+    expect(onQueued).toHaveBeenNthCalledWith(2, recordFor(manager, "c").id, 1);
+  });
+
+  // One queue serves both pools, so a saturated foreground pool sitting at the
+  // head must not stall background agents behind it.
+  it("does not let a full foreground queue head-of-line-block the background pool", async () => {
+    const resolvers = controllableRuns();
+    manager = new AgentManager(undefined, 1);
+    manager.setMaxConcurrentForeground(1);
+
+    void fg(manager, "fg-holder");
+    void fg(manager, "fg-queued");
+    bg(manager, "bg-holder");
+    bg(manager, "bg-queued");
+
+    expect(recordFor(manager, "fg-queued").status).toBe("queued");
+    expect(recordFor(manager, "bg-queued").status).toBe("queued");
+
+    // Free a BACKGROUND slot while the foreground queue is still stuck.
+    resolvers.get("bg-holder")!();
+    await flush();
+
+    expect(recordFor(manager, "bg-queued").status).toBe("running");
+    expect(recordFor(manager, "fg-queued").status).toBe("queued");
+  });
+});

--- a/test/settings.test.ts
+++ b/test/settings.test.ts
@@ -283,6 +283,20 @@ describe("settings persistence", () => {
       expect(loadSettings(projectDir).maxConcurrent).toBeUndefined();
     });
 
+    // Unlike maxConcurrent above, 0 is the DEFAULT here and means unlimited —
+    // dropping it would make the default unrepresentable in the file.
+    it("keeps maxConcurrentForeground: 0 (explicit unlimited)", () => {
+      writeProject({ maxConcurrentForeground: 0 });
+      expect(loadSettings(projectDir)).toEqual({ maxConcurrentForeground: 0 });
+    });
+
+    it("drops out-of-range or non-integer maxConcurrentForeground", () => {
+      for (const bad of [-1, 1025, 1.5, "four", null]) {
+        writeProject({ maxConcurrentForeground: bad });
+        expect(loadSettings(projectDir).maxConcurrentForeground).toBeUndefined();
+      }
+    });
+
     it("accepts defaultMaxTurns: 0 (explicit unlimited)", () => {
       writeProject({ defaultMaxTurns: 0 });
       expect(loadSettings(projectDir)).toEqual({ defaultMaxTurns: 0 });
@@ -509,6 +523,7 @@ describe("settings persistence", () => {
     beforeEach(() => {
       appliers = {
         setMaxConcurrent: vi.fn(),
+        setMaxConcurrentForeground: vi.fn(),
         setDefaultMaxTurns: vi.fn(),
         setGraceTurns: vi.fn(),
         setDefaultJoinMode: vi.fn(),
@@ -531,6 +546,19 @@ describe("settings persistence", () => {
         setShowCost: vi.fn(),
         setShowModel: vi.fn(),
       };
+    });
+
+    // 0 is a real value here, so `if (s.x)` truthiness would silently skip it.
+    it("applies maxConcurrentForeground, including an explicit 0", () => {
+      applySettings({ maxConcurrentForeground: 3 }, appliers);
+      expect(appliers.setMaxConcurrentForeground).toHaveBeenCalledWith(3);
+
+      applySettings({ maxConcurrentForeground: 0 }, appliers);
+      expect(appliers.setMaxConcurrentForeground).toHaveBeenCalledWith(0);
+
+      vi.mocked(appliers.setMaxConcurrentForeground).mockClear();
+      applySettings({}, appliers);
+      expect(appliers.setMaxConcurrentForeground).not.toHaveBeenCalled();
     });
 
     it("applies reportUsage and showCost", () => {
@@ -746,6 +774,7 @@ describe("settings persistence", () => {
     beforeEach(() => {
       appliers = {
         setMaxConcurrent: vi.fn(),
+        setMaxConcurrentForeground: vi.fn(),
         setDefaultMaxTurns: vi.fn(),
         setGraceTurns: vi.fn(),
         setDefaultJoinMode: vi.fn(),


### PR DESCRIPTION
Closes #253.

`maxConcurrent` has never covered foreground agents, and that exemption is deliberate — a foreground agent blocks the parent anyway, so charging it to the background pool would let a saturated pool starve the main session of work it could have done itself.

But the exemption was *total*. pi dispatches a message's tool calls through `Promise.all` (`pi-agent-core`'s `executeToolCallsParallel`) unless a tool declares `executionMode: "sequential"`, which this extension deliberately does not set (0.18.0, #232). So several `Agent` calls with `run_in_background: false` in one message have always started within microseconds of each other with **no ceiling at all**. On local models that is expensive rather than fast — parallel agents thrash the prompt cache — and asking the model to spawn fewer is not enforceable.

This adds a second pool, `maxConcurrentForeground`, independent of `maxConcurrent` in both directions.

## Default is off, and off means unchanged — with one stated exception

Default `0` = unlimited. With it unset nothing queues, no counter moves, no gate is allocated and `spawn()` reaches `startAgent()` synchronously, exactly as before.

Two pieces of evidence rather than an assertion:

- **No pre-existing test needed editing.** The two existing test files touched are purely additive — `git diff` shows zero removed lines.
- **Master's test suite passes against this branch's `src`.** Checked directly, by running master's `test/` tree unmodified against the new implementation: 1471 passed, 4 skipped. Nothing on master depended on behaviour this changes.

The one exception, called out because it is **not** gated on the setting: `startAgent` used to wire an already-aborted signal with `addEventListener`, which never fires — so an agent handed a pre-aborted signal ran to completion beyond the reach of Esc or `/agents`. It is now stopped immediately. That path is reachable on master today (a foreground `Agent` call whose signal aborts between pi's dispatch and `execute`); a queued spawn only makes it common. Pinned by a test that runs with the pool **off**.

`settlePools` deliberately keeps master's drain condition verbatim (`options.isBackground || pool !== undefined`) rather than the tighter "only when a slot freed". The tighter form is almost certainly equivalent — a drain with nothing freed can only start something if room already existed — but that is a reachability argument, and matching the old condition needs no argument at all.

## What takes a slot

Keyed on a new internal `blocking` flag set only by `spawnAndWait` — not on `isBackground === false`, because `spawn()` is also the funnel for detached RPC and `@handle` spawns, which may legitimately pass `isBackground: false` and are documented as starting immediately regardless. Queueing one would break that contract *and* park a record with nobody waiting to release it. `spawnTopLevel` strips `blocking` alongside the other internal capabilities.

| Path | Slot? |
|---|---|
| `Agent` tool, `run_in_background: false` | **yes** — the target |
| Nested delegation | no — parent is blocked *awaiting* the child, so queueing it behind its own parent deadlocks |
| Cross-extension RPC / `@handle` / registry | no — detached, blocks nobody |
| `/agents` agent-file generator | no queue (`bypassQueue`) — a modal wizard where Esc never reaches the manager, so a wait would be uncancellable |
| Foreground `resume` | no — reopens an existing session, never reaches the spawn path |

The nested exemption lives in the predicate rather than at the call site, so no caller can reintroduce the deadlock. It also means `nested-tools.ts` needed no edit.

Foreground `resume` being outside the pool is a real, documented gap: N blocking resumes in one message can still exceed the limit.

## Surfaces

A waiting agent is a real `queued` record, not an opaque semaphore, so it inherits everything already built on that status — it shows in `/agents → Running agents`, can be stopped there or with Esc, and `abortAll`/`dispose`/`hasRunning` already handle it. Its `Agent` call renders `queued — waiting for a foreground slot (N ahead)` while it waits, keeping the spinner (a status the renderer doesn't know falls through to raw text and reads as hung), then returns its result normally.

The `Agent` tool description is **deliberately unchanged**. Telling the model that foreground calls may serialize is the #232 mistake — it pushed orchestrators into background spawns they didn't need. It also stays true: the calls *are* dispatched concurrently; they queue, and each still returns its agent's full result.

## Bugs found and fixed along the way

**A latent `onSpawned` bug, fixed as a prerequisite.** `spawnAndWait` parked its hook on the manager and restored it in a `finally` right after `spawn()` — which only worked because `spawn()` reached `startAgent()` synchronously. The moment a foreground spawn can be deferred, the hook fires at drain time with the field already restored, and the caller silently loses its output transcript. It now rides on the options.

**An acquire/release desync on a mid-run limit change**, caught in review. `settlePools` recomputed the pool at completion instead of using the one the run was charged to at start; since `poolFor` reads the live limit, the two could disagree:

- Limit `1`, agent takes a slot, user sets `0`, agent finishes → **no decrement**. `runningForeground` sticks with nothing running to free it, and every later blocking call queues forever — a hang, not an error, since a queued record has no promise and pi has no tool-execution timeout.
- The reverse is the #253 flow exactly: agent starts under the default, user turns the setting on *because* agents are already thrashing, agent finishes → decrement to `-1`, silently lifting the limit.

`startAgent` now resolves the pool once and both settle paths close over it.

## Cancellation

The hard constraint: a tool `execute` that **rejects** rejects pi's whole `Promise.all` batch, killing unrelated tool calls. So the queue gate resolves and never rejects. An abort while queued dequeues, marks the record `stopped`, and `spawnAndWait` returns it — rendering through the existing `getForegroundOutcomeNote("stopped")` path, character-for-character what an agent Esc-ed one second after starting already produces. No new status, no new branch.

A queued record never reaches `startAgent`'s signal wiring, so the parent abort is armed at enqueue instead; an already-aborted signal is never enqueued at all, since `addEventListener` would never fire and the caller would wait forever.

## Tests

28 new tests across `test/foreground-concurrency.test.ts` (manager) and `test/foreground-concurrency-wiring.test.ts` (real extension, dispatching two `execute()` calls without awaiting the first — the only shape in which the queue is reachable).

Every one was mutation-checked. Several fail as **hangs** rather than assertion failures, which is the real hazard here and why each path out of the queue gets its own test: `abort`, `abortAll`, `dispose`, stale-skip, drain-time throw.

One honest note: the `maxConcurrentForeground > 0` short-circuit in `poolFor` is *not* pinned by a test — mutating it away breaks nothing, because `poolHasRoom` already reports an unlimited pool as always having room. It only avoids counter churn and a no-op drain. The comment says so rather than overclaiming.

1501 tests pass; lint and typecheck clean.
