### PR TITLE
feat: announce subagents via the permission-system lifecycle convention

### DIFF
--- a/README.md
+++ b/README.md
@@ -736,8 +736,13 @@ Agent lifecycle events are emitted via `pi.events.emit()` so other extensions ca
 | `subagents:ready` | RPC handlers registered and armed — fired on session start; not emitted in a session that excludes pi-subagents | `{}` (empty object) |
 | `subagents:settings_loaded` | Persisted settings applied at extension init | `settings` (merged global + project) |
 | `subagents:settings_changed` | `/agents` → Settings mutation was applied | `settings`, `persisted` (`boolean` — `false` on write failure) |
+| `subagents:child:session-created` | A child session was created, emitted synchronously before its extensions bind — the subagent adapter convention (ADR 0012) a permission system subscribes to in order to detect in-process children | `sessionId`, `parentSessionId` |
+| `subagents:child:bound` | A child's extensions bound successfully — the optional convention event; emits only on success, and buys the permission system's unguarded-child alarm | `sessionId`, `parentSessionId` |
+| `subagents:child:disposed` | A child's run settled — success or error — unregistering it from any listener's registry | `sessionId` |
 
 The four agent-lifecycle events — `subagents:started`, `:completed`, `:failed`, `:compacted` — are emitted for **top-level agents only**. Nested subagents and a workflow's children emit nothing at all; they report through the parent or workflow that owns them.
+
+The `subagents:child:*` events are different in kind: they fire for **every** in-process child, nested and workflow children included, and carry the child's **session id** rather than the extension's agent id. They are the subagent adapter convention a permission system (`@gotgenes/pi-permission-system`) uses to detect a child and forward its `ask` gates to the interactive parent — without such a listener they are inert (a `pi.events.emit` with no subscriber). `parentSessionId` is always the top-level session that spawned the chain, so permission asks reach the session that can actually serve them at any nesting depth. A child resumed via `resume` is not re-announced (its run continues without a fresh bind), so its asks fall back to fail-closed for the resumed turn.
 
 `tokens.total` = `input + output + cacheWrite`. `cacheRead` is excluded — each turn's `cacheRead` is the cumulative cached prefix re-read on that one API call, so summing per-message would over-count it as a measure of work done. Use `contextUsage.percent` (surfaced as `(NN%)` in the widget) for current context size.
 

