### PR TITLE
fix: hold completion notifications until the parent run settles

### DIFF
--- a/README.md
+++ b/README.md
@@ -582,6 +582,8 @@ When background agents complete, they notify the main agent. The **join mode** c
 
 **Timeout behavior:** When agents are grouped, a 30-second timeout starts after the first agent completes. If not all agents finish in time, a partial notification is sent with completed results and remaining agents continue with a shorter 15-second re-batch window for stragglers.
 
+Notifications that come due while the parent agent is still running stay in-process until the parent settles (`agent_settled`). Sending them mid-run would park them in pi's follow-up queue, where they can no longer be cancelled — so an agent already joined with `get_subagent_result` would still notify after the final answer, one wasted turn each. A due notification is delivered immediately when the parent is idle.
+
 **Configuration:**
 - Configure join mode in `/agents` → Settings → Join mode
 
@@ -953,6 +955,7 @@ src/
   child-context.ts    # AsyncLocalStorage flag marking work done for a child session
   abortable.ts        # Race a wait against Esc without cancelling the background child
   group-join.ts       # Group join manager: batched completion notifications with timeout
+  nudge-queue.ts      # Hold completion notifications until the parent run settles
   status-note.ts      # Honest status note + salvaged partial output for non-normal outcomes
   usage.ts            # Token usage shapes, accumulators, session-stats readers
 

--- a/docs/rpc.md
+++ b/docs/rpc.md
@@ -120,8 +120,9 @@ When a background agent finishes, pi-subagents sends the user a completion notif
 | When you consume | What happens |
 |---|---|
 | Synchronously, inside your `subagents:completed` handler | The notification is never scheduled. This is the clean path |
-| After an `await`, within 200 ms | Still suppressed. The nudge is held for `NUDGE_HOLD_MS` (`src/index.ts:451`), `consume` cancels the pending timer (`:819`), and there is a re-check at send time (`:474`) |
-| After 200 ms | Too late. The follow-up has fired with `triggerTurn: true` and cost the parent a turn |
+| After an `await`, within 200 ms | Still suppressed. The nudge is held for `NUDGE_HOLD_MS` (`src/nudge-queue.ts`), `consume` cancels it, and there is a re-check at send time |
+| After 200 ms, parent still running | Still suppressed. The due notification is parked in-process until `agent_settled`; `consume` cancels the parked send |
+| After the parent has settled | Too late. The follow-up has fired with `triggerTurn: true` and cost the parent a turn |
 
 Fire-and-forget is the intended use: the reply carries nothing to act on, and the channel sits outside the `subagents:rpc:ping` version handshake on purpose (`src/cross-extension-rpc.ts:190`), so you can send it unconditionally and an older pi-subagents with no handler simply keeps notifying.
 

--- a/src/index.ts
+++ b/src/index.ts
@@ -31,6 +31,7 @@ import { runMentionClone } from "./mention-clone.js";
 import { describeModel, type ModelRegistry, resolveModel } from "./model-resolver.js";
 import { checkModelScope, isScopeModelsEnabled, setScopeModelsEnabled } from "./model-scope.js";
 import { getMaxSubagentDepth, setMaxSubagentDepth } from "./nested-tools.js";
+import { DEFAULT_HOLD_MS, NudgeQueue } from "./nudge-queue.js";
 import { createOutputFilePath, ensureOutputFile, getOutputTranscriptDefault, sessionTaskDir, setOutputTranscriptDefault, streamToOutputFile, writeInitialEntry } from "./output-file.js";
 import { SubagentScheduler } from "./schedule.js";
 import { resolveStorePath, ScheduleStore } from "./schedule-store.js";
@@ -443,30 +444,27 @@ export default function (pi: ExtensionAPI) {
     persistSettings(ctx, `Viewer markdown set to ${mode}`);
   }
   const pendingUsage = new PendingUsagePool();
+  // Bound on session_start; read by notification delivery and RPC spawn.
+  let currentCtx: ExtensionContext | undefined;
 
   // ---- Cancellable pending notifications ----
-  // Holds notifications briefly so get_subagent_result can cancel them
-  // before they reach pi.sendMessage (fire-and-forget).
-  const pendingNudges = new Map<string, ReturnType<typeof setTimeout>>();
-  const NUDGE_HOLD_MS = 200;
+  // Holds notifications briefly so get_subagent_result can cancel them before
+  // they reach pi.sendMessage (fire-and-forget), and parks any that come due
+  // mid-run until the parent settles — see nudge-queue.ts for why emitting
+  // during a run is worse than holding.
+  const NUDGE_HOLD_MS = DEFAULT_HOLD_MS;
   // A queued result wait must observe completion before its held notification
   // can fire, so successful waits can still suppress that redundant nudge.
   const QUEUE_WAIT_POLL_MS = Math.floor(NUDGE_HOLD_MS / 4);
 
+  const nudges = new NudgeQueue(() => currentCtx?.isIdle?.() === false, NUDGE_HOLD_MS);
+
   function scheduleNudge(key: string, send: () => void, delay = NUDGE_HOLD_MS) {
-    cancelNudge(key);
-    pendingNudges.set(key, setTimeout(() => {
-      pendingNudges.delete(key);
-      try { send(); } catch { /* ignore stale completion side-effect errors */ }
-    }, delay));
+    nudges.schedule(key, send, delay);
   }
 
   function cancelNudge(key: string) {
-    const timer = pendingNudges.get(key);
-    if (timer != null) {
-      clearTimeout(timer);
-      pendingNudges.delete(key);
-    }
+    nudges.cancel(key);
   }
 
   // ---- Individual nudge helper (async join mode) ----
@@ -750,7 +748,6 @@ export default function (pi: ExtensionAPI) {
   }
 
   // --- Cross-extension RPC via pi.events ---
-  let currentCtx: ExtensionContext | undefined;
   // RPC handlers + the `subagents:ready` broadcast are wired on `session_start`
   // (a bound lifecycle event), not at factory time. pi runs every extension
   // factory before the `extensions:` filter and only fires lifecycle events for
@@ -1087,6 +1084,16 @@ export default function (pi: ExtensionAPI) {
     return { action: "handled" };
   });
 
