### PR TITLE
fix: bound conversation viewer render cost

### DIFF
--- a/src/ui/conversation-viewer.ts
+++ b/src/ui/conversation-viewer.ts
@@ -28,8 +28,8 @@ export const VIEWPORT_HEIGHT_PCT = 70;
  * every render *and* on every scroll key (`handleInput` calls it to compute
  * `maxScroll`), so an uncapped 200 KB result costs ~6 ms per keystroke to parse
  * as Markdown, against ~0.5 ms once capped and effectively nothing on a cache
- * hit (best of 5, width 76). 16,000 code units is roughly a screenful at every
- * terminal size and still ~30x the 500 characters this replaces, which was small enough to cut
+ * hit (best of 5, width 76). 16 KB is roughly a screenful at every terminal size
+ * and still ~30x the 500 characters this replaces, which was small enough to cut
  * most real results mid-sentence.
  */
 export const RESULT_MAX_CHARS = 16_000;
@@ -121,7 +121,7 @@ function capResult(text: string): { text: string; elided: number } {
 }
 
 function truncationNote(elided: number): string {
-  return `... (truncated, ${elided} more UTF-16 code unit${elided === 1 ? "" : "s"})`;
+  return `... (truncated, ${elided} more character${elided === 1 ? "" : "s"})`;
 }
 
 export class ConversationViewer implements Component {

--- a/src/ui/conversation-viewer.ts
+++ b/src/ui/conversation-viewer.ts
@@ -120,8 +120,21 @@ function capResult(text: string): { text: string; elided: number } {
   };
 }
 