--- a/src/agent-manager.ts
+++ b/src/agent-manager.ts
@@ -369,6 +369,14 @@ export class AgentManager {
   private onUsage?: OnAgentUsage;
   private maxConcurrent: number;
   private maxConcurrentForeground = DEFAULT_MAX_CONCURRENT_FOREGROUND;
+  /**
+   * Session id of the top-level session owning this manager, stamped at each
+   * `session_start`. Every spawn — top-level, nested, workflow, scheduler,
+   * RPC — announces this as its parent session id (root-targeted), so a
+   * permission system forwards a child's `ask` to the interactive session that
+   * can serve it rather than a headless intermediate.
+   */
+  rootSessionId: string | undefined;
   /** Base repos worktrees were created from — so dispose() can prune them all,
    *  not just the parent repo (caller-supplied cwd can target other repos). */
   private worktreeRepos = new Set<string>();
@@ -761,6 +769,7 @@ export class AgentManager {
     const promise = runAgent(ctx, type, prompt, {
       pi,
       agentId: id,
+      parentSessionId: this.rootSessionId,
       model: options.model,
       maxTurns: options.maxTurns,
       isolated: options.isolated,

--- a/src/agent-runner.ts
+++ b/src/agent-runner.ts
@@ -44,6 +44,34 @@ export const SUBAGENT_TOOL_NAMES = {
   STEER: "steer_subagent",
 } as const;
 
+/**
+ * Subagent adapter convention (ADR 0012) — the channel names and payload
+ * shapes MUST match @gotgenes/pi-permission-system's
+ * `subagent-lifecycle-events.ts` (v29+). Announcing each child lets an
+ * installed permission system detect our in-process children and forward
+ * their `ask` gates to the interactive parent session instead of failing
+ * closed (`confirmationUnavailable`). Emitting with no listener is a no-op,
+ * so these broadcasts are safe whether or not a permission system is present.
+ */
+export const CHILD_SESSION_CREATED = "subagents:child:session-created";
+export const CHILD_SESSION_BOUND = "subagents:child:bound";
+export const CHILD_SESSION_DISPOSED = "subagents:child:disposed";
+
+/** Payload carried by the child lifecycle broadcasts. */
+export interface ChildLifecyclePayload {
+  /** Child session id — the registry key. */
+  sessionId: string;
+  /**
+   * Session that spawned the child. Root-targeted for nested spawns so every
+   * ask forwards to the interactive top-level session, not a headless parent.
+   */
+  parentSessionId?: string;
+}
+
+function emitChildLifecycle(pi: ExtensionAPI | undefined, channel: string, payload: ChildLifecyclePayload): void {
+  pi?.events?.emit(channel, payload);
+}
+
 /** Names of tools registered by this extension that subagents must NOT inherit. */
 const EXCLUDED_TOOL_NAMES: string[] = Object.values(SUBAGENT_TOOL_NAMES);
 
@@ -430,6 +458,13 @@ export interface RunOptions {
    * "this is how you return your answer" instructions is worse than one.
    */
   workflow?: boolean;
+  /**
+   * Session id of the top-level session that spawned this run. Root-targeted:
+   * every child, nested or not, announces this as its parent so permission
+   * asks always reach the interactive session that can serve them. Falls back
+   * to `ctx`'s own session id when unset (direct programmatic callers).
+   */
+  parentSessionId?: string;
   /** Override working directory (e.g. for worktree isolation). */
   cwd?: string;
   /**
@@ -978,6 +1013,10 @@ export async function runAgent(
   // Pi 0.80.8 replaced createAgentSession's modelRegistry option with
   // modelRuntime, but ExtensionContext still exposes only the registry facade.
   // Pass both so the full supported Pi range retains the parent's providers.
+  // SAFETY: ExtensionContext.modelRegistry is typed as a registry facade whose
+  // private `.runtime` field carries the resolved ModelRuntime; the double
+  // assertion is deliberate so pre-0.80.8 pi (no modelRuntime option) and newer
+  // pi (typed ModelRuntime) both satisfy `Parameters<typeof createAgentSession>[0]`.
   const parentModelRuntime = (ctx.modelRegistry as unknown as { runtime?: unknown }).runtime;
   const sessionOpts: Parameters<typeof createAgentSession>[0] & {
     modelRegistry: ExtensionContext["modelRegistry"];
@@ -1007,6 +1046,20 @@ export async function runAgent(
 
   const { session } = await runInChildSessionContext(() => createAgentSession(sessionOpts));
 
+  // Subagent adapter convention: announce the child synchronously, before
+  // `bindExtensions()`, so a permission system's registration lands before the
+  // child's own extensions load (the contract's pre-bind ordering). The id is
+  // the session manager's — the same manager the child's own ctx reports, so
+  // its permission instance detects itself via the process-global registry.
+  // Root-targeted: `parentSessionId` is the top-level session (threaded by the
+  // manager), never the immediate spawner, so nested grandchildren forward to
+  // the interactive session that can actually serve.
+  const childSessionId = sessionManager.getSessionId?.();
+  const parentSessionId = options.parentSessionId ?? ctx.sessionManager?.getSessionId?.();
+  if (childSessionId !== undefined) {
+    emitChildLifecycle(options.pi, CHILD_SESSION_CREATED, { sessionId: childSessionId, parentSessionId });
+  }
+
   const baseSessionName = agentConfig?.name ?? type;
   session.setSessionName(
     options.agentId ? `${baseSessionName}#${options.agentId.slice(0, 8)}` : baseSessionName,
@@ -1016,14 +1069,29 @@ export async function runAgent(
   // (e.g. loading credentials, setting up state). Tool gating already happened
   // at session construction via the `tools:` allowlist above — no separate
   // post-bind filter is needed. All ExtensionBindings fields are optional.
-  await session.bindExtensions({
-    onError: (err) => {
-      options.onToolActivity?.({
-        type: "end",
-        toolName: `extension-error:${err.extensionPath}`,
-      });
-    },
-  });
+  try {
+    await session.bindExtensions({
+      onError: (err) => {
+        options.onToolActivity?.({
+          type: "end",
+          toolName: `extension-error:${err.extensionPath}`,
+        });
+      },
+    });
+  } catch (err) {
+    // A bind failure means the session never ran; still unregister it so the
+    // parent's registry does not keep a dead child entry.
+    if (childSessionId !== undefined) {
+      emitChildLifecycle(options.pi, CHILD_SESSION_DISPOSED, { sessionId: childSessionId });
+    }
+    throw err;
+  }
+  // Optional `bound` broadcast — success path only. Buys the permission
+  // system's unguarded-child alarm: a child that finished binding without a
+  // permission node is announced so the operator hears about it.
+  if (childSessionId !== undefined) {
+    emitChildLifecycle(options.pi, CHILD_SESSION_BOUND, { sessionId: childSessionId, parentSessionId });
+  }
 
   // With `allowedToolNames` unset, the registry is scoped by `excludeTools` but
   // the ACTIVE set still needs managing: pi activates only its four default
@@ -1126,6 +1194,15 @@ export async function runAgent(
     unsubTurns();
     collector.unsubscribe();
     cleanupAbort();
+    // The run has settled (success or error) — unregister the child. The only
+    // remaining body after this is synchronous string work that cannot throw,
+    // so this finally is the run's true end. ponytail: a throw in the few
+    // synchronous setup lines between bind and this finally (installExtensionToolScope,
+    // onSessionCreated) would leak the registry entry — harmless, since session ids
+    // are unique per process and never matched again.
+    if (childSessionId !== undefined) {
+      emitChildLifecycle(options.pi, CHILD_SESSION_DISPOSED, { sessionId: childSessionId });
+    }
   }
 
   const responseText = collector.getText().trim() || getLastAssistantText(session, startLen);

--- a/src/index.ts
+++ b/src/index.ts
@@ -788,6 +788,9 @@ export default function (pi: ExtensionAPI) {
   // bound session_start, so a filtered-out activation never advertises (#142).
   pi.on("session_start", async (_event, ctx) => {
     currentCtx = ctx;
+    // Root-target: every child this session spawns announces this id as its
+    // parent, so permission asks forward to THIS session (the one with UI).
+    manager.rootSessionId = ctx.sessionManager?.getSessionId?.();
     if (ctx.hasUI) {
       widget.setUICtx(ctx.ui);
       fleet.setUICtx(ctx.ui as any);
@@ -1135,6 +1138,9 @@ export default function (pi: ExtensionAPI) {
   // Claude Code-style FleetView: navigable list of main + subagents below the editor.
   // The last two arguments keep a conversation overlay opened here identical to
   // one opened from `/agents`: same setting on the way in, same persist out.
+  // SAFETY: currentCtx (ExtensionContext) and ExtensionCommandContext share the
+  // surface the viewer-menu callback needs (sessionManager/cwd); the cast narrows
+  // the declared type to the exact TUI-command shape, not the runtime shape.
   const fleet = new FleetList(manager, agentActivity, isShowCostEnabled, getViewerMarkdown,
     (mode) => chooseViewerMarkdown(mode, currentCtx as unknown as ExtensionCommandContext | undefined));
   let fleetViewEnabled = true;
@@ -1360,6 +1366,8 @@ export default function (pi: ExtensionAPI) {
   // Grab UI context from first tool execution + clear lingering widget on new turn
   pi.on("tool_execution_start", async (_event, ctx) => {
     widget.setUICtx(ctx.ui as UICtx);
+    // SAFETY: FleetUICtx is a superset of the ui shapes pi exposes on tool ctx;
+    // the casts bridge the two extension APIs' independently-declared ui types.
     fleet.setUICtx(ctx.ui as unknown as FleetUICtx);
     widget.onTurnStart();
   });
@@ -3981,6 +3989,8 @@ Write the file using the write tool. Only write the file, nothing else.`;
     viewAgentConversation,
     // Read lazily: `currentCtx` is rebound on every session_start, and the
     // fleet list may act between sessions, when there is none.
+    // SAFETY: currentCtx carries a superset of the ExtensionCommandContext surface
+    // the fleet menu needs; the cast narrows the declared type, not the runtime.
     getCtx: () => currentCtx as unknown as ExtensionCommandContext | undefined,
   };
 

--- a/test/subagent-lifecycle-events.test.ts
+++ b/test/subagent-lifecycle-events.test.ts
@@ -1,0 +1,324 @@
+import { beforeEach, describe, expect, it, vi } from "vitest";
+
+/**
+ * Subagent adapter convention (ADR 0012): runAgent must announce each child on
+ * the pi.events bus — `session-created` synchronously BEFORE bindExtensions,
+ * `bound` after a successful bind, `disposed` when the run settles (success or
+ * error) — so an installed permission system can detect our in-process
+ * children and forward their `ask` gates to the interactive parent instead of
+ * failing closed. The harness below mirrors agent-runner.test.ts: the
+ * @earendil-works/pi-coding-agent surface is mocked, so the emissions are
+ * asserted against a fake `pi.events.emit` spy.
+ */
+
+const {
+  createAgentSession,
+  defaultResourceLoaderCtor,
+  loaderExtensionsRef,
+  getAgentDir,
+  sessionManagerInMemory,
+  sessionManagerCreate,
+  sessionManagerOpen,
+  settingsManagerCreate,
+  settingsManagerGetSessionDir,
+} = vi.hoisted(() => ({
+  createAgentSession: vi.fn(),
+  defaultResourceLoaderCtor: vi.fn(),
+  loaderExtensionsRef: {
+    current: { extensions: [], errors: [], runtime: {} } as {
+      extensions: Array<{ path: string; tools: Map<string, unknown> }>;
+      errors: Array<{ path: string; error: string }>;
+      runtime: Record<string, unknown>;
+    },
+  },
+  getAgentDir: vi.fn(() => "/mock/agent-dir"),
+  sessionManagerInMemory: vi.fn(() => ({ kind: "memory-session-manager" })),
+  sessionManagerCreate: vi.fn(
+    () => ({ kind: "persistent-session-manager" }) as { kind: string; getSessionId?: () => string },
+  ),
+  sessionManagerOpen: vi.fn(() => ({ kind: "reopened-session-manager" })),
+  settingsManagerGetSessionDir: vi.fn(() => undefined as string | undefined),
+  settingsManagerCreate: vi.fn(() => ({ kind: "settings-manager", getSessionDir: settingsManagerGetSessionDir })),
+}));
+
+vi.mock("@earendil-works/pi-coding-agent", () => ({
+  createAgentSession,
+  defineTool: (definition: unknown) => definition,
+  DefaultResourceLoader: class {
+    opts: any;
+    constructor(options: any) {
+      this.opts = options;
+      defaultResourceLoaderCtor(options);
+    }
+
+    async reload() {
+      if (this.opts.noExtensions) {
+        loaderExtensionsRef.current = { extensions: [], errors: [], runtime: {} };
+        return;
+      }
+      if (this.opts.extensionsOverride) {
+        loaderExtensionsRef.current = this.opts.extensionsOverride(loaderExtensionsRef.current);
+      }
+    }
+
+    getExtensions() {
+      return loaderExtensionsRef.current;
+    }
+  },
+  getAgentDir,
+  SessionManager: { inMemory: sessionManagerInMemory, create: sessionManagerCreate, open: sessionManagerOpen },
+  SettingsManager: { create: settingsManagerCreate },
+}));
+
+vi.mock("../src/agent-types.js", () => ({
+  BUILTIN_TOOL_NAMES: ["read", "bash", "edit", "write", "grep", "find", "ls"],
+  getConfig: vi.fn(() => ({
+    displayName: "Explore",
+    description: "Explore",
+    builtinToolNames: ["read"],
+    extensions: false,
+    skills: false,
+    promptMode: "replace",
+  })),
+  getAgentConfig: vi.fn(() => ({
+    name: "Explore",
+    description: "Explore",
+    builtinToolNames: ["read"],
+    extensions: false,
+    skills: false,
+    systemPrompt: "You are Explore.",
+    promptMode: "replace",
+    inheritContext: false,
+    runInBackground: false,
+    isolated: false,
+  })),
+  getMemoryToolNames: vi.fn(() => []),
+  getReadOnlyMemoryToolNames: vi.fn(() => []),
+  getToolNamesForType: vi.fn(() => ["read"]),
+}));
+
+vi.mock("../src/env.js", () => ({
+  detectEnv: vi.fn(async () => ({ isGitRepo: false, branch: "", platform: "linux" })),
+}));
+
+vi.mock("../src/prompts.js", () => ({
+  buildAgentPrompt: vi.fn(() => "system prompt"),
+}));
+
+vi.mock("../src/memory.js", () => ({
+  buildMemoryBlock: vi.fn(() => ""),
+  buildReadOnlyMemoryBlock: vi.fn(() => ""),
+}));
+
+vi.mock("../src/skill-loader.js", () => ({
+  preloadSkills: vi.fn(() => []),
+}));
+
+vi.mock("../src/nested-tools.js", () => ({
+  getMaxSubagentDepth: vi.fn(() => 2),
+  createNestedSubagentTools: vi.fn(() => [
+    { name: "Agent" },
+    { name: "get_subagent_result" },
+    { name: "steer_subagent" },
+  ]),
+}));
+
+import { runAgent, setRememberAgents } from "../src/agent-runner.js";
+
+/** Child session id reported by the mocked SessionManager.create. */
+const CHILD_ID = "child-123";
+/** Root session id returned by the fake ctx sessionManager. */
+const ROOT_ID = "root-456";
+
+function createSession(finalText: string) {
+  const listeners: Array<(event: any) => void> = [];
+  let activeToolNames: string[] = ["read", "bash", "edit", "write"];
+  const session = {
+    messages: [] as any[],
+    subscribe: vi.fn((listener: (event: any) => void) => {
+      listeners.push(listener);
+      return () => {};
+    }),
+    prompt: vi.fn(async () => {
+      session.messages.push({
+        role: "assistant",
+        content: [{ type: "text", text: finalText }],
+      });
+    }),
+    abort: vi.fn(),
+    steer: vi.fn(),
+    getActiveToolNames: vi.fn(() => activeToolNames),
+    setActiveToolsByName: vi.fn((names: string[]) => {
+      activeToolNames = [...names];
+    }),
+    getAllTools: vi.fn(() => {
+      const opts = createAgentSession.mock.calls[0]?.[0];
+      return opts ? mockRegistry(opts).map((name) => ({ name })) : [];
+    }),
+    agent: { beforeToolCall: undefined } as {
+      beforeToolCall?: (context: any, signal?: any) => Promise<any>;
+    },
+    setSessionName: vi.fn(),
+    bindExtensions: vi.fn(async () => {}),
+  };
+  return { session, listeners };
+}
+
+function mockRegistry(opts: any): string[] {
+  return opts.tools ?? [];
+}
+
+const ctx = {
+  cwd: "/tmp",
+  model: undefined,
+  modelRegistry: { find: vi.fn(), getAvailable: vi.fn(() => []) },
+  getSystemPrompt: vi.fn(() => "parent prompt"),
+  sessionManager: {
+    getBranch: vi.fn(() => []),
+    getSessionFile: vi.fn(() => "/sessions/parent.jsonl"),
+    getSessionId: vi.fn(() => ROOT_ID),
+  },
+} as any;
+
+function makePi() {
+  return { events: { emit: vi.fn() } } as any;
+}
+
+beforeEach(() => {
+  createAgentSession.mockReset();
+  defaultResourceLoaderCtor.mockClear();
+  getAgentDir.mockClear();
+  sessionManagerInMemory.mockClear();
+  sessionManagerCreate.mockReset();
+  sessionManagerOpen.mockClear();
+  setRememberAgents(true);
+  settingsManagerGetSessionDir.mockReset();
+  settingsManagerGetSessionDir.mockReturnValue(undefined);
+  settingsManagerCreate.mockClear();
+  loaderExtensionsRef.current = { extensions: [], errors: [], runtime: {} };
+  // The child session id is read off the LOCAL SessionManager (the one runAgent
+  // creates before createAgentSession); give the mock a stable id.
+  sessionManagerCreate.mockReturnValue({
+    kind: "persistent-session-manager",
+    getSessionId: () => CHILD_ID,
+  });
+});
+
+function emitted(pi: any, channel: string): Array<Record<string, unknown>> {
+  return pi.events.emit.mock.calls
+    .filter((call: [string, unknown]) => call[0] === channel)
+    .map((call: [string, unknown]) => call[1] as Record<string, unknown>);
+}
+
+/** The channel strings are the contract — pinned here so drift from the
+ *  permission system's subagent-lifecycle-events.ts fails the suite. */
+const CREATED = "subagents:child:session-created";
+const BOUND = "subagents:child:bound";
+const DISPOSED = "subagents:child:disposed";
+
+describe("runAgent subagent lifecycle emissions", () => {
+  it("emits session-created synchronously before bindExtensions, root-targeted", async () => {
+    const { session } = createSession("DONE");
+    createAgentSession.mockResolvedValue({ session });
+    const pi = makePi();
+
+    // Simulate the manager root-targeting: options.parentSessionId is the
+    // top-level session id, overriding the spawner ctx's own id.
+    await runAgent(ctx, "Explore", "go", { pi, parentSessionId: ROOT_ID });
+
+    const created = emitted(pi, CREATED);
+    expect(created).toHaveLength(1);
+    expect(created[0]).toEqual({ sessionId: CHILD_ID, parentSessionId: ROOT_ID });
+
+    const emitOrder = pi.events.emit.mock.invocationCallOrder;
+    const bindOrder = session.bindExtensions.mock.invocationCallOrder;
+    expect(emitOrder[0]).toBeLessThan(bindOrder[0]);
+  });
+
+  it("emits bound after bindExtensions and disposed after the run settles", async () => {
+    const { session } = createSession("DONE");
+    createAgentSession.mockResolvedValue({ session });
+    const pi = makePi();
+
+    await runAgent(ctx, "Explore", "go", { pi, parentSessionId: ROOT_ID });
+
+    const bound = emitted(pi, BOUND);
+    expect(bound).toHaveLength(1);
+    expect(bound[0]).toEqual({ sessionId: CHILD_ID, parentSessionId: ROOT_ID });
+
+    const disposed = emitted(pi, DISPOSED);
+    expect(disposed).toHaveLength(1);
+    expect(disposed[0]).toEqual({ sessionId: CHILD_ID });
+
+    const emitOrder = pi.events.emit.mock.invocationCallOrder;
+    const bindOrder = session.bindExtensions.mock.invocationCallOrder;
+    const promptOrder = session.prompt.mock.invocationCallOrder;
+    expect(emitOrder[1]).toBeGreaterThan(bindOrder[0]);
+    expect(emitOrder[2]).toBeGreaterThan(promptOrder[0]);
+  });
+
+  it("falls back to the spawner ctx's session id when no parentSessionId is threaded", async () => {
+    const { session } = createSession("DONE");
+    createAgentSession.mockResolvedValue({ session });
+    const pi = makePi();
+
+    await runAgent(ctx, "Explore", "go", { pi });
+
+    const created = emitted(pi, CREATED);
+    expect(created[0]).toEqual({ sessionId: CHILD_ID, parentSessionId: ROOT_ID });
+  });
+
+  it("emits the exact channel strings from the permission-system contract, in order", async () => {
+    const { session } = createSession("DONE");
+    createAgentSession.mockResolvedValue({ session });
+    const pi = makePi();
+
+    await runAgent(ctx, "Explore", "go", { pi, parentSessionId: ROOT_ID });
+
+    expect(pi.events.emit.mock.calls.map((call: [string, unknown]) => call[0])).toEqual([
+      CREATED,
+      BOUND,
+      DISPOSED,
+    ]);
+  });
+
+  it("emits disposed when the run throws", async () => {
+    const { session } = createSession("DONE");
+    createAgentSession.mockResolvedValue({ session });
+    session.prompt.mockRejectedValueOnce(new Error("provider exploded"));
+    const pi = makePi();
+
+    await expect(runAgent(ctx, "Explore", "go", { pi, parentSessionId: ROOT_ID })).rejects.toThrow("provider exploded");
+
+    expect(emitted(pi, CREATED)).toHaveLength(1);
+    expect(emitted(pi, BOUND)).toHaveLength(1);
+    const disposed = emitted(pi, DISPOSED);
+    expect(disposed).toHaveLength(1);
+    expect(disposed[0]).toEqual({ sessionId: CHILD_ID });
+  });
+
+  it("emits disposed (and no bound) when bindExtensions throws, and rethrows", async () => {
+    const { session } = createSession("DONE");
+    createAgentSession.mockResolvedValue({ session });
+    session.bindExtensions.mockRejectedValueOnce(new Error("extension load failed"));
+    const pi = makePi();
+
+    await expect(runAgent(ctx, "Explore", "go", { pi, parentSessionId: ROOT_ID })).rejects.toThrow("extension load failed");
+
+    expect(emitted(pi, CREATED)).toHaveLength(1);
+    expect(emitted(pi, BOUND)).toHaveLength(0);
+    const disposed = emitted(pi, DISPOSED);
+    expect(disposed).toHaveLength(1);
+    expect(disposed[0]).toEqual({ sessionId: CHILD_ID });
+  });
+
+  it("is a no-op when the events bus is absent", async () => {
+    const { session } = createSession("DONE");
+    createAgentSession.mockResolvedValue({ session });
+
+    // Same bare `pi` the rest of the suite uses: no `events` surface at all.
+    const result = await runAgent(ctx, "Explore", "go", { pi: {} as any });
+
+    expect(result.responseText).toBe("DONE");
+  });
+});


### PR DESCRIPTION
Adopts the subagent adapter convention (ADR 0012) defined by `@gotgenes/pi-permission-system`'s [`docs/subagent-integration.md`](https://github.com/gotgenes/pi-packages/blob/main/packages/pi-permission-system/docs/subagent-integration.md): announce every in-process child on the `pi.events` bus so an installed permission system can detect it and forward its `ask` gates to the interactive parent session. Nothing to close — new feature.

## Summary

A permission-gated tool call made by a subagent fails closed with `confirmationUnavailable` ("requires approval, but no interactive UI is available"). The permission system already ships the full forwarded-ask delegation envelope — it detects a child, and forwards its `ask` to the parent session's UI where the user approves or denies and the child resumes — but only for subagent implementations that announce their children. This extension publishes no such signal, so its in-process children are invisible to that machinery; the conformance table in `subagent-integration.md` lists it as ✗ "Publishes no lifecycle event". Under a read-only-by-default permission posture, any subagent tool call that needs approval (write, non-allowlisted bash, git push, …) is dead on arrival: the child cannot ask, so the task fails rather than prompting.

The fix belongs here, not in the permission system: teach `runAgent` to announce children using the existing convention. Zero new permission-system code, zero configuration.

## What changed

One emission point, three broadcasts, in `runAgent` (`src/agent-runner.ts`) — the single funnel every spawn path (Agent tool, workflows, scheduler, cross-extension RPC, nested) already passes through via `AgentManager.spawn`:

| Event | When | Payload |
|---|---|---|
| `subagents:child:session-created` | Synchronously before `bindExtensions()` — the contract's pre-bind ordering, so the permission system's registration lands before the child's own extensions load | `{ sessionId, parentSessionId }` |
| `subagents:child:bound` | After a successful bind (optional convention event; buys the permission system's unguarded-child alarm) | `{ sessionId, parentSessionId }` |
| `subagents:child:disposed` | When the run settles — success or error | `{ sessionId }` |

- **Root-targeting**: `parentSessionId` is the top-level session owning the spawn chain, not the immediate spawner. `AgentManager` stamps a `rootSessionId` at each `session_start` (`src/index.ts`) and threads it into every spawn, so a nested grandchild forwards to the interactive session that can actually serve it instead of a headless intermediate (permission-system forwarding is one-hop to the announced parent).
- **Contract exactness**: channel strings and payload shapes match the permission system's `subagent-lifecycle-events.ts` v29+; the optional event is `subagents:child:bound` (not the earlier `:session-bound` name). The tests pin the literal channel strings so drift from the contract fails the suite.
- **No-op safety**: emission is `pi?.events?.emit(...)` — with no listener it is a synchronous no-op, so users without the permission system see no change.
- **Child id**: read off the child's own `SessionManager` (already constructed before `createAgentSession`), the same manager the child's ctx reports — no extra plumbing.
- Files: `src/agent-runner.ts`, `src/agent-manager.ts`, `src/index.ts`, new `test/subagent-lifecycle-events.test.ts`, `README.md` (event table + semantics note).

## Related work

| Number | Title | State | Relation |
|---|---|---|---|
| — | `@gotgenes/pi-permission-system` `docs/subagent-integration.md` | published | The convention this change adopts (ADR 0012); its conformance table lists this extension as non-conformant — this change brings it to full conformance |

No issue or PR in this repo — flagged as a new feature; happy to split or adjust per review.

## Behavior and compatibility

- **No breaking changes.** No new settings, no new dependencies, no config surface.
- With no permission system installed: nothing observable (the emissions are inert).
- With `@gotgenes/pi-permission-system` v29+ (channel names stabilized there): a child's `ask` now surfaces on the parent UI as a "(Subagent)" dialog and the child resumes on the answer; whole-session approvals propagate to children unchanged.
- Known gap: a child resumed via `resume` is not re-announced (its run continues without a fresh bind), so its asks fall back to fail-closed for the resumed turn — the same as before this change. Documented in the README.
- The `bound` event means a child whose configuration excluded the permission extension is now reported by the permission system's unguarded-child alarm — intended, it is what that alarm exists for.
- `CHANGELOG.md` untouched per `CONTRIBUTING.md` ("entries are added by the maintainer") — maintainer note: an entry is expected.

## Performance

`npm run bench:ab -- master`, spawn path row: "Agent tool — background spawn > general-purpose, run_in_background" — **318.10µs (master) vs 328.75µs (this tree), +3.3%** — inside the bench's own threshold ("Treat anything under ~5% as noise unless it reproduces"). The change adds three constant synchronous `pi.events.emit` calls per spawn, each a no-op when no listener is registered.

## Testing

- `npm run check` (lint + typecheck + test): **106 files, 2135 passed, 7 skipped** (master: 105/2128).
- New `test/subagent-lifecycle-events.test.ts` — 7 hermetic tests (fake `pi.events.emit` spy, no new dev deps): pre-bind ordering asserted via `mock.invocationCallOrder`; payload shapes; root-target override vs. spawner-ctx fallback; `disposed` on prompt error and on bind error (no `bound` on the latter); no-op with no events bus; literal channel strings.
- Mutation checks (break → red → restore): wrong channel string → 5 tests fail; dropped ctx fallback → 1 fails; dropped bind-error `disposed` → 1 fails.
- **Not covered in CI**: a live run against the real permission system (it is not a dev dependency; CI stays hermetic). Verified manually with `@gotgenes/pi-permission-system` v29.1.0 installed: a child's gated `write` surfaced as a forwarded ask on the parent and was approved via dialog — review log recorded `resolution: "approved"` with `decidedBy: { kind: "forwarded", responderSessionId: <parent> }` instead of `confirmation_unavailable`.
