### PR TITLE
perf: reduce conversation viewer render time by up to 99%

### DIFF
--- a/src/ui/conversation-viewer.ts
+++ b/src/ui/conversation-viewer.ts
@@ -159,6 +159,13 @@ export class ConversationViewer implements Component {
    * Weak so a compacted-away message doesn't pin its render.
    */
   private readonly markdownCache = new WeakMap<object, { md: Markdown; text: string; failed?: boolean }>();
+  /**
+   * One rendered block per message, so a warm `buildContentLines()` only
+   * re-renders messages that changed. Message objects are stable and their
+   * text only grows while streaming, so the `{ width, mode, key }` guard 
+   * catches the three ways a cached block can go stale.
+   */
+  private readonly contentCache = new WeakMap<object, { width: number; mode: ViewerMarkdownMode; key: string; lines: string[] }>();
 
   constructor(
     private tui: TUI,
@@ -327,7 +334,8 @@ export class ConversationViewer implements Component {
     if (invocationLine) lines.push(row(invocationLine));
     lines.push(hrMid);
 
-    // Content area — rebuild every render (live data, no cache needed)
+    // Content area — assembled from the per-message block cache; only messages
+    // that changed since the last frame re-render (see messageLines).
     const contentLines = this.buildContentLines(innerW);
     const viewportHeight = this.viewportHeight();
     const maxScroll = Math.max(0, contentLines.length - viewportHeight);
@@ -519,61 +527,13 @@ export class ConversationViewer implements Component {
     }
 
     const mode = this.markdownMode();
+    const separator = th.fg("dim", "───");
     let needsSeparator = false;
     for (const msg of messages) {
-      if (msg.role === "user") {
-        const text = typeof msg.content === "string"
-          ? msg.content
-          : extractText(msg.content);
-        if (!text.trim()) continue;
-        if (needsSeparator) lines.push(th.fg("dim", "───"));
-        lines.push(th.fg("accent", "[User]"));
-        for (const line of wrapTextWithAnsi(text.trim(), width)) {
-          lines.push(line);
-        }
-      } else if (msg.role === "assistant") {
-        const textParts: string[] = [];
-        const toolCalls: string[] = [];
-        for (const c of msg.content) {
-          if (c.type === "text" && c.text) textParts.push(c.text);
-          else if (c.type === "toolCall") {
-            toolCalls.push((c as any).name ?? (c as any).toolName ?? "unknown");
-          }
-        }
-        if (needsSeparator) lines.push(th.fg("dim", "───"));
-        lines.push(th.bold("[Assistant]"));
-        if (textParts.length > 0) {
-          const text = textParts.join("\n").trim();
-          lines.push(...(mode === "off"
-            ? this.rawLines(text, width, false)
-            : this.markdownLines(msg, text, width, false)));
-        }
-        for (const name of toolCalls) {
-          lines.push(truncateToWidth(th.fg("muted", `  [Tool: ${name}]`), width));
-        }
-      } else if (msg.role === "toolResult") {
-        const { text, elided } = capResult(extractText(msg.content).trim());
-        if (!text) continue;
-        if (needsSeparator) lines.push(th.fg("dim", "───"));
-        lines.push(th.fg("dim", "[Result]"));
-        lines.push(...(mode === "all"
-          ? this.markdownLines(msg, text, width, true)
-          : this.rawLines(text, width, true)));
-        if (elided) lines.push(truncateToWidth(th.fg("dim", truncationNote(elided)), width));
-      } else if ((msg as any).role === "bashExecution") {
-        const bash = msg as any;
-        if (needsSeparator) lines.push(th.fg("dim", "───"));
-        lines.push(truncateToWidth(th.fg("muted", `  $ ${bash.command}`), width));
-        if (bash.output?.trim()) {
-          // Same cap as a tool result, never Markdown: command output is the one
-          // thing here that is definitionally not authored as Markdown.
-          const { text, elided } = capResult(bash.output.trim());
-          lines.push(...this.rawLines(text, width, true));
-          if (elided) lines.push(truncateToWidth(th.fg("dim", truncationNote(elided)), width));
-        }
-      } else {
-        continue;
-      }
+      const block = this.messageLines(msg, width, mode);
+      if (block.length === 0) continue;
+      if (needsSeparator) lines.push(separator);
+      lines.push(...block);
       needsSeparator = true;
     }
 
@@ -584,6 +544,87 @@ export class ConversationViewer implements Component {
       lines.push(truncateToWidth(th.fg("accent", "▍ ") + th.fg("dim", act), width));
     }
 
-    return lines.map(l => truncateToWidth(l, width));
+    return lines;
+  }
+
+  /**
+   * One message's rendered block (header + body, lines pre-truncated to
+   * `width`), or an empty array for a message the transcript skips. Cached per
+   * message against `{ width, mode, key }`; a miss rebuilds just that block.
+   */
+  private messageLines(msg: AgentSession["messages"][number], width: number, mode: ViewerMarkdownMode): string[] {
+    const th = this.theme;
+    // The key folds in everything the block is rendered from, so a streaming
+    // append (same object, new text) rebuilds while an unchanged message hits.
+    let key: string;
+    let render: () => string[];
+    if (msg.role === "user") {
+      const text = typeof msg.content === "string" ? msg.content : extractText(msg.content);
+      key = text;
+      render = () => {
+        const lines = [th.fg("accent", "[User]")];
+        for (const line of wrapTextWithAnsi(text.trim(), width)) lines.push(line);
+        return lines;
+      };
+      if (!text.trim()) return [];
+    } else if (msg.role === "assistant") {
+      const textParts: string[] = [];
+      const toolCalls: string[] = [];
+      for (const c of msg.content) {
+        if (c.type === "text" && c.text) textParts.push(c.text);
+        else if (c.type === "toolCall") {
+          toolCalls.push((c as any).name ?? (c as any).toolName ?? "unknown");
+        }
+      }
+      key = `${textParts.join("")} ${toolCalls.join("")}`;
+      render = () => {
+        const lines = [th.bold("[Assistant]")];
+        if (textParts.length > 0) {
+          const text = textParts.join("\n").trim();
+          lines.push(...(mode === "off"
+            ? this.rawLines(text, width, false)
+            : this.markdownLines(msg, text, width, false)));
+        }
+        for (const name of toolCalls) {
+          lines.push(truncateToWidth(th.fg("muted", `  [Tool: ${name}]`), width));
+        }
+        return lines;
+      };
+    } else if (msg.role === "toolResult") {
+      const raw = extractText(msg.content).trim();
+      key = raw;
+      if (!raw) return [];
+      render = () => {
+        const { text, elided } = capResult(raw);
+        const lines = [th.fg("dim", "[Result]")];
+        lines.push(...(mode === "all"
+          ? this.markdownLines(msg, text, width, true)
+          : this.rawLines(text, width, true)));
+        if (elided) lines.push(truncateToWidth(th.fg("dim", truncationNote(elided)), width));
+        return lines;
+      };
+    } else if ((msg as any).role === "bashExecution") {
+      const bash = msg as any;
+      key = `${bash.command ?? ""} ${bash.output ?? ""}`;
+      render = () => {
+        const lines = [truncateToWidth(th.fg("muted", `  $ ${bash.command}`), width)];
+        if (bash.output?.trim()) {
+          // Same cap as a tool result, never Markdown: command output is the one
+          // thing here that is definitionally not authored as Markdown.
+          const { text, elided } = capResult(bash.output.trim());
+          lines.push(...this.rawLines(text, width, true));
+          if (elided) lines.push(truncateToWidth(th.fg("dim", truncationNote(elided)), width));
+        }
+        return lines;
+      };
+    } else {
+      return [];
+    }
+
+    const cached = this.contentCache.get(msg);
+    if (cached && cached.width === width && cached.mode === mode && cached.key === key) return cached.lines;
+    const lines = render().map(l => truncateToWidth(l, width));
+    this.contentCache.set(msg, { width, mode, key, lines });
+    return lines;
   }
 }

--- a/test/perf/render-invariants.perf.test.ts
+++ b/test/perf/render-invariants.perf.test.ts
@@ -56,34 +56,50 @@ beforeEach(() => {
 });
 
 describe("ConversationViewer — cost stays linear in transcript length", () => {
-  /** Leaf calls one render makes over a transcript of `n` messages. */
-  function wrapsFor(n: number, mode: string): number {
+  /** Leaf calls the first render of a fresh viewer makes over `n` messages. */
+  function coldWrapsFor(n: number, mode: string): number {
     const viewer = mountViewer(ConversationViewer, makeSession(n), undefined, () => mode);
-    viewer.render(120); // prime, so caches are warm and only steady state counts
     counts.wrap = 0;
     counts.markdownRender = 0;
     viewer.render(120);
     return counts.wrap + counts.markdownRender;
   }
 
-  // The viewer rebuilds every line of the transcript on every frame, so the work
-  // is expected to grow with it. What must not happen is growing FASTER than it:
-  // ten times the messages, at most ~ten times the work. A quadratic here is
-  // invisible on a short conversation and locks the TUI on a long one.
+  // Every message is wrapped/parsed exactly once, the first time it renders, so
+  // cold work grows with the transcript. What must not happen is growing FASTER
+  // than it: ten times the messages, at most ~ten times the work. A quadratic
+  // here is invisible on a short conversation and locks the TUI on a long one.
   it("does ~10x the work for 10x the messages (raw wrap path)", () => {
-    const small = wrapsFor(30, "off");
-    const large = wrapsFor(300, "off");
+    const small = coldWrapsFor(30, "off");
+    const large = coldWrapsFor(300, "off");
 
     expect(small).toBeGreaterThan(0);
     expect(large / small).toBeLessThanOrEqual(11);
   });
 
   it("does ~10x the work for 10x the messages (markdown path)", () => {
-    const small = wrapsFor(30, "assistant");
-    const large = wrapsFor(300, "assistant");
+    const small = coldWrapsFor(30, "assistant");
+    const large = coldWrapsFor(300, "assistant");
 
     expect(small).toBeGreaterThan(0);
     expect(large / small).toBeLessThanOrEqual(11);
+  });
+
+  // The per-message content cache is what keeps a long transcript affordable:
+  // a warm frame with unchanged messages must re-render NOTHING. Before it,
+  // every frame (and every scroll key) re-wrapped the whole transcript, well
+  // past the frame budget on a long session. Zero is the whole point; a regression that
+  // drops the cache rediscovers that cost, and nothing else in the suite would
+  // notice.
+  it("re-renders a warm transcript without touching a single wrap", () => {
+    for (const mode of ["off", "assistant"] as const) {
+      const viewer = mountViewer(ConversationViewer, makeSession(300), undefined, () => mode);
+      viewer.render(120);
+      counts.wrap = 0;
+      counts.markdownRender = 0;
+      viewer.render(120);
+      expect(counts.wrap + counts.markdownRender, `mode ${mode}`).toBe(0);
+    }
   });
 
   // #259's WeakMap is keyed by the message object. If a refactor ever rebuilds

--- a/test/perf/viewer.bench.ts
+++ b/test/perf/viewer.bench.ts
@@ -3,12 +3,13 @@
  * growing size.
  *
  * The highest-value benchmark in the repo: this is the only frame-rate path
- * whose cost is unbounded in the data it renders. `buildContentLines()` rebuilds
- * the *entire* transcript on every render — "rebuild every render (live data, no
- * cache needed)", conversation-viewer.ts — and the viewer subscribes to the
- * session, so a running agent redraws it on every token (coalesced by pi at
- * ~62 Hz). Everything above the viewport is built and thrown away, and
- * `handleInput` builds it a second time on every scroll key just to count lines.
+ * whose cost is unbounded in the data it renders. `buildContentLines()` renders
+ * messages through a per-message block cache, so a warm frame only re-renders
+ * messages whose text changed (the streaming tail); everything else is a cache
+ * hit. A regression that breaks `contentCache` makes the largest transcript
+ * orders of magnitude slower. The viewer subscribes to the session, so a
+ * running agent redraws it on every token (coalesced by pi at ~62 Hz), and
+ * `handleInput` calls the same build on every scroll key to count lines.
  *
  * Both markdown modes are measured. `assistant` is the default and sends
  * assistant text through pi's Markdown parser; `off` is the raw wrap path. The


### PR DESCRIPTION
## Summary

The conversation viewer rebuilt its entire transcript on every frame. `buildContentLines()` re-wrapped and re-truncated every line of every message on every render, and again on every scroll event. The per-message Markdown cache from #259 skips parsing, but nothing cached the assembled lines. At thousands of lines, it becomes extremely costly to render (~200ms/frame) and is guaranteed to go over the frame time budget. The viewer subscribes to the session, so a running agent redraws on every token and pays this cost continuously.

## What changed

Cache the render, not just the parse.

`ConversationViewer` gains a `contentCache`, a `WeakMap` keyed by the message object holding that message's rendered block (header + body, lines pre-truncated). Three things invalidate an entry: terminal width, markdown mode, or the message text. A streaming append rebuilds only the streaming message. `buildContentLines()` is now an assembly loop over cached blocks plus separators. The per-role rendering moved into `messageLines()`, which runs only on a cache miss.

## Performance

Results from `npm run bench:ab -- master`:

```
Comparing working tree against master (4f572ea), 3 round(s).

benchmark                                                                       4f572ea       working      delta
-------------------------------------------------------------------------  ------------  ------------  ---------
ConversationViewer.render — cold cache (first frame) > 50 messages              3.220ms       3.090ms      -4.0%
ConversationViewer.render — cold cache (first frame) > 500 messages            33.967ms      33.075ms      -2.6%
ConversationViewer.render — markdown: assistant (default) > 50 messages         2.119ms      184.57us     -91.3%
ConversationViewer.render — markdown: assistant (default) > 500 messages       20.070ms      266.64us     -98.7%
ConversationViewer.render — markdown: assistant (default) > 5000 messages     216.221ms       1.416ms     -99.3%
ConversationViewer.render — markdown: off (raw wrap) > 50 messages              2.331ms      175.50us     -92.5%
ConversationViewer.render — markdown: off (raw wrap) > 500 messages            24.684ms      260.85us     -98.9%
ConversationViewer.render — markdown: off (raw wrap) > 5000 messages          258.652ms       1.193ms     -99.5%

```

## Testing

- `npm run lint`: clean
- `npm run typecheck`: clean
- `npm run test`: 2129 passed, 7 skipped
- `npm run build`: clean