### PR TITLE
fix(worktree): preserve changes when cleanup fails

### DIFF
--- a/README.md
+++ b/README.md
@@ -859,14 +859,15 @@ Set `isolation: worktree` to run an agent in a temporary git worktree:
 Agent({ subagent_type: "refactor", prompt: "...", isolation: "worktree" })
 ```
 
-The agent gets a full, isolated copy of the repository. The worktree directory is removed on completion either way — what differs is whether a branch is left behind:
+The agent gets a full, isolated copy of the repository. The worktree is normally removed on completion:
 - **No changes:** worktree is cleaned up automatically, no branch
 - **Changes made:** changes are committed to a new branch (`pi-agent-<id>`), and the result names the branch and the `git merge` command for it. The branch is the only artifact — the worktree path is gone, so nothing points into it
 - **Agent committed its own work:** the branch is created at the agent's HEAD, preserving its commits (uncommitted leftovers are committed on top first)
+- **Preservation failed:** the run reports an error and keeps the worktree. Its path is included in the result so the changes can be recovered manually
 
 The agent's system prompt names the worktree as an isolated copy and tells it to work only there, even if other instructions name the main checkout — otherwise an inherited parent prompt or a task prompt mentioning the project path walks it straight back out of the copy. This is a directive, not a sandbox: an agent with shell access can still `cd` out, so don't rely on `isolation` alone to protect the main checkout.
 
-The automatic preservation commit uses `--no-verify`, so local pre-commit hooks can't block it — the commit is local-only and never pushed, and pre-push/server-side hooks still apply.
+The automatic preservation commit uses `--no-verify` and `--no-gpg-sign`, so local pre-commit hooks and interactive signing configuration can't block it. The commit is local-only and never pushed; pre-push and server-side hooks still apply. Other Git failures keep the worktree intact and report its recovery path instead of deleting the only copy.
 
 If the worktree cannot be created (not a git repo, no commits, or `git worktree add` fails), the `Agent` call fails with a clear error instead of running unisolated — `isolation: "worktree"` is a strict guarantee, not a hint. The call is reported as a failed tool call, not as a subagent that ran and returned that message, so the model doesn't retry it as if the agent had merely reported a problem. Initialize git and commit at least once, or omit `isolation`.
 

--- a/docs/rpc.md
+++ b/docs/rpc.md
@@ -8,7 +8,7 @@ For the channel list, the reply envelope, the per-channel snippets and the event
 
 ## Spawn options
 
-`subagents:rpc:spawn` forwards `options` to `AgentManager.spawn` — but not verbatim. The manager's `spawn` behind the RPC is `spawnTopLevel` (`src/index.ts:698-721`), which deletes internal-only fields first, and then `spawnResolved` (`src/index.ts:666-696`) overwrites the activity-tracker callbacks with its own. The full interface is `SpawnOptions` at `src/agent-manager.ts:169-303`; what a bus caller actually gets is three different things.
+`subagents:rpc:spawn` forwards `options` to `AgentManager.spawn` — but not verbatim. The manager's `spawn` behind the RPC is `spawnTopLevel` (`src/index.ts:698-721`), which deletes internal-only fields first, and then `spawnResolved` (`src/index.ts:666-696`) overwrites the activity-tracker callbacks with its own. The full interface is `SpawnOptions` at `src/agent-manager.ts:177-313`; what a bus caller actually gets is three different things.
 
 **Honoured** — set these and they take effect:
 
@@ -49,7 +49,7 @@ Four things that are not obvious from the tables:
 
 - **Nothing is required at runtime.** `description` is non-optional in TypeScript and never validated. A spawn with no `options` at all is legal and is what `test/cross-extension-rpc.test.ts:81-94` pins.
 - **`bypassQueue` is not stripped.** Its own doc comment scopes it to the scheduler and the `/agents` generator, but a bus caller can set it and skip the `maxConcurrent` check.
-- **`structuredOutput` is documented "set only by the workflow host"** (`src/agent-manager.ts:231-234`) and is also not stripped.
+- **`structuredOutput` is documented "set only by the workflow host"** (`src/agent-manager.ts:239-242`) and is also not stripped.
 - **`signal` and the `on*` callbacks are function values.** They work only because the bus is in-process. A caller that genuinely serializes its payload cannot use them, and they arrive as `undefined` rather than failing.
 
 ### Names that look right and are not
@@ -80,11 +80,12 @@ Every failure reaches the caller as `{ success: false, error }`, where `error` i
 | `Unknown or disabled agent type: "<raw>". Available: <list>.` | `src/agent-types.ts:187` — only under `fallbackSubagent: none` |
 | `No agent type given. Available: <list>.` | `src/agent-types.ts:187-194` — same condition |
 | `<reason> The configured fallbackSubagent "<x>" is itself unknown or disabled. Available: <list>.` | `src/agent-types.ts:205-207` |
-| `SpawnOptions.cwd must be an absolute path: "<value>"` | `src/agent-manager.ts:85` |
-| `SpawnOptions.cwd does not exist: "<cwd>"` | `src/agent-manager.ts:91` |
-| `SpawnOptions.cwd is not a directory: "<cwd>"` | `src/agent-manager.ts:94` |
-| `Cannot run with isolation: "worktree" — not a git repo, no commits yet, or 'git worktree add' failed.` | `src/agent-manager.ts:716-719`, surfaced through `awaitStartup` |
-| git plumbing failures | `src/worktree.ts:76` |
+| `SpawnOptions.cwd must be an absolute path: "<value>"` | `src/agent-manager.ts:93` |
+| `SpawnOptions.cwd does not exist: "<cwd>"` | `src/agent-manager.ts:99` |
+| `SpawnOptions.cwd is not a directory: "<cwd>"` | `src/agent-manager.ts:102` |
+| `Cannot run with isolation: "worktree" — not a git repo, no commits yet, or 'git worktree add' failed.` | `src/agent-manager.ts:724-727`, surfaced through `awaitStartup` |
+| `Worktree cleanup failed: <reason>` + retained recovery path | `src/agent-manager.ts:76-81`; the agent becomes an error instead of losing the worktree |
+| git plumbing failures | `src/worktree.ts:78` |
 | `Agent not found` | stop — `src/cross-extension-rpc.ts:170` |
 | `Agent is owned by another agent or workflow` | stop — `:178` |
 | `Agent is not running` | stop — `:182`. The record exists, so it has already settled |
@@ -92,13 +93,13 @@ Every failure reaches the caller as `{ success: false, error }`, where `error` i
 
 Three things the table cannot show:
 
-- **The failure that is not an error.** With `worktreeIsolation` off project-wide, `isolation: "worktree"` is dropped at `src/agent-manager.ts:712` with no error, no note on the record, and a success envelope on the wire. Your agent runs in the main tree. If you asked for isolation because two agents were going to write the same files, they now collide and nothing told you.
+- **The failure that is not an error.** With `worktreeIsolation` off project-wide, `isolation: "worktree"` is dropped at `src/agent-manager.ts:720` with no error, no note on the record, and a success envelope on the wire. Your agent runs in the main tree. If you asked for isolation because two agents were going to write the same files, they now collide and nothing told you.
 - **`data` is omitted** when a handler returns nothing, so a successful stop or consume reply is a bare `{ success: true }` and `reply.data.anything` throws.
 - **`requestId` is not validated.** It is interpolated straight into the reply channel, so a caller that omits it gets its reply on the literal channel `subagents:rpc:spawn:reply:undefined` — where every other caller that omitted it is also listening. Send one, and send a unique one.
 
 ## Ownership
 
-`isTopLevelAgent(record)` is `parentAgentId === undefined && workflowId === undefined` (`src/agent-manager.ts:122-126`). `subagents:rpc:stop` enforces it (`src/cross-extension-rpc.ts:178`): a nested child or a workflow's agent is owned by something that is *waiting on it*, and aborting it out from under that owner turns another extension's stop into a failed step. It is defence in depth rather than a live hole — no RPC hands out agent ids, so a caller has no ordinary way to name one it does not own.
+`isTopLevelAgent(record)` is `parentAgentId === undefined && workflowId === undefined` (`src/agent-manager.ts:130-134`). `subagents:rpc:stop` enforces it (`src/cross-extension-rpc.ts:178`): a nested child or a workflow's agent is owned by something that is *waiting on it*, and aborting it out from under that owner turns another extension's stop into a failed step. It is defence in depth rather than a live hole — no RPC hands out agent ids, so a caller has no ordinary way to name one it does not own.
 
 Two asymmetries to know about, stated as they are:
 
@@ -125,7 +126,7 @@ When a background agent finishes, pi-subagents sends the user a completion notif
 
 Fire-and-forget is the intended use: the reply carries nothing to act on, and the channel sits outside the `subagents:rpc:ping` version handshake on purpose (`src/cross-extension-rpc.ts:190`), so you can send it unconditionally and an older pi-subagents with no handler simply keeps notifying.
 
-Consumption is not terminal. An `@handle` steer un-consumes the record (`src/index.ts:920`) because the agent's reply to that message still needs relaying, and so does a background resume (`src/agent-manager.ts:1135`) because the record is starting a new run.
+Consumption is not terminal. An `@handle` steer un-consumes the record (`src/index.ts:920`) because the agent's reply to that message still needs relaying, and so does a background resume (`src/agent-manager.ts:1148`) because the record is starting a new run.
 
 One related thing that lives nowhere else: on every top-level settle, pi-subagents writes a session entry — not an event — via `pi.appendEntry("subagents:record", …)` (`src/index.ts:585`), carrying `id`, `type`, `description`, `status`, `result`, `error`, `startedAt` and `completedAt`. It exists for cross-extension history reconstruction. It is append-only history, not something to react to.
 

--- a/src/agent-manager.ts
+++ b/src/agent-manager.ts
@@ -25,7 +25,7 @@ import { describeModel } from "./model-resolver.js";
 import type { AgentInvocation, AgentRecord, AgentTombstone, IsolationMode, MentionResolution, SubagentType, ThinkingLevel } from "./types.js";
 import { addUsage, type LifetimeUsage } from "./usage.js";
 import type { CompiledSchema } from "./workflow/json-schema.js";
-import { cleanupWorktree, createWorktree, isWorktreeIsolationEnabled, pruneWorktrees, } from "./worktree.js";
+import { cleanupWorktree, createWorktree, isWorktreeIsolationEnabled, pruneWorktrees, type WorktreeCleanupResult, } from "./worktree.js";
 
 export type OnAgentComplete = (record: AgentRecord) => void;
 export type OnAgentStart = (record: AgentRecord) => void;
@@ -72,6 +72,14 @@ const DEFAULT_MAX_CONCURRENT_FOREGROUND = 0;
  * far above the handful anyone keeps in their head.
  */
 const MAX_TOMBSTONES = 100;
+
+function applyWorktreeCleanupFailure(record: AgentRecord, result: WorktreeCleanupResult): boolean {
+  if (!result.error || !result.path) return false;
+  const message = `Worktree cleanup failed: ${result.error}\nAgent worktree remains at \`${result.path}\` for recovery.`;
+  record.status = "error";
+  record.error = record.error ? `${record.error}\n${message}` : message;
+  return true;
+}
 
 /**
  * Validate a caller-supplied SpawnOptions.cwd. `undefined`/`null` mean "unset"
@@ -736,6 +744,9 @@ export class AgentManager {
       if (record.status !== "running") {
         releaseSlot();
         record.worktreeResult = await cleanupWorktree(pi, baseCwd, wt, options.description);
+        if (applyWorktreeCleanupFailure(record, record.worktreeResult)) {
+          throw new Error(record.error);
+        }
         this.drainQueue();
         return;
       }
@@ -890,7 +901,8 @@ export class AgentManager {
           }
           const wtResult = await cleanupWorktree(pi, baseCwd, record.worktree, options.description);
           record.worktreeResult = wtResult;
-          if (wtResult.hasChanges && wtResult.branch) {
+          const cleanupFailed = applyWorktreeCleanupFailure(record, wtResult);
+          if (!cleanupFailed && wtResult.hasChanges && wtResult.branch) {
             // With a caller-supplied cwd the branch lives in THAT repo, not the
             // parent session's — say so, or the orchestrator merges in the wrong repo.
             const repoNote = customCwd !== undefined ? ` in \`${baseCwd}\`` : "";
@@ -928,6 +940,7 @@ export class AgentManager {
           try {
             const wtResult = await cleanupWorktree(pi, baseCwd, record.worktree, options.description);
             record.worktreeResult = wtResult;
+            applyWorktreeCleanupFailure(record, wtResult);
           } catch { /* ignore cleanup errors */ }
         }
 