+/**
+ * `999` · `1.5k` · `8.4M` — a magnitude cue, not an exact count, past 1000.
+ *
+ * The bracket is chosen against the *rounded* value, so 999,999 reads `1M`
+ * rather than the `1000.0k` a naive `< 1e6` test produces.
+ */
+function humanCount(n: number): string {
+  if (n < 1_000) return `${n}`;
+  const thousands = n < 999_950;
+  const value = thousands ? n / 1_000 : n / 1_000_000;
+  return `${value.toFixed(1).replace(/\.0$/, "")}${thousands ? "k" : "M"}`;
+}
+
 function truncationNote(elided: number): string {
-  return `... (truncated, ${elided} more character${elided === 1 ? "" : "s"})`;
+  return `... (truncated, ${humanCount(elided)} more character${elided === 1 ? "" : "s"})`;
 }
 
 export class ConversationViewer implements Component {

--- a/src/ui/conversation-viewer.ts
+++ b/src/ui/conversation-viewer.ts
@@ -28,8 +28,8 @@ export const VIEWPORT_HEIGHT_PCT = 70;
  * every render *and* on every scroll key (`handleInput` calls it to compute
  * `maxScroll`), so an uncapped 200 KB result costs ~6 ms per keystroke to parse
  * as Markdown, against ~0.5 ms once capped and effectively nothing on a cache
- * hit (best of 5, width 76). 16 KB is roughly a screenful at every terminal size
- * and still ~30x the 500 characters this replaces, which was small enough to cut
+ * hit (best of 5, width 76). 16,000 code units is roughly a screenful at every
+ * terminal size and still ~30x the 500 characters this replaces, which was small enough to cut
  * most real results mid-sentence.
  */
 export const RESULT_MAX_CHARS = 16_000;
@@ -116,12 +116,12 @@ function capResult(text: string): { text: string; elided: number } {
   if (text.length <= RESULT_MAX_CHARS) return { text, elided: 0 };
   return {
     text: text.slice(0, RESULT_MAX_CHARS),
-    elided: text.slice(RESULT_MAX_CHARS).split("\n").length,
+    elided: text.length - RESULT_MAX_CHARS,
   };
 }
 
 function truncationNote(elided: number): string {
-  return `... (truncated, ${elided} more line${elided === 1 ? "" : "s"})`;
+  return `... (truncated, ${elided} more UTF-16 code unit${elided === 1 ? "" : "s"})`;
 }
 
 export class ConversationViewer implements Component {
@@ -391,7 +391,7 @@ export class ConversationViewer implements Component {
   }
 
   /** Render `text` as Markdown, reusing this message's component instance. */
-  private markdownLines(msg: object, text: string, width: number, dim: boolean): string[] {
+  private markdownLines(msg: AgentSession["messages"][number], text: string, width: number, dim: boolean): string[] {
     let entry = this.markdownCache.get(msg);
     if (!entry) {
       entry = {
@@ -411,10 +411,13 @@ export class ConversationViewer implements Component {
       };
       this.markdownCache.set(msg, entry);
     } else if (entry.text !== text) {
-      // Streaming: the message object is stable, its text grows.
+      // Streaming: the message object is stable, its text grows. A failed
+      // prefix remains unsafe after append-only deltas, so retry only when the
+      // content was replaced or truncated.
+      const shouldRetry = !text.startsWith(entry.text);
       entry.md.setText(text);
       entry.text = text;
-      entry.failed = false;
+      if (shouldRetry) entry.failed = false;
     }
     if (entry.failed) return this.rawLines(text, width, dim);
 

--- a/test/conversation-viewer.test.ts
+++ b/test/conversation-viewer.test.ts
@@ -504,7 +504,7 @@ describe("ConversationViewer", () => {
 
       expect(out).toContain("line 100");                       // far past the old 500-char cut
       expect(out).not.toContain("line 2999");                  // but still bounded
-      expect(out).toMatch(/\.\.\. \(truncated, \d+ more UTF-16 code units\)/);
+      expect(out).toMatch(/\.\.\. \(truncated, \d+ more characters\)/);
     });
 
     it("puts the truncation notice outside the code fence it cut into", () => {
@@ -515,15 +515,25 @@ describe("ConversationViewer", () => {
 
       // Appended into the content it lands inside the unterminated fence, where
       // it picks up the code-block indent and reads as a line of the tool's source.
-      expect(note).toMatch(/^\.\.\. \(truncated, \d+ more UTF-16 code units\)$/);
+      expect(note).toMatch(/^\.\.\. \(truncated, \d+ more characters\)$/);
     });
 
-    it("reports the exact omitted UTF-16 code-unit count", () => {
+    it("reports the exact omitted character count", () => {
+      // UTF-16 code units, so the astral character here counts as two.
       const text = `${"x".repeat(RESULT_MAX_CHARS)}😀x`;
       const viewer = viewerFor(result(text));
       const content = ((viewer as any).buildContentLines(76) as string[]).map(strip);
 
-      expect(content).toContain("... (truncated, 3 more UTF-16 code units)");
+      expect(content).toContain("... (truncated, 3 more characters)");
+    });
+
+    it("keeps the truncation notice inside a narrow frame", () => {
+      // The notice goes through truncateToWidth at innerW (width - 4), so a
+      // wording long enough to be cut there leaves the reader a bare number.
+      const text = `${"x".repeat(RESULT_MAX_CHARS)}${"y".repeat(1_100_000)}`;
+      const note = viewerFor(result(text)).render(50).map(strip).find(l => l.includes("truncated,"));
+
+      expect(note).toContain("1100000 more characters)");
     });
 
     it("falls back to literal wrapping once for an unsafe streaming prefix", () => {
@@ -590,7 +600,7 @@ describe("ConversationViewer", () => {
       const messages = [{ role: "bashExecution", command: "yes", output: "y\n".repeat(20000) }];
       const out = strip(viewerFor(messages).render(80).join("\n"));
 
-      expect(out).toMatch(/\.\.\. \(truncated, \d+ more UTF-16 code units\)/);
+      expect(out).toMatch(/\.\.\. \(truncated, \d+ more characters\)/);
     });
 
     it("keeps tool results dim even when rendering them as Markdown", () => {

--- a/test/conversation-viewer.test.ts
+++ b/test/conversation-viewer.test.ts
@@ -10,6 +10,8 @@ import type { AgentRecord } from "../src/types.js";
 let wrapOverride: ((text: string, width: number) => string[]) | null = null;
 /** Bumped per `new Markdown(...)`, so a test can assert the per-message cache holds. */
 let markdownConstructions = 0;
+/** Bumped per Markdown render attempt, including failed ones. */
+let markdownRenderCalls = 0;
 /** Forces the Markdown component to throw, for the viewer's fallback path. */
 let markdownThrows = false;
 
@@ -23,6 +25,7 @@ vi.mock("@earendil-works/pi-tui", async (importOriginal) => {
         super(...args);
       }
       render(width: number): string[] {
+        markdownRenderCalls++;
         // Real trigger is ~54 nested blockquotes overflowing pi-tui's recursive
         // renderer. Forced rather than reproduced: a real overflow costs ~2.4s
         // and its depth depends on the platform's stack limit, so reproducing it
@@ -92,6 +95,7 @@ function assertAllLinesFit(lines: string[], width: number) {
 beforeEach(() => {
   wrapOverride = null;
   markdownConstructions = 0;
+  markdownRenderCalls = 0;
   markdownThrows = false;
 });
 
@@ -500,7 +504,7 @@ describe("ConversationViewer", () => {
 
       expect(out).toContain("line 100");                       // far past the old 500-char cut
       expect(out).not.toContain("line 2999");                  // but still bounded
-      expect(out).toMatch(/\.\.\. \(truncated, \d+ more lines\)/);
+      expect(out).toMatch(/\.\.\. \(truncated, \d+ more UTF-16 code units\)/);
     });
 
     it("puts the truncation notice outside the code fence it cut into", () => {
@@ -511,27 +515,49 @@ describe("ConversationViewer", () => {
 
       // Appended into the content it lands inside the unterminated fence, where
       // it picks up the code-block indent and reads as a line of the tool's source.
-      expect(note).toMatch(/^\.\.\. \(truncated, \d+ more lines\)$/);
+      expect(note).toMatch(/^\.\.\. \(truncated, \d+ more UTF-16 code units\)$/);
     });
 
-    it("falls back to literal wrapping when the Markdown parser throws", () => {
+    it("reports the exact omitted UTF-16 code-unit count", () => {
+      const text = `${"x".repeat(RESULT_MAX_CHARS)}😀x`;
+      const viewer = viewerFor(result(text));
+      const content = ((viewer as any).buildContentLines(76) as string[]).map(strip);
+
+      expect(content).toContain("... (truncated, 3 more UTF-16 code units)");
+    });
+
+    it("falls back to literal wrapping once for an unsafe streaming prefix", () => {
       // render() is on the TUI's critical path, so a parser throw must degrade
       // rather than take the overlay down with it.
-      const viewer = viewerFor(result("# heading"), "all");
+      const messages = result("# heading");
+      const viewer = viewerFor(messages, "all");
       markdownThrows = true;
 
       expect(() => viewer.render(80)).not.toThrow();
       expect(strip(viewer.render(80).join("\n"))).toContain("# heading");
 
-      // And the failure is remembered — otherwise the throw repeats on every
-      // render and every scroll key. Still literal once the parser would work.
+      // An append-only delta keeps the unsafe prefix, so it must stay literal
+      // without retrying the recursive parser on every streamed update.
+      messages[0].content[0].text += "\nmore";
+      expect(strip(viewer.render(80).join("\n"))).toContain("more");
+      expect(markdownRenderCalls).toBe(1);
+
       markdownThrows = false;
       expect(strip(viewer.render(80).join("\n"))).toContain("# heading");
+      expect(markdownRenderCalls).toBe(1);
+
+      // Replacing the failed content can remove the unsafe prefix, so it gets
+      // one fresh Markdown attempt instead of staying literal forever.
+      messages[0].content[0].text = "## safe";
+      const replaced = strip(viewer.render(80).join("\n"));
+      expect(markdownRenderCalls).toBe(2);
+      expect(replaced).toContain("safe");
+      expect(replaced).not.toContain("## safe");
     });
 
     it("tracks a tool result that keeps growing past the cap", () => {
       // The live case: the capped prefix never changes, so the parse is reused,
-      // but the count of what is being held back has to keep moving.
+      // but the character count being held back has to keep moving.
       const msg = { role: "toolResult", toolUseId: "t", content: [{ type: "text", text: `${"row\n".repeat(4500)}` }] };
       const viewer = viewerFor([msg]);
       const elided = () => Number(
@@ -564,7 +590,7 @@ describe("ConversationViewer", () => {
       const messages = [{ role: "bashExecution", command: "yes", output: "y\n".repeat(20000) }];
       const out = strip(viewerFor(messages).render(80).join("\n"));
 
-      expect(out).toMatch(/\.\.\. \(truncated, \d+ more lines\)/);
+      expect(out).toMatch(/\.\.\. \(truncated, \d+ more UTF-16 code units\)/);
     });
 
     it("keeps tool results dim even when rendering them as Markdown", () => {

--- a/test/conversation-viewer.test.ts
+++ b/test/conversation-viewer.test.ts
@@ -504,7 +504,7 @@ describe("ConversationViewer", () => {
 
       expect(out).toContain("line 100");                       // far past the old 500-char cut
       expect(out).not.toContain("line 2999");                  // but still bounded
-      expect(out).toMatch(/\.\.\. \(truncated, \d+ more characters\)/);
+      expect(out).toMatch(/\.\.\. \(truncated, [\d.]+[kM]? more characters\)/);
     });
 
     it("puts the truncation notice outside the code fence it cut into", () => {
@@ -515,7 +515,7 @@ describe("ConversationViewer", () => {
 
       // Appended into the content it lands inside the unterminated fence, where
       // it picks up the code-block indent and reads as a line of the tool's source.
-      expect(note).toMatch(/^\.\.\. \(truncated, \d+ more characters\)$/);
+      expect(note).toMatch(/^\.\.\. \(truncated, [\d.]+[kM]? more characters\)$/);
     });
 
     it("reports the exact omitted character count", () => {
@@ -527,13 +527,23 @@ describe("ConversationViewer", () => {
       expect(content).toContain("... (truncated, 3 more characters)");
     });
 
-    it("keeps the truncation notice inside a narrow frame", () => {
-      // The notice goes through truncateToWidth at innerW (width - 4), so a
-      // wording long enough to be cut there leaves the reader a bare number.
+    it("abbreviates a large omitted count so the notice fits a narrow frame", () => {
+      // The notice goes through truncateToWidth at innerW (width - 4). An exact
+      // count runs to seven digits on a multi-megabyte result and pushes the
+      // notice past 46, where the unit is cut off and only a number survives.
       const text = `${"x".repeat(RESULT_MAX_CHARS)}${"y".repeat(1_100_000)}`;
       const note = viewerFor(result(text)).render(50).map(strip).find(l => l.includes("truncated,"));
 
-      expect(note).toContain("1100000 more characters)");
+      expect(note).toContain("1.1M more characters)");
+    });
+
+    it("rounds into the M bracket rather than reporting 1000k", () => {
+      // 999,999 / 1000 rounds to 1000.0 — the bracket has to be picked against
+      // the rounded value, not the raw one.
+      const text = `${"x".repeat(RESULT_MAX_CHARS)}${"y".repeat(999_999)}`;
+      const note = strip(viewerFor(result(text)).render(80).join("\n")).split("\n").find(l => l.includes("truncated,"));
+
+      expect(note).toContain("1M more characters");
     });
 
     it("falls back to literal wrapping once for an unsafe streaming prefix", () => {
@@ -570,10 +580,11 @@ describe("ConversationViewer", () => {
       // but the character count being held back has to keep moving.
       const msg = { role: "toolResult", toolUseId: "t", content: [{ type: "text", text: `${"row\n".repeat(4500)}` }] };
       const viewer = viewerFor([msg]);
-      const elided = () => Number(
-        strip(((viewer as any).buildContentLines(76) as string[]).join("\n"))
-          .match(/truncated, (\d+) more/)?.[1],
-      );
+      const elided = () => {
+        const m = strip(((viewer as any).buildContentLines(76) as string[]).join("\n"))
+          .match(/truncated, ([\d.]+)([kM]?) more/);
+        return Number(m?.[1]) * (m?.[2] === "M" ? 1e6 : m?.[2] === "k" ? 1e3 : 1);
+      };
 
       const before = elided();
       msg.content[0].text += "row\n".repeat(1000);
@@ -600,7 +611,7 @@ describe("ConversationViewer", () => {
       const messages = [{ role: "bashExecution", command: "yes", output: "y\n".repeat(20000) }];
       const out = strip(viewerFor(messages).render(80).join("\n"));
 
-      expect(out).toMatch(/\.\.\. \(truncated, \d+ more characters\)/);
+      expect(out).toMatch(/\.\.\. \(truncated, [\d.]+[kM]? more characters\)/);
     });
 
     it("keeps tool results dim even when rendering them as Markdown", () => {


### PR DESCRIPTION
Fixes #263

## Summary

- make the 16,000-code-unit viewer cap report omitted UTF-16 code units in O(1), instead of splitting and allocating across the entire hidden tail during every render and scroll-bound calculation
- keep Markdown's literal fallback cached across append-only streaming deltas after a render failure
- retry Markdown when the message content is replaced or shortened, so a corrected message does not stay literal forever
- use the concrete `AgentSession` message type for the Markdown cache key

## Evidence

The issue benchmark reproduced the hidden-tail cost in all 42 comparisons. At 32 MiB, median render time fell from 70.054 ms to 0.735 ms and scroll handling from 74.661 ms to 0.451 ms with the O(1) count.

The failure harness reproduced 50/50 times: one initial failure plus five append-only deltas caused six caught Markdown throws before this fix and one after it.

## Verification

- focused conversation-viewer suite: 59 passed
- `npm run lint` (only the existing `workflow-tool-description.test.ts` template-placeholder warning on master)
- `npm run typecheck`
- `npm run test`: 105 files, 2126 passed, 7 skipped
- `npm run build`
- active LSP/Lens diagnostics: no errors in the two changed files

Per CONTRIBUTING.md, this PR does not edit CHANGELOG.md.
