### PR TITLE
fix: replace schedule-lock busy-wait with stale reclaim and fail-fast

### DIFF
--- a/src/schedule-store.ts
+++ b/src/schedule-store.ts
@@ -14,7 +14,6 @@ import { existsSync, mkdirSync, readFileSync, renameSync, unlinkSync, writeFileS
 import { dirname, join } from "node:path";
 import type { ScheduledSubagent, ScheduleStoreData } from "./types.js";
 
-const LOCK_RETRY_MS = 50;
 const LOCK_MAX_RETRIES = 100;
 
 function isProcessRunning(pid: number): boolean {
@@ -27,19 +26,25 @@ function acquireLock(lockPath: string): void {
       writeFileSync(lockPath, `${process.pid}`, { flag: "wx" });
       return;
     } catch (e: any) {
-      if (e.code === "EEXIST") {
-        try {
-          const pid = parseInt(readFileSync(lockPath, "utf-8"), 10);
-          if (pid && !isProcessRunning(pid)) {
-            unlinkSync(lockPath);
-            continue;
-          }
-        } catch { /* ignore — try again */ }
-        const start = Date.now();
-        while (Date.now() - start < LOCK_RETRY_MS) { /* busy wait */ }
+      if (e.code !== "EEXIST") throw e;
+      let pid: number;
+      try {
+        pid = parseInt(readFileSync(lockPath, "utf-8"), 10);
+      } catch {
+        // unreadable lock: never unlink what we cant prove stale
+        throw new Error(`Schedule store lock is unreadable: ${lockPath}`);
+      }
+      // empty/garbage content is the create-write race window, not staleness
+      if (!Number.isInteger(pid)) {
+        throw new Error(`Schedule store lock has no valid PID: ${lockPath}`);
+      }
+      if (pid === process.pid || !isProcessRunning(pid)) {
+        try { unlinkSync(lockPath); } catch {
+          // raced, retry writeFile
+        }
         continue;
       }
-      throw e;
+      throw new Error(`Schedule store is locked by live process ${pid}: ${lockPath}`);
     }
   }
   throw new Error(`Failed to acquire schedule lock: ${lockPath}`);

--- a/src/schedule.ts
+++ b/src/schedule.ts
@@ -180,7 +180,12 @@ export class SubagentScheduler {
           const t = setTimeout(() => {
             this.executeJob(job.id);
             // Auto-disable one-shots after they fire (mirrors pi-cron-schedule)
-            store.update(job.id, { enabled: false });
+            try {
+              store.update(job.id, { enabled: false });
+            } catch (err) {
+              this.emit({ type: "error", jobId: job.id, error: err instanceof Error ? err.message : String(err) });
+              return;
+            }
             const updated = store.get(job.id);
             if (updated) this.emit({ type: "updated", job: updated });
           }, delay);
@@ -227,7 +232,12 @@ export class SubagentScheduler {
     const job = store.get(id);
     if (!job?.enabled) return;
 
-    store.update(id, { lastStatus: "running" });
+    // status persistence is bookkeeping; a lock failure must not escape the tick
+    try {
+      store.update(id, { lastStatus: "running" });
+    } catch (err) {
+      this.emit({ type: "error", jobId: id, error: err instanceof Error ? err.message : String(err) });
+    }
 
     // Resolve model at fire time — registry contents may have changed since the
     // job was created (auth added/removed). Fall back silently to spawn-default
@@ -274,7 +284,9 @@ export class SubagentScheduler {
       });
     } catch (err) {
       const error = err instanceof Error ? err.message : String(err);
-      store.update(id, { lastRun: new Date().toISOString(), lastStatus: "error" });
+      try {
+        store.update(id, { lastRun: new Date().toISOString(), lastStatus: "error" });
+      } catch { /* bookkeeping — the error event below is the durable signal */ }
       this.emit({ type: "error", jobId: id, error });
       return;
     }
@@ -282,14 +294,16 @@ export class SubagentScheduler {
     this.emit({ type: "fired", jobId: id, agentId, name: job.name });
 
     const finalize = (status: "success" | "error") => {
-      const next = this.getNextRun(id);
-      const current = store.get(id);
-      store.update(id, {
-        lastRun: new Date().toISOString(),
-        lastStatus: status,
-        runCount: (current?.runCount ?? 0) + 1,
-        nextRun: next,
-      });
+      try {
+        const next = this.getNextRun(id);
+        const current = store.get(id);
+        store.update(id, {
+          lastRun: new Date().toISOString(),
+          lastStatus: status,
+          runCount: (current?.runCount ?? 0) + 1,
+          nextRun: next,
+        });
+      } catch { /* bookkeeping — a failed persist must not surface as an unhandled rejection */ }
     };
 
     // AgentManager's promise resolves either way (its .catch returns ""), so we

--- a/test/schedule-store.test.ts
+++ b/test/schedule-store.test.ts
@@ -5,7 +5,8 @@
  * load/save, parse-error self-heal, stale-lock recovery.
  */
 
-import { existsSync, mkdtempSync, readFileSync, rmSync, writeFileSync } from "node:fs";
+import { spawn } from "node:child_process";
+import { chmodSync, existsSync, mkdtempSync, readFileSync, rmSync, writeFileSync } from "node:fs";
 import { tmpdir } from "node:os";
 import { join } from "node:path";
 import { afterEach, beforeEach, describe, expect, it } from "vitest";
@@ -137,6 +138,62 @@ describe("ScheduleStore", () => {
     store.add(a);
     store.add(b);  // would hang if the lock from the first add wasn't released
     expect(store.list().map(j => j.id).sort()).toEqual(["a", "b"]);
+  });
+
+  it("reclaims a lock held by its own PID without blocking the event loop", async () => {
+    const file = join(tmp, "s.json");
+    const lockFile = file + ".lock";
+    // A same-process lock is necessarily stale: withLock() never awaits
+    // between acquire and release, so the single-threaded process cannot be
+    // mid-mutation while another call tries to acquire.
+    writeFileSync(lockFile, String(process.pid));
+
+    let timerFired = false;
+    setTimeout(() => { timerFired = true; }, 50);
+    const store = new ScheduleStore(file);
+    store.add(makeJob());
+    await new Promise((r) => setTimeout(r, 100));
+
+    expect(store.list()).toHaveLength(1);
+    expect(timerFired).toBe(true);  // event loop never blocked
+  });
+
+  it("fails fast on a lock held by a live foreign process", () => {
+    const file = join(tmp, "s.json");
+    const lockFile = file + ".lock";
+    // A live child stands in for a foreign holder (PID 1 is EPERM-invisible).
+    const holder = spawn("sleep", ["30"]);
+    writeFileSync(lockFile, String(holder.pid));
+    try {
+      const store = new ScheduleStore(file);
+      expect(() => store.add(makeJob())).toThrow(/locked by live process/);
+    } finally {
+      holder.kill();
+    }
+  });
+
+  it("fails fast on a lock whose content has no valid PID", () => {
+    const file = join(tmp, "s.json");
+    writeFileSync(file + ".lock", "");
+    const store = new ScheduleStore(file);
+    expect(() => store.add(makeJob())).toThrow(/no valid PID/);
+
+    writeFileSync(file + ".lock", "garbage");
+    expect(() => store.add(makeJob())).toThrow(/no valid PID/);
+  });
+
+  it("fails fast on an unreadable lock without unlinking it", () => {
+    const file = join(tmp, "s.json");
+    const lockFile = file + ".lock";
+    writeFileSync(lockFile, String(process.pid));
+    chmodSync(lockFile, 0o000);
+    try {
+      const store = new ScheduleStore(file);
+      expect(() => store.add(makeJob())).toThrow(/unreadable/);
+    } finally {
+      chmodSync(lockFile, 0o644);
+    }
+    expect(existsSync(lockFile)).toBe(true);
   });
 
   it("does not create the backing directory until a mutation persists", () => {

--- a/test/schedule.test.ts
+++ b/test/schedule.test.ts
@@ -270,6 +270,25 @@ describe("SubagentScheduler — fire path", () => {
     expect(manager.spawn).toHaveBeenCalledTimes(3);
   });
 
+  it("a throwing store at fire time emits an error instead of crashing the timer tick", () => {
+    scheduler.addJob({
+      name: "contended", description: "tick", schedule: "10s",
+      subagent_type: "general-purpose", prompt: "tick",
+    });
+    vi.spyOn(store, "update").mockImplementation(() => {
+      throw new Error("locked by live process 999");
+    });
+
+    // An uncaught throw here would fail the test outright (uncaught in tick).
+    vi.advanceTimersByTime(10_000);
+
+    expect(pi.events.emit).toHaveBeenCalledWith("subagents:scheduled", expect.objectContaining({
+      type: "error", error: expect.stringContaining("locked by live process"),
+    }));
+    // The failure is bookkeeping-only; the job still spawned.
+    expect(manager.spawn).toHaveBeenCalledTimes(1);
+  });
+
   it("refuses at fire time when the job's agent type no longer resolves", () => {
     // The registry is what production populates at activation; a job outliving
     // its agent must not silently run something else (#183).


### PR DESCRIPTION
Closes issue #247.

## Summary

`acquireLock()` in the schedule store retried lock acquisition 100 times, each with a 50 ms synchronous spin. Contention froze the single-threaded event loop for up to 5 seconds, blocking rendering, input, and streaming.

## What changed

No waiting. On `EEXIST`, resolve the lock by ownership instead of retrying:

- Holder is dead or our PID: reclaim and proceed. `withLock()` has no awaits between acquire and release, so the lock can only be stale.
- Live foreign process: throw, naming the PID.
- Unreadable or non-PID content: throw. Unlinking requires proof of staleness; empty content is the create-write race window.

The old spin outlasted the sub-millisecond critical section, so callers never caught. The new code throws on first contention. The scheduler now wraps its fire-time mutations (`executeJob`, `finalize`, the one-shot callback): a lock failure emits a `subagents:scheduled` error event and the job still spawns. Only status bookkeeping gets skipped. Without this, a throw from a timer callback would be uncaught.

Cross-process contention now errors promptly instead of blocking. The affected case is two pi processes sharing a session's schedule file (resuming the same session in two terminals, both running the same cron job); the loser gets an error event naming the holder PID. No settings, events, or formats change.

## Testing

- `npm run lint`
- `npm run typecheck`
- `npm run test`
- `npm run build`