--- a/src/index.ts
+++ b/src/index.ts
@@ -1462,11 +1462,11 @@ export default function (pi: ExtensionAPI) {
   // With no per-result note by design, the model would have every reason to go
   // on reporting a `pi-agent-*` branch that was never created.
   const isolationGuideline = isWorktreeIsolationEnabled()
-    ? `\n- Use isolation: "worktree" to give the agent its own git worktree (safe parallel file modifications); leave it unset, or pass "off", for none. The worktree is removed when the agent finishes; if it made changes, they are committed to a branch and the branch is named in the result.`
+    ? `\n- Use isolation: "worktree" to give the agent its own git worktree (safe parallel file modifications); leave it unset, or pass "off", for none. The worktree is normally removed when the agent finishes and changes land on a named branch. If preservation fails, the worktree is kept and its recovery path is reported.`
     : "";
 
   const isolationCompactGuideline = isWorktreeIsolationEnabled()
-    ? `\n- isolation: "worktree" gives the agent its own git worktree (removed on completion); changes land on a branch named in the result.`
+    ? `\n- isolation: "worktree" uses a temporary git worktree. Changes land on a branch; a preservation failure keeps the worktree and reports its path.`
     : "";
 
   // Compact Agent tool description (#91, `toolDescriptionMode: "compact"`) —

--- a/src/types.ts
+++ b/src/types.ts
@@ -205,7 +205,7 @@ export interface AgentRecord {
   /** Worktree info if the agent is running in an isolated worktree. */
   worktree?: { path: string; branch: string; baseSha: string; workPath: string };
   /** Worktree cleanup result after agent completion. */
-  worktreeResult?: { hasChanges: boolean; branch?: string };
+  worktreeResult?: { hasChanges: boolean; branch?: string; path?: string; error?: string };
   /** The tool_use_id from the original Agent tool call. */
   toolCallId?: string;
   /** Path to the streaming output transcript file. */

--- a/src/worktree.ts
+++ b/src/worktree.ts
@@ -53,12 +53,14 @@ export function isWorktreeIsolationEnabled(): boolean {
 }
 
 export interface WorktreeCleanupResult {
-  /** Whether changes were found in the worktree. */
+  /** Whether changes were found or may remain after a cleanup failure. */
   hasChanges: boolean;
   /** Branch name if changes were committed. */
   branch?: string;
-  /** Worktree path if it was kept. */
+  /** Worktree path. On error, the agent's changes remain here for recovery. */
   path?: string;
+  /** Cleanup failure. When present, the worktree is deliberately preserved. */
+  error?: string;
 }
 
 /**
@@ -132,6 +134,7 @@ export async function cleanupWorktree(
     return { hasChanges: false };
   }
 
+  let preservedBranch: string | undefined;
   try {
     // Check for uncommitted changes in the worktree
     const status = await git(pi, worktree.path, ["status", "--porcelain"], 10000);
@@ -142,7 +145,7 @@ export async function cleanupWorktree(
       // Truncate description for commit message (no shell sanitization needed — pi.exec uses argv)
       const safeDesc = agentDescription.slice(0, 200);
       const commitMsg = `pi-agent: ${safeDesc}`;
-      await git(pi, worktree.path, ["commit", "--no-verify", "-m", commitMsg], 10000);
+      await git(pi, worktree.path, ["commit", "--no-verify", "--no-gpg-sign", "-m", commitMsg], 10000);
     } else {
       const currentSha = await git(pi, worktree.path, ["rev-parse", "HEAD"], 5000);
 
@@ -165,6 +168,7 @@ export async function cleanupWorktree(
     }
     // Update branch name in worktree info for the caller
     worktree.branch = branchName;
+    preservedBranch = branchName;
 
     // Remove the worktree (branch persists in main repo)
     await removeWorktree(pi, cwd, worktree.path);
@@ -174,10 +178,15 @@ export async function cleanupWorktree(
       branch: worktree.branch,
       path: worktree.path,
     };
-  } catch {
-    // Best effort cleanup on error
-    try { await removeWorktree(pi, cwd, worktree.path); } catch { /* ignore */ }
-    return { hasChanges: false };
+  } catch (error) {
+    // This may be the only copy of the agent's work. Keep it recoverable and
+    // report the path instead of turning a preservation failure into "no changes".
+    return {
+      hasChanges: true,
+      ...(preservedBranch ? { branch: preservedBranch } : {}),
+      path: worktree.path,
+      error: error instanceof Error ? error.message : String(error),
+    };
   }
 }
 