+  // Deliver notifications parked while the parent was running. `agent_settled`
+  // rather than `agent_end` or `turn_end`: those fire with a retry, compaction,
+  // or another tool-calling turn still ahead, and a notification emitted then is
+  // parked by pi's follow-up queue exactly as before — unsuppressable and
+  // delivered after the final answer. `agent_settled` is the first point where
+  // pi will not continue on its own.
+  pi.on("agent_settled", () => {
+    nudges.flush();
+  });
+
   pi.on("session_before_switch", () => {
     manager.clearCompleted(true);
     scheduler.stop();
@@ -1112,8 +1119,7 @@ export default function (pi: ExtensionAPI) {
     for (const task of workflowTasks.values()) task.abortController.abort();
     workflowTasks.clear();
     manager.abortAll();
-    for (const timer of pendingNudges.values()) clearTimeout(timer);
-    pendingNudges.clear();
+    nudges.dispose();
     fleet.dispose();
     // Awaited: it emits `session_shutdown` into every retained child session so
     // extensions bound there can release what they armed in `session_start` (#242).
@@ -2374,8 +2380,9 @@ Terse command-style prompts produce shallow, generic work.
 
   /**
    * Hand a finished run back to the model through the SAME channel a background
-   * agent uses — held briefly by `scheduleNudge`, delivered as a follow-up that
-   * triggers a turn, rendered by the existing `subagent-notification` renderer.
+   * agent uses — held by `scheduleNudge` (briefly, then until the parent settles
+   * if it is still running), delivered as a follow-up that triggers a turn,
+   * rendered by the existing `subagent-notification` renderer.
    */
   function notifyWorkflowFinished(task: WorkflowTask) {
     widget.update();

--- a/src/nudge-queue.ts
+++ b/src/nudge-queue.ts
@@ -1,0 +1,104 @@
+/**
+ * nudge-queue.ts — Delivery timing for background agent completion notifications.
+ *
+ * Notifications are sent with `deliverAs: "followUp"`, which pi delivers only
+ * once the agent has no more tool calls. Emitting one mid-run therefore parks it
+ * in pi's follow-up queue until the run ends — and a parked message can no
+ * longer be withdrawn, so an agent the orchestrator joins with
+ * `get_subagent_result` in the meantime still produces a notification after the
+ * final answer. With pi's default `followUpMode: "one-at-a-time"` a batch of
+ * those drains one wasted turn each, and a large enough batch can force a
+ * compaction.
+ *
+ * This queue keeps due notifications in-process instead. `schedule` holds each
+ * one for a short window (so a same-tick join can cancel it), then either sends
+ * it — parent idle, delivery is immediate and useful — or parks it here until
+ * `flush` runs at `agent_settled`. Because every send closure re-checks
+ * `resultConsumed` before emitting, deferring the call defers the check: an
+ * agent joined in the meantime simply never notifies.
+ *
+ * The queue deliberately holds nothing across a session shutdown: results are
+ * undeliverable once the session is gone, matching `abortAll()` on shutdown.
+ */
+
+/** Window that lets a same-tick `get_subagent_result` cancel a due notification. */
+export const DEFAULT_HOLD_MS = 200;
+
+export class NudgeQueue {
+  private pending = new Map<string, ReturnType<typeof setTimeout>>();
+  private held = new Map<string, () => void>();
+
+  /**
+   * @param isBusy Whether the parent agent is mid-run. A due notification is
+   *   parked while this is true. Read at delivery time rather than tracked as
+   *   local state so an unbalanced lifecycle event cannot strand notifications.
+   * @param holdMs Cancellation window applied before a notification comes due.
+   */
+  constructor(
+    private readonly isBusy: () => boolean,
+    private readonly holdMs: number = DEFAULT_HOLD_MS,
+  ) {}
+
+  /** Number of notifications parked waiting for the parent run to settle. */
+  get heldCount(): number {
+    return this.held.size;
+  }
+
+  /** Number of notifications inside their cancellation window. */
+  get pendingCount(): number {
+    return this.pending.size;
+  }
+
+  /** Queue `send` under `key`, replacing any notification already queued for it. */
+  schedule(key: string, send: () => void, delay: number = this.holdMs): void {
+    this.cancel(key);
+    this.pending.set(
+      key,
+      setTimeout(() => {
+        this.pending.delete(key);
+        if (this.isBusy()) {
+          this.held.set(key, send);
+          return;
+        }
+        this.deliver(send);
+      }, delay),
+    );
+  }
+
+  /** Drop `key` from both the cancellation window and the parked set. */
+  cancel(key: string): void {
+    const timer = this.pending.get(key);
+    if (timer != null) {
+      clearTimeout(timer);
+      this.pending.delete(key);
+    }
+    this.held.delete(key);
+  }
+
+  /**
+   * Deliver everything parked while the parent was running. Sends re-check
+   * their own relevance, so this is safe to call whenever the agent settles —
+   * including when nothing is parked.
+   */
+  flush(): void {
+    if (this.held.size === 0) return;
+    const sends = [...this.held.values()];
+    this.held.clear();
+    for (const send of sends) this.deliver(send);
+  }
+
+  /** Drop everything without delivering. */
+  dispose(): void {
+    for (const timer of this.pending.values()) clearTimeout(timer);
+    this.pending.clear();
+    this.held.clear();
+  }
+
+  private deliver(send: () => void): void {
+    try {
+      send();
+    } catch {
+      /* ignore stale completion side-effect errors */
+    }
+  }
+}

--- a/test/nudge-queue.test.ts
+++ b/test/nudge-queue.test.ts
@@ -1,0 +1,156 @@
+/**
+ * nudge-queue.test.ts — Delivery timing for completion notifications.
+ *
+ * The regression this guards: a notification emitted while the parent agent is
+ * mid-run is parked by pi's follow-up queue until the run ends, where it can no
+ * longer be suppressed — so agents the orchestrator already joined with
+ * `get_subagent_result` still notified after the final answer, one wasted turn
+ * each. Fake timers keep the hold window deterministic.
+ */
+
+import { afterEach, beforeEach, describe, expect, it, vi } from "vitest";
+import { DEFAULT_HOLD_MS, NudgeQueue } from "../src/nudge-queue.js";
+
+describe("NudgeQueue", () => {
+  beforeEach(() => vi.useFakeTimers());
+  afterEach(() => vi.useRealTimers());
+
+  it("delivers after the hold window when the parent is idle", () => {
+    const send = vi.fn();
+    const q = new NudgeQueue(() => false);
+
+    q.schedule("a", send);
+    expect(send).not.toHaveBeenCalled();
+
+    vi.advanceTimersByTime(DEFAULT_HOLD_MS);
+    expect(send).toHaveBeenCalledTimes(1);
+    expect(q.heldCount).toBe(0);
+  });
+
+  it("parks instead of delivering while the parent is mid-run", () => {
+    const send = vi.fn();
+    const q = new NudgeQueue(() => true);
+
+    q.schedule("a", send);
+    vi.advanceTimersByTime(DEFAULT_HOLD_MS);
+
+    expect(send).not.toHaveBeenCalled();
+    expect(q.heldCount).toBe(1);
+  });
+
+  it("delivers parked notifications on flush", () => {
+    const first = vi.fn();
+    const second = vi.fn();
+    const q = new NudgeQueue(() => true);
+
+    q.schedule("a", first);
+    q.schedule("b", second);
+    vi.advanceTimersByTime(DEFAULT_HOLD_MS);
+    expect(q.heldCount).toBe(2);
+
+    q.flush();
+    expect(first).toHaveBeenCalledTimes(1);
+    expect(second).toHaveBeenCalledTimes(1);
+    expect(q.heldCount).toBe(0);
+  });
+
+  it("never delivers a notification cancelled while parked", () => {
+    const send = vi.fn();
+    const q = new NudgeQueue(() => true);
+
+    q.schedule("a", send);
+    vi.advanceTimersByTime(DEFAULT_HOLD_MS);
+
+    // The orchestrator joins the agent with get_subagent_result mid-run.
+    q.cancel("a");
+    q.flush();
+
+    expect(send).not.toHaveBeenCalled();
+    expect(q.heldCount).toBe(0);
+  });
+
+  it("cancels a notification still inside its hold window", () => {
+    const send = vi.fn();
+    const q = new NudgeQueue(() => false);
+
+    q.schedule("a", send);
+    q.cancel("a");
+    vi.advanceTimersByTime(DEFAULT_HOLD_MS * 10);
+
+    expect(send).not.toHaveBeenCalled();
+    expect(q.pendingCount).toBe(0);
+  });
+
+  it("re-reads busy state at delivery time rather than at schedule time", () => {
+    const send = vi.fn();
+    let busy = false;
+    const q = new NudgeQueue(() => busy);
+
+    q.schedule("a", send);
+    busy = true; // parent started a run inside the hold window
+    vi.advanceTimersByTime(DEFAULT_HOLD_MS);
+
+    expect(send).not.toHaveBeenCalled();
+    expect(q.heldCount).toBe(1);
+  });
+
+  it("replaces an earlier notification for the same key", () => {
+    const stale = vi.fn();
+    const fresh = vi.fn();
+    const q = new NudgeQueue(() => false);
+
+    q.schedule("a", stale);
+    q.schedule("a", fresh);
+    vi.advanceTimersByTime(DEFAULT_HOLD_MS);
+
+    expect(stale).not.toHaveBeenCalled();
+    expect(fresh).toHaveBeenCalledTimes(1);
+  });
+
+  it("flushes each parked notification exactly once", () => {
+    const send = vi.fn();
+    const q = new NudgeQueue(() => true);
+
+    q.schedule("a", send);
+    vi.advanceTimersByTime(DEFAULT_HOLD_MS);
+
+    q.flush();
+    q.flush();
+
+    expect(send).toHaveBeenCalledTimes(1);
+  });
+
+  it("keeps delivering after a send throws", () => {
+    const boom = vi.fn(() => {
+      throw new Error("stale record");
+    });
+    const ok = vi.fn();
+    const q = new NudgeQueue(() => true);
+
+    q.schedule("a", boom);
+    q.schedule("b", ok);
+    vi.advanceTimersByTime(DEFAULT_HOLD_MS);
+
+    expect(() => q.flush()).not.toThrow();
+    expect(ok).toHaveBeenCalledTimes(1);
+  });
+
+  it("drops everything undelivered on dispose", () => {
+    const parked = vi.fn();
+    const inWindow = vi.fn();
+    const q = new NudgeQueue(() => true);
+
+    q.schedule("a", parked);
+    vi.advanceTimersByTime(DEFAULT_HOLD_MS);
+    q.schedule("b", inWindow);
+
+    q.dispose();
+    vi.advanceTimersByTime(DEFAULT_HOLD_MS * 10);
+    q.flush();
+
+    expect(parked).not.toHaveBeenCalled();
+    expect(inWindow).not.toHaveBeenCalled();
+    expect(q.heldCount).toBe(0);
+    expect(q.pendingCount).toBe(0);
+  });
+});

--- a/test/rpc-result-consumption.test.ts
+++ b/test/rpc-result-consumption.test.ts
@@ -63,7 +63,7 @@ function makePi() {
   return { pi, lifecycle, bus };
 }
 
-function ctx() {
+function ctx(overrides: Record<string, unknown> = {}) {
   return {
     hasUI: false,
     ui: { setStatus: vi.fn(), setWidget: vi.fn(), notify: vi.fn(), addAutocompleteProvider: vi.fn() },
@@ -72,6 +72,9 @@ function ctx() {
     modelRegistry: { find: vi.fn(), getAvailable: vi.fn(() => []) },
     sessionManager: { getSessionId: vi.fn(() => "s1"), getBranch: vi.fn(() => []) },
     getSystemPrompt: vi.fn(() => "parent"),
+    // Idle unless a test is pinning the mid-run hold.
+    isIdle: () => true,
+    ...overrides,
   } as any;
 }
 
@@ -117,10 +120,10 @@ describe("subagents:rpc:consume", () => {
   });
 
   /** Boot the real extension with its RPC handlers bound, as session_start does. */
-  async function boot() {
+  async function boot(ctxOverrides?: Record<string, unknown>) {
     const booted = makePi();
     subagentsExtension(booted.pi);
-    await booted.lifecycle.get("session_start")({}, ctx());
+    await booted.lifecycle.get("session_start")({}, ctx(ctxOverrides));
     shutdown = () => booted.lifecycle.get("session_shutdown")();
     return booted;
   }
@@ -187,5 +190,32 @@ describe("subagents:rpc:consume", () => {
 
     await vi.waitFor(() => expect(reply).toHaveBeenCalled());
     expect(reply).toHaveBeenCalledWith({ success: false, error: "Agent not found or still running" });
+  });
+
+  it("holds the notification while the parent run is still in progress", async () => {
+    vi.mocked(runAgent).mockResolvedValue({ responseText: "TASK_EXECUTE_AGENT_OK" } as any);
+    let idle = false;
+    const { pi, bus, lifecycle } = await boot({ isIdle: () => idle });
+
+    await spawnOverRpc(bus, "req-spawn-hold");
+    await new Promise(r => setTimeout(r, PAST_THE_HOLD_MS));
+    expect(notifications(pi)).toEqual([]);
+
+    idle = true;
+    await lifecycle.get("agent_settled")();
+    expect(notifications(pi)).toHaveLength(1);
+  });
+
+  it("still suppresses a parked notification after consume", async () => {
+    vi.mocked(runAgent).mockResolvedValue({ responseText: "TASK_EXECUTE_AGENT_OK" } as any);
+    const { pi, bus, lifecycle } = await boot({ isIdle: () => false });
+
+    const id = await spawnOverRpc(bus, "req-spawn-parked");
+    await new Promise(r => setTimeout(r, PAST_THE_HOLD_MS));
+    expect(notifications(pi)).toEqual([]);
+
+    bus.emit("subagents:rpc:consume", { requestId: "req-consume-parked", agentId: id });
+    await lifecycle.get("agent_settled")();
+    expect(notifications(pi)).toEqual([]);
   });
 });


### PR DESCRIPTION
## Summary

Background completion notifications are sent with `deliverAs: "followUp"`. Pi only delivers those once the parent has no more tool calls, so a notification emitted mid-run parks in pi's follow-up queue and cannot be withdrawn.

That means an agent already joined with `get_subagent_result` (or `subagents:rpc:consume`) still notified after the final answer. With `followUpMode: "one-at-a-time"` those stale messages drain one wasted turn each. Observed in the wild: seven agents that had finished up to 1h41m earlier flushed in 54 seconds after the final answer and forced a compaction.

This keeps due notifications in-process instead:

- 200ms hold so a same-tick join can still cancel
- if the parent is mid-run, park until `agent_settled` (not `agent_end` / `turn_end`, which still have work ahead)
- send closures already re-check `resultConsumed`, so deferring the call defers the check
- busy state is read from `ctx.isIdle()` at delivery time

Idle parents still notify immediately. Shutdown drops undelivered notifications, matching `abortAll()`.

## Verification

- `npm run lint`
- `npm run typecheck`
- `npm run test` (2140 passed, 7 skipped)
- `npm run build`
