### PR TITLE
fix: load the compiled dist/ entry instead of transpiling src/ at every boot

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -7,6 +7,9 @@ and this project adheres to [Semantic Versioning](https://semver.org/spec/v2.0.0
 
 ## [Unreleased]
 
+### Fixed
+- **`pi.extensions` now points at the compiled `./dist/index.js` instead of `./src/index.ts`**, removing the per-boot TypeScript transform (~0.6–1.1 s per session, [#252](https://github.com/tintinweb/pi-subagents/issues/252)). A `prepare` script builds `dist/` on git installs, falling back to `npx -p typescript` since pi installs those without devDependencies.
+
 ## [0.19.0] - 2026-08-25
 
 > **⚠️ Breaking — this release requires pi 0.84.0 or newer** (`peerDependencies` moves from `>=0.81.0`). `SubagentWorkflow` needs two host APIs that do not exist below it, and both fail the typecheck rather than degrading quietly — see the `Changed` entry below for which, and why neither was worth reimplementing to hold the old floor. npm flags an older pi at install time.

--- a/package.json
+++ b/package.json
@@ -36,6 +36,7 @@
   },
   "scripts": {
     "build": "node -e \"require('fs').rmSync('dist',{recursive:true,force:true})\" && tsc",
+    "prepare": "tsc --noCheck || npx -p typescript tsc --noCheck",
     "prepublishOnly": "npm run lint && npm run typecheck && npm run test && npm run build",
     "test": "vitest run",
     "test:watch": "vitest",
@@ -60,7 +61,7 @@
   },
   "pi": {
     "extensions": [
-      "./src/index.ts"
+      "./dist/index.js"
     ],
     "video": "https://github.com/tintinweb/pi-subagents/raw/master/media/demo.mp4",
     "image": "https://github.com/tintinweb/pi-subagents/raw/master/media/screenshot.png"


### PR DESCRIPTION
Closes #252 — suggestion (1) from @apmantza's writeup there (happy to close this in favor of theirs if they'd rather land their own).

Pointing `pi.extensions` at the shipped `./dist/index.js` removes the per-boot TypeScript transform of `src/`, dropping startup to the no-extensions baseline (~5.6 s saved on pi 0.84.1, ~0.7 s on 0.84.2+ per #252). Since `dist/` is gitignored, a `prepare` script builds it on git installs — pi runs those with `npm install --omit=dev --omit=peer`, so it falls back to `npx -p typescript tsc --noCheck` (emit-only; the publish path still type-checks).

Verified on all three install paths: npm tarball (live install, extension loads and flags register), dev clone (`prepare` builds, `typecheck` clean), and a simulated pi git install (npx fallback builds `dist/`, pi boots against the tree cleanly).