@@ -187,11 +196,14 @@ export async function cleanupWorktree(
 async function removeWorktree(pi: ExtensionAPI, cwd: string, worktreePath: string): Promise<void> {
   try {
     await git(pi, cwd, ["worktree", "remove", "--force", worktreePath], 10000);
-  } catch {
-    // If git worktree remove fails, try pruning
+  } catch (removeError) {
+    // A concurrent remover may have deleted the directory while Git still
+    // returned an error. Prune stale metadata, but report failure if the copy
+    // still exists — callers must not mistake a leaked worktree for success.
     try {
       await git(pi, cwd, ["worktree", "prune"], 5000);
     } catch { /* ignore */ }
+    if (existsSync(worktreePath)) throw removeError;
   }
 }
 

--- a/test/agent-manager.test.ts
+++ b/test/agent-manager.test.ts
@@ -911,6 +911,126 @@ describe("AgentManager — isolation: worktree fails loud, no silent fallback", 
     expect(record.result).toContain("Changes saved to branch");
   });
 
+  it("reports a preserved worktree when cleanup fails after a completed run", async () => {
+    const { createWorktree, cleanupWorktree } = await import("../src/worktree.js");
+    const wt = { path: "/wt/recover", branch: "pi-agent-recover", baseSha: "abc", workPath: "/wt/recover" };
+    vi.mocked(createWorktree).mockResolvedValueOnce(wt);
+    vi.mocked(cleanupWorktree).mockResolvedValueOnce({
+      hasChanges: true,
+      path: wt.path,
+      error: "commit failed",
+    });
+    resolvedRun();
+
+    manager = new AgentManager();
+    const id = manager.spawn(mockPi, mockCtx, "X", "go", {
+      description: "go", isBackground: true, isolation: "worktree",
+    });
+    await manager.awaitStartup(id);
+    await manager.getRecord(id)!.promise;
+
+    const record = manager.getRecord(id)!;
+    expect(record.status).toBe("error");
+    expect(record.error).toBe(
+      "Worktree cleanup failed: commit failed\nAgent worktree remains at `/wt/recover` for recovery.",
+    );
+    expect(record.result).toBe("done");
+    expect(record.worktreeResult).toMatchObject({ path: wt.path, error: "commit failed" });
+  });
+
+  it("keeps a resolved agent failure when cleanup also fails", async () => {
+    const { createWorktree, cleanupWorktree } = await import("../src/worktree.js");
+    const wt = { path: "/wt/resolved-error", branch: "pi-agent-error", baseSha: "abc", workPath: "/wt/resolved-error" };
+    vi.mocked(createWorktree).mockResolvedValueOnce(wt);
+    vi.mocked(cleanupWorktree).mockResolvedValueOnce({
+      hasChanges: true,
+      path: wt.path,
+      error: "commit failed",
+    });
+    vi.mocked(runAgent).mockResolvedValueOnce({
+      responseText: "partial output",
+      session: mockSession(),
+      aborted: false,
+      steered: false,
+      failure: "model failed",
+    });
+
+    manager = new AgentManager();
+    const id = manager.spawn(mockPi, mockCtx, "X", "go", {
+      description: "go", isBackground: true, isolation: "worktree",
+    });
+    await manager.awaitStartup(id);
+    await manager.getRecord(id)!.promise;
+
+    const record = manager.getRecord(id)!;
+    expect(record.status).toBe("error");
+    expect(record.error).toBe(
+      "model failed\nWorktree cleanup failed: commit failed\nAgent worktree remains at `/wt/resolved-error` for recovery.",
+    );
+  });
+
+  it("adds the recovery path to an existing agent error", async () => {
+    const { createWorktree, cleanupWorktree } = await import("../src/worktree.js");
+    const wt = { path: "/wt/error", branch: "pi-agent-error", baseSha: "abc", workPath: "/wt/error" };
+    vi.mocked(createWorktree).mockResolvedValueOnce(wt);
+    vi.mocked(cleanupWorktree).mockResolvedValueOnce({
+      hasChanges: true,
+      path: wt.path,
+      error: "branch failed",
+    });
+    vi.mocked(runAgent).mockRejectedValueOnce(new Error("provider failed"));
+
+    manager = new AgentManager();
+    const id = manager.spawn(mockPi, mockCtx, "X", "go", {
+      description: "go", isBackground: true, isolation: "worktree",
+    });
+    await manager.awaitStartup(id);
+    await manager.getRecord(id)!.promise;
+
+    const record = manager.getRecord(id)!;
+    expect(record.status).toBe("error");
+    expect(record.error).toBe(
+      "provider failed\nWorktree cleanup failed: branch failed\nAgent worktree remains at `/wt/error` for recovery.",
+    );
+  });
+
+  it("surfaces the recovery path when cleanup fails after a stop", async () => {
+    const { createWorktree, cleanupWorktree } = await import("../src/worktree.js");
+    const wt = { path: "/wt/stopped", branch: "pi-agent-stopped", baseSha: "abc", workPath: "/wt/stopped" };
+    vi.mocked(createWorktree).mockResolvedValueOnce(wt);
+    vi.mocked(cleanupWorktree).mockResolvedValueOnce({
+      hasChanges: true,
+      path: wt.path,
+      error: "commit failed",
+    });
+    let finishRun: (() => void) | undefined;
+    vi.mocked(runAgent).mockImplementationOnce(
+      () => new Promise((resolve) => {
+        finishRun = () => resolve({
+          responseText: "partial output",
+          session: mockSession(),
+          aborted: false,
+          steered: false,
+        });
+      }),
+    );
+
+    manager = new AgentManager();
+    const id = manager.spawn(mockPi, mockCtx, "X", "go", {
+      description: "go", isBackground: true, isolation: "worktree",
+    });
+    await manager.awaitStartup(id);
+    expect(manager.abort(id)).toBe(true);
+    finishRun!();
+    await manager.getRecord(id)!.promise;
+
+    const record = manager.getRecord(id)!;
+    expect(record.status).toBe("error");
+    expect(record.error).toBe(
+      "Worktree cleanup failed: commit failed\nAgent worktree remains at `/wt/stopped` for recovery.",
+    );
+  });
+
   it("a stop that lands during the copy discards the worktree instead of running", async () => {
     // Window that did not exist when creation was synchronous: abort() can mark
     // the record stopped while the repo is still being copied.
@@ -936,6 +1056,86 @@ describe("AgentManager — isolation: worktree fails loud, no silent fallback", 
     expect(runAgent).not.toHaveBeenCalled();
     expect(cleanupWorktree).toHaveBeenCalledWith(mockPi, "/tmp", wt, "stopped");
     expect(manager.getRecord(id)!.status).toBe("stopped");
+  });
+
+  it("surfaces cleanup failure when a stop lands during the copy", async () => {
+    const { createWorktree, cleanupWorktree } = await import("../src/worktree.js");
+    let releaseCopy!: () => void;
+    const wt = { path: "/wt/copy-failed", branch: "pi-agent-x", baseSha: "abc", workPath: "/wt/copy-failed" };
+    vi.mocked(createWorktree).mockImplementationOnce(
+      () => new Promise(resolve => { releaseCopy = () => resolve(wt); }),
+    );
+    vi.mocked(cleanupWorktree).mockResolvedValueOnce({
+      hasChanges: true,
+      path: wt.path,
+      error: "remove failed",
+    });
+    vi.mocked(runAgent).mockClear();
+
+    manager = new AgentManager();
+    const id = manager.spawn(mockPi, mockCtx, "X", "stopped", {
+      description: "stopped", isBackground: true, isolation: "worktree",
+    });
+    const startup = manager.awaitStartup(id);
+    expect(manager.abort(id)).toBe(true);
+
+    releaseCopy();
+    await expect(startup).rejects.toThrow(
+      "Worktree cleanup failed: remove failed\nAgent worktree remains at `/wt/copy-failed` for recovery.",
+    );
+
+    expect(runAgent).not.toHaveBeenCalled();
+    expect(cleanupWorktree).toHaveBeenCalledWith(mockPi, "/tmp", wt, "stopped");
+    expect(manager.getRecord(id)).toBeUndefined();
+  });
+
+  it("notifies a queued caller when copy-stage cleanup fails", async () => {
+    const { createWorktree, cleanupWorktree } = await import("../src/worktree.js");
+    let finishFirst: (() => void) | undefined;
+    vi.mocked(runAgent).mockImplementationOnce(
+      () => new Promise((resolve) => {
+        finishFirst = () => resolve({
+          responseText: "done",
+          session: mockSession(),
+          aborted: false,
+          steered: false,
+        });
+      }),
+    );
+    let releaseCopy: (() => void) | undefined;
+    const wt = { path: "/wt/queued-failed", branch: "pi-agent-x", baseSha: "abc", workPath: "/wt/queued-failed" };
+    vi.mocked(createWorktree).mockImplementationOnce(
+      () => new Promise(resolve => { releaseCopy = () => resolve(wt); }),
+    );
+    vi.mocked(cleanupWorktree).mockResolvedValueOnce({
+      hasChanges: true,
+      path: wt.path,
+      error: "remove failed",
+    });
+    const completed: AgentRecord[] = [];
+    manager = new AgentManager((record) => completed.push(record), 1);
+
+    const firstId = manager.spawn(mockPi, mockCtx, "X", "first", {
+      description: "first", isBackground: true,
+    });
+    await manager.awaitStartup(firstId);
+    const queuedId = manager.spawn(mockPi, mockCtx, "X", "queued", {
+      description: "queued", isBackground: true, isolation: "worktree",
+    });
+    expect(manager.getRecord(queuedId)!.status).toBe("queued");
+
+    finishFirst!();
+    await manager.getRecord(firstId)!.promise;
+    await vi.waitFor(() => expect(releaseCopy).toBeDefined());
+    expect(manager.abort(queuedId)).toBe(true);
+    releaseCopy!();
+
+    await vi.waitFor(() => expect(manager.getRecord(queuedId)!.status).toBe("error"));
+    const queuedRecord = manager.getRecord(queuedId)!;
+    expect(queuedRecord.error).toBe(
+      "Worktree cleanup failed: remove failed\nAgent worktree remains at `/wt/queued-failed` for recovery.",
+    );
+    expect(completed).toContain(queuedRecord);
   });
 });
 

--- a/test/env.test.ts
+++ b/test/env.test.ts
@@ -36,7 +36,7 @@ describe("detectEnv", () => {
     // Create a temp repo on a known branch to test branch detection
     const tmpDir = mkdtempSync(join(tmpdir(), "pi-env-branch-"));
     try {
-      execSync("git init && git config user.email test@test.com && git config user.name Test && git checkout -b test-branch && git commit --allow-empty -m init", {
+      execSync("git init && git config user.email test@test.com && git config user.name Test && git checkout -b test-branch && git commit --no-gpg-sign --allow-empty -m init", {
         cwd: tmpDir, stdio: "pipe",
       });
       const env = await detectEnv(mockPi(), tmpDir);

--- a/test/workflow-gate-worktree.test.ts
+++ b/test/workflow-gate-worktree.test.ts
@@ -102,7 +102,7 @@ function initRepo(): string {
   execFileSync("git", ["config", "user.name", "Test"], { cwd: dir, stdio: "pipe" });
   writeFileSync(join(dir, "README.md"), "# gate");
   execFileSync("git", ["add", "README.md"], { cwd: dir, stdio: "pipe" });
-  execFileSync("git", ["commit", "-m", "initial"], { cwd: dir, stdio: "pipe" });
+  execFileSync("git", ["commit", "--no-gpg-sign", "-m", "initial"], { cwd: dir, stdio: "pipe" });
   return dir;
 }
 

--- a/test/worktree-isolation-e2e.test.ts
+++ b/test/worktree-isolation-e2e.test.ts
@@ -46,7 +46,7 @@ function initGitRepo(): string {
   git(dir, "config", "user.name", "Test");
   writeFileSync(join(dir, "README.md"), "# Test repo");
   git(dir, "add", "README.md");
-  git(dir, "commit", "-m", "initial");
+  git(dir, "commit", "--no-gpg-sign", "-m", "initial");
   return dir;
 }
 

--- a/test/worktree.test.ts
+++ b/test/worktree.test.ts
@@ -1,6 +1,6 @@
 import { execFileSync } from "node:child_process";
 import { existsSync, mkdirSync, mkdtempSync, rmSync, writeFileSync } from "node:fs";
-import { tmpdir } from "node:os";
+import { platform, tmpdir } from "node:os";
 import { join } from "node:path";
 import type { ExtensionAPI } from "@earendil-works/pi-coding-agent";
 import { afterEach, beforeEach, describe, expect, it, vi } from "vitest";
@@ -60,7 +60,7 @@ function initGitRepo(): string {
   execFileSync("git", ["config", "user.name", "Test"], { cwd: dir, stdio: "pipe" });
   writeFileSync(join(dir, "README.md"), "# Test repo");
   execFileSync("git", ["add", "README.md"], { cwd: dir, stdio: "pipe" });
-  execFileSync("git", ["commit", "-m", "initial"], { cwd: dir, stdio: "pipe" });
+  execFileSync("git", ["commit", "--no-gpg-sign", "-m", "initial"], { cwd: dir, stdio: "pipe" });
   return dir;
 }
 
@@ -149,7 +149,7 @@ describe("worktree", () => {
       mkdirSync(join(repoDir, "packages", "api"), { recursive: true });
       writeFileSync(join(repoDir, "packages", "api", "index.ts"), "export {}");
       execFileSync("git", ["add", "-A"], { cwd: repoDir, stdio: "pipe" });
-      execFileSync("git", ["commit", "-m", "add package"], { cwd: repoDir, stdio: "pipe" });
+      execFileSync("git", ["commit", "--no-gpg-sign", "-m", "add package"], { cwd: repoDir, stdio: "pipe" });
 
       const wt = (await createWorktree(pi, join(repoDir, "packages", "api"), "subdir-wp"))!;
       expect(wt).toBeDefined();
@@ -258,13 +258,48 @@ describe("worktree", () => {
       try { execFileSync("git", ["branch", "-D", result.branch!], { cwd: repoDir, stdio: "pipe" }); } catch { /* ignore */ }
     });
 
+    it("bypasses configured commit signing for preservation commits", async () => {
+      const isWindows = platform() === "win32";
+      const signerMarker = join(repoDir, "signer-invoked");
+      const signerPath = join(repoDir, isWindows ? "signer.cmd" : "signer.sh");
+      writeFileSync(
+        signerPath,
+        isWindows
+          ? `@echo invoked>"${signerMarker}"\r\nexit /b 1\r\n`
+          : `#!/bin/sh\nprintf invoked > "${signerMarker}"\nexit 1\n`,
+        { mode: 0o755 },
+      );
+      for (const [key, value] of [
+        ["commit.gpgsign", "true"],
+        ["gpg.format", "ssh"],
+        ["gpg.ssh.program", signerPath],
+        ["user.signingkey", "test-signing-key"],
+      ]) {
+        execFileSync("git", ["config", key, value], { cwd: repoDir, stdio: "pipe" });
+      }
+
+      const wt = (await createWorktree(pi, repoDir, "signed-1"))!;
+      writeFileSync(join(wt.path, "signed-file.txt"), "agent wrote this");
+
+      try {
+        const result = await cleanupWorktree(pi, repoDir, wt, "signing must not block");
+
+        expect(result.hasChanges).toBe(true);
+        expect(result.branch).toBe("pi-agent-signed-1");
+        expect(existsSync(signerMarker)).toBe(false);
+      } finally {
+        try { execFileSync("git", ["worktree", "remove", "--force", wt.path], { cwd: repoDir, stdio: "pipe" }); } catch { /* ignore */ }
+        try { execFileSync("git", ["branch", "-D", wt.branch], { cwd: repoDir, stdio: "pipe" }); } catch { /* ignore */ }
+      }
+    });
+
     it("creates branch when worktree is clean but HEAD moved", async () => {
       const wt = (await createWorktree(pi, repoDir, "committed-1"))!;
       expect(wt).toBeDefined();
 
       writeFileSync(join(wt.path, "committed-file.txt"), "agent committed this");
       execFileSync("git", ["add", "committed-file.txt"], { cwd: wt.path, stdio: "pipe" });
-      execFileSync("git", ["commit", "-m", "agent commit"], { cwd: wt.path, stdio: "pipe" });
+      execFileSync("git", ["commit", "--no-gpg-sign", "-m", "agent commit"], { cwd: wt.path, stdio: "pipe" });
       const agentCommit = execFileSync("git", ["rev-parse", "HEAD"], {
         cwd: wt.path, stdio: "pipe",
       }).toString().trim();
@@ -340,20 +375,47 @@ describe("worktree", () => {
       try { execFileSync("git", ["branch", "-D", result.branch!], { cwd: repoDir, stdio: "pipe" }); } catch { /* ignore */ }
     });
 
-    it("falls back to pruning when `git worktree remove` fails", async () => {
-      // Removal failing is not fatal — the registration is pruned instead, and
-      // the caller still hears that there were no changes.
+    it("reports the recovery path when clean worktree removal fails", async () => {
       const wt = (await createWorktree(pi, repoDir, "remove-fails"))!;
       const failing = failingPi(
         args => args[0] === "worktree" && args[1] === "remove",
         { code: 1, killed: false },
       );
 
-      const result = await cleanupWorktree(failing, repoDir, wt, "removal fails");
+      try {
+        const result = await cleanupWorktree(failing, repoDir, wt, "removal fails");
 
-      expect(result.hasChanges).toBe(false);
-      expect(vi.mocked(failing.exec).mock.calls.some(([, args]) => args[0] === "worktree" && args[1] === "prune")).toBe(true);
-      try { execFileSync("git", ["worktree", "remove", "--force", wt.path], { cwd: repoDir, stdio: "pipe" }); } catch { /* ignore */ }
+        expect(result).toEqual({ hasChanges: true, path: wt.path, error: "boom" });
+        expect(existsSync(wt.path)).toBe(true);
+        expect(vi.mocked(failing.exec).mock.calls.some(([, args]) => args[0] === "worktree" && args[1] === "prune")).toBe(true);
+      } finally {
+        try { execFileSync("git", ["worktree", "remove", "--force", wt.path], { cwd: repoDir, stdio: "pipe" }); } catch { /* ignore */ }
+      }
+    });
+
+    it("keeps branch metadata when removal fails after preserving changes", async () => {
+      const wt = (await createWorktree(pi, repoDir, "dirty-remove-fails"))!;
+      writeFileSync(join(wt.path, "work.txt"), "agent output");
+      const failing = failingPi(
+        args => args[0] === "worktree" && args[1] === "remove",
+        { code: 1, killed: false },
+      );
+
+      try {
+        const result = await cleanupWorktree(failing, repoDir, wt, "removal fails");
+
+        expect(result).toEqual({
+          hasChanges: true,
+          branch: wt.branch,
+          path: wt.path,
+          error: "boom",
+        });
+        expect(existsSync(wt.path)).toBe(true);
+        expect(execFileSync("git", ["branch", "--list", wt.branch], { cwd: repoDir, encoding: "utf8" })).toContain(wt.branch);
+      } finally {
+        try { execFileSync("git", ["worktree", "remove", "--force", wt.path], { cwd: repoDir, stdio: "pipe" }); } catch { /* ignore */ }
+        try { execFileSync("git", ["branch", "-D", wt.branch], { cwd: repoDir, stdio: "pipe" }); } catch { /* ignore */ }
+      }
     });
   });
 
@@ -373,11 +435,9 @@ describe("worktree", () => {
   });
 });
 
-// cleanupWorktree's outer catch is the only place in the repo where a caught
-// error can DESTROY user work while reporting success-shaped output: it removes
-// the worktree and returns `{ hasChanges: false }`, which the manager renders as
-// "the agent changed nothing". If the commit or branch step fails, the agent's
-// commits go with the worktree and nobody is told.
+// A cleanup failure must never remove the only copy of the agent's work. The
+// result carries both the preserved path and the Git error so callers can tell
+// the user how to recover.
 describe("cleanupWorktree — failure path", () => {
   let repoDir: string;
   let pi: ExtensionAPI;
@@ -402,39 +462,54 @@ describe("cleanupWorktree — failure path", () => {
     expect(result.branch).toBeUndefined();
   });
 
-  it("swallows a git failure inside a still-present worktree and reports no changes", async () => {
-    // The outer catch. The directory exists — so the existsSync guard above
-    // does not fire — but git cannot operate in it, which is what a corrupted
-    // or externally-detached worktree looks like. The agent's work is lost
-    // either way; what matters is that cleanup does not reject out of the
-    // manager's settle path and take the whole record down with it.
+  it("preserves a still-present worktree when git status fails", async () => {
     const wt = (await createWorktree(pi, repoDir, "corrupt"))!;
     writeFileSync(join(wt.path, "work.txt"), "agent output");
     // Break the worktree's link back to the repo.
     writeFileSync(join(wt.path, ".git"), "gitdir: /nonexistent/path/that/is/not/a/repo");
 
-    const result = await cleanupWorktree(pi, repoDir, wt, "corrupted agent");
+    try {
+      const result = await cleanupWorktree(pi, repoDir, wt, "corrupted agent");
 
-    expect(result.hasChanges).toBe(false);
-    expect(result.branch).toBeUndefined();
+      expect(result).toMatchObject({
+        hasChanges: true,
+        path: wt.path,
+        error: expect.any(String),
+      });
+      expect(result.branch).toBeUndefined();
+      expect(existsSync(wt.path)).toBe(true);
+      expect(existsSync(join(wt.path, "work.txt"))).toBe(true);
+    } finally {
+      rmSync(wt.path, { recursive: true, force: true });
+    }
   });
 
-  it("reports no changes when the preservation commit fails", async () => {
-    // `git commit` failing resolves with a non-zero code rather than throwing,
-    // so the outer catch is only reached if the result is inspected.
-    const wt = (await createWorktree(pi, repoDir, "commit-fails"))!;
-    writeFileSync(join(wt.path, "work.txt"), "agent output");
+  it.each(["add", "commit", "branch"])(
+    "preserves the worktree and reports the error when git %s fails",
+    async (failingCommand) => {
+      const wt = (await createWorktree(pi, repoDir, `${failingCommand}-fails`))!;
+      writeFileSync(join(wt.path, "work.txt"), "agent output");
 
-    const result = await cleanupWorktree(
-      failingPi(args => args[0] === "commit", { code: 1, killed: false }),
-      repoDir,
-      wt,
-      "commit fails",
-    );
+      try {
+        const result = await cleanupWorktree(
+          failingPi(args => args[0] === failingCommand, { code: 1, killed: false }),
+          repoDir,
+          wt,
+          `${failingCommand} fails`,
+        );
 
-    expect(result.hasChanges).toBe(false);
-    expect(result.branch).toBeUndefined();
-  });
+        expect(result).toEqual({
+          hasChanges: true,
+          path: wt.path,
+          error: "boom",
+        });
+        expect(existsSync(wt.path)).toBe(true);
+        expect(existsSync(join(wt.path, "work.txt"))).toBe(true);
+      } finally {
+        try { execFileSync("git", ["worktree", "remove", "--force", wt.path], { cwd: repoDir, stdio: "pipe" }); } catch { /* ignore */ }
+      }
+    },
+  );
 
   it("creates the branch BEFORE removing the worktree, so a removal failure cannot lose commits", async () => {
     // Ordering is the actual safety property. If a refactor moved
@@ -486,15 +561,16 @@ describe("worktree isolation switch", () => {
   // The switch gates callers; it deliberately does not disarm createWorktree
   // itself, so a caller that has already decided (agent-manager checks first)
   // still gets a real worktree rather than a silent no-op.
-  it("does not disable createWorktree directly", () => {
+  it("does not disable createWorktree directly", async () => {
     const repoDir = initGitRepo();
+    const pi = mockPi();
     try {
       setWorktreeIsolationEnabled(false);
-      const wt = createWorktree(repoDir, "switch-test");
+      const wt = await createWorktree(pi, repoDir, "switch-test");
       expect(wt).toBeDefined();
-      cleanupWorktree(repoDir, wt!, "switch test");
+      await cleanupWorktree(pi, repoDir, wt!, "switch test");
     } finally {
-      pruneWorktrees(repoDir);
+      await pruneWorktrees(pi, repoDir);
       rmSync(repoDir, { recursive: true, force: true });
     }
   });


### PR DESCRIPTION
Closes #246.

## Summary

- `cleanupWorktree()` currently force-removes the only copy of agent changes after `git status`, staging, commit, branch, or removal errors, then reports `{ hasChanges: false }`
- repositories with `commit.gpgSign=true` reproduce the loss when a headless preservation commit cannot reach its signer
- the caller receives neither an error nor a recovery path

The reported loss follows this sequence:

```text
git status sees agent edits
→ git add succeeds
→ git commit invokes the configured signer and fails
→ cleanup catches the error
→ git worktree remove --force deletes the only copy
→ cleanup returns { hasChanges: false }
```

The same destructive catch also covered status, staging, branch creation, and worktree removal failures.

## What changed

- make automatic preservation commits non-interactive with `--no-gpg-sign`, alongside the existing `--no-verify`
- preserve a worktree after any cleanup failure and return additive `path`, `error`, and already-created `branch` metadata
- treat cleanup failures as agent errors across completed, failed, and stopped runs, preserving any original agent error and reporting the recovery path
- report a failed `git worktree remove` when the directory still exists instead of treating `git worktree prune` as successful removal
- document the failure behavior and RPC error surface, and make Git-creating test fixtures independent of the contributor's signing configuration

## Related work

| Item | State | Relation |
| --- | --- | --- |
| #246 — Worktree cleanup can discard agent changes after commit failure | open | Closed by this PR, including the reported signing reproduction and the broader cleanup failure path |
| #192 — Configurable worktree checkout timeout | open | Independent checkout-timeout change; overlaps `src/worktree.ts`, `README.md`, and worktree tests, so whichever lands second may need a mechanical rebase |

States as of opening.

## Behavior and compatibility

- no-change and successful branch-preservation paths are unchanged
- cleanup failure now changes the agent outcome to `error` and leaves the worktree registered on disk; the result names its absolute recovery path
- `WorktreeCleanupResult` gains optional `error`; existing fields remain compatible
- no setting, default, or migration is added
- no automatic retry or later deletion is attempted after preservation fails; the user recovers or removes the reported worktree manually
- `CHANGELOG.md` is intentionally unchanged per the contributor guidelines

## Performance

Not benchmarked. The successful path adds no Git subprocesses; it only adds one commit flag. Failure paths retain the worktree instead of issuing a destructive cleanup after an earlier Git error.

## Testing

- baseline reproduction before the source fix: 3 failures for a real rejected signer, `git status` failure, and `git commit` failure; each returned `hasChanges: false`
- focused worktree and AgentManager tests: 152 passed
- mutation checks:
  - swallowing `git worktree remove` errors made both clean and dirty removal tests fail
  - preserving `stopped` status made both stopped-run recovery tests fail
  - disabling the Manager recovery formatter made its completion/error tests fail
- `npm run check`: 105 files passed; 2138 tests passed, 7 skipped
- `npm run test:e2e`: 15 files passed; 68 tests passed, 7 live-model tests skipped
- `npm run build`: passed
- tested with the contributor's real `commit.gpgSign=true` / 1Password Git environment; fixture commits no longer invoke it, while the regression test enables a failing repository-local SSH signer and verifies that signer is not called

Not covered: the Windows signer script branch is present but was not executed on Windows; live-model e2e remains opt-in.
