### PR TITLE
fix: harden abort and resume lifecycle paths

### DIFF
--- a/src/agent-manager.ts
+++ b/src/agent-manager.ts
@@ -599,6 +599,7 @@ export class AgentManager {
       if (record) {
         record.status = "stopped";
         record.completedAt = Date.now();
+        record.pendingSteers = undefined;
       }
       return false;
     }
@@ -624,17 +625,23 @@ export class AgentManager {
       () => { this.startups.delete(id); },
       (err) => {
         this.startups.delete(id);
-        if (queuedPool !== undefined) {
-          // Mirrors settleRun: an inline caller gets this failure as a throw
-          // out of spawnAndWait, so an unconsumed record would ALSO nudge the
-          // session about it — the same failure reported twice.
-          if (queuedPool === "foreground") record.resultConsumed = true;
-          record.status = "error";
-          record.error = err instanceof Error ? err.message : String(err);
-          record.completedAt = Date.now();
-          this.onComplete?.(record);
-        } else {
-          this.agents.delete(id);
+        // A stop that landed mid-startup owns the record now: don't relabel it
+        // "error" (queued path) or delete it (immediate path) — the stop was
+        // already reported, and get_subagent_result must still find it.
+        // The slot is freed and the queue drains either way.
+        if (record.status !== "stopped") {
+          if (queuedPool !== undefined) {
+            // Mirrors settleRun: an inline caller gets this failure as a throw
+            // out of spawnAndWait, so an unconsumed record would ALSO nudge the
+            // session about it — the same failure reported twice.
+            if (queuedPool === "foreground") record.resultConsumed = true;
+            record.status = "error";
+            record.error = err instanceof Error ? err.message : String(err);
+            record.completedAt = Date.now();
+            this.onComplete?.(record);
+          } else {
+            this.agents.delete(id);
+          }
         }
         // The agent never kept its slot (startAgent gives it back on failure),
         // so anything queued behind it can go now.
@@ -1083,8 +1090,14 @@ export class AgentManager {
     // the immediate path owes its caller: pi only marks a tool result failed
     // when `execute` throws. A queued spawn's failure landed on the record
     // instead (nobody was awaiting `startups` at drain time) and is rethrown
-    // below, so the contract is the same either way.
-    await this.awaitStartup(id);
+    // below, so the contract is the same either way. A stop that landed
+    // mid-startup owns the record instead: the failure is moot, swallow it
+    // and let the caller render the stopped record below.
+    try {
+      await this.awaitStartup(id);
+    } catch (err) {
+      if (record.status !== "stopped") throw err;
+    }
 
     // undefined when it was aborted while queued, or stopped mid-copy, and so
     // never ran — the record is already terminal with a completedAt, which is
@@ -1113,6 +1126,14 @@ export class AgentManager {
     const record = this.agents.get(id);
     if (!record?.session) return undefined;
 
+    // Never re-enter a run that is still in flight — foreground or background.
+    // A second run would overwrite record.abortController (orphaning the live
+    // run beyond stop's reach) and race on result/status/completedAt. The
+    // background caller pre-checks this for a better message; the foreground
+    // path relies on this guard (pi dispatches one message's tool calls via
+    // Promise.all, so two resumes can overlap).
+    if (record.status === "running" || record.status === "queued") return undefined;
+
     // Background resume: settle asynchronously and notify on completion exactly
     // like a background spawn, returning immediately with the record still
     // "running" — or "queued" when at the concurrency limit. Previously
@@ -1120,17 +1141,16 @@ export class AgentManager {
     // returned before its background branch, and resume() only ever awaited
     // inline), so a resumed agent always blocked the caller until it finished.
     if (options?.isBackground) {
-      // Never re-enter a run that is still in flight. Detaching means the caller
-      // gets control back while the record stays "running", so nothing stops the
-      // model from resuming the same agent again. Starting a second run would
-      // overwrite record.abortController — orphaning the live run beyond the
-      // reach of `/agents` stop and abortAll() — double-count the pool slot, and
-      // then reject from session.prompt() with "Agent is already processing",
-      // whose settle path would abort the LIVE run's children and report a
-      // failure for a run that is still going. Refuse instead, leaving the
-      // record untouched; the caller decides whether to wait or steer.
-      if (record.status === "running" || record.status === "queued") return undefined;
-
+      // (Re-entry is already refused above, for foreground and background
+      // alike. The background-specific reason stands: detaching means the
+      // caller gets control back while the record stays "running", so
+      // nothing stops the model from resuming the same agent again. Starting
+      // a second run would overwrite record.abortController — orphaning the
+      // live run beyond the reach of `/agents` stop and abortAll() —
+      // double-count the pool slot, and then reject from session.prompt()
+      // with "Agent is already processing", whose settle path would abort
+      // the LIVE run's children and report a failure for a run that is
+      // still going.)
       record.isBackground = true;
       record.resultConsumed = false;
       record.result = undefined;
@@ -1173,35 +1193,75 @@ export class AgentManager {
     record.result = undefined;
     record.error = undefined;
 
-    try {
-      const { text, failure } = await resumeAgent(record.session, prompt, {
-        onToolActivity: (activity) => {
-          if (activity.type === "end") record.toolUses++;
-          options?.onToolActivity?.(activity);
-        },
-        onAssistantUsage: (usage) => {
-          addUsage(record.lifetimeUsage, usage);
-          this.onUsage?.(record, usage);
-          options?.onAssistantUsage?.(usage);
-        },
-        onCompaction: (info) => {
-          record.compactionCount++;
-          this.onCompact?.(record, info);
-          options?.onCompaction?.(info);
-        },
-        signal,
-      });
-      // Same contract as the spawn path (#144): a failed final turn is an
-      // error, not a completion — but the resumed text stays available.
-      record.status = failure ? "error" : "completed";
-      if (failure) record.error = failure;
-      record.result = text;
-      record.completedAt = Date.now();
-    } catch (err) {
-      record.status = "error";
-      record.error = err instanceof Error ? err.message : String(err);
-      record.completedAt = Date.now();
+    // Fresh abort controller so stop reaches THIS run (mirrors startAgent and
+    // startResume): the previous run's controller is settled and detached, so
+    // without this abort() would mark "stopped" while the session kept going.
+    // (Closure: the "running" assignment above narrows the field in straight-
+    // line scope, so the settle guards read through a function boundary
+    // exactly like the .then() guards elsewhere in this file.)
+    const isExternallyStopped = () => record.status === "stopped";
+    const abortController = new AbortController();
+    record.abortController = abortController;
+    // A foreground caller awaiting inline still owns Esc: route the caller's
+    // interrupt through abort() exactly like the spawn path, so it reads as
+    // "stopped" rather than a provider-style "error".
+    let detachCallerSignal: (() => void) | undefined;
+    if (signal) {
+      if (signal.aborted) this.abort(id);
+      else {
+        const onCallerAbort = () => this.abort(id);
+        signal.addEventListener("abort", onCallerAbort, { once: true });
+        detachCallerSignal = () => signal.removeEventListener("abort", onCallerAbort);
+      }
     }
+
+    // Capture the session for the run below: property narrowing does not
+    // cross the async-closure boundary.
+    const session = record.session;
+    // The run's promise, so waiters (get_subagent_result wait:true, waitForAll)
+    // observe THIS run instead of the previous run's settled promise. Resolves
+    // to "" like the spawn path's promise; callers only await it.
+    record.promise = (async (): Promise<string> => {
+      try {
+        const { text, failure } = await resumeAgent(session, prompt, {
+          onToolActivity: (activity) => {
+            if (activity.type === "end") record.toolUses++;
+            options?.onToolActivity?.(activity);
+          },
+          onAssistantUsage: (usage) => {
+            addUsage(record.lifetimeUsage, usage);
+            this.onUsage?.(record, usage);
+            options?.onAssistantUsage?.(usage);
+          },
+          onCompaction: (info) => {
+            record.compactionCount++;
+            this.onCompact?.(record, info);
+            options?.onCompaction?.(info);
+          },
+          signal: abortController.signal,
+        });
+        // Don't overwrite an external stop — mirrors every other settle path.
+        // Without this a stop landing mid-run would be relabeled "completed".
+        if (!isExternallyStopped()) {
+          // Same contract as the spawn path (#144): a failed final turn is an
+          // error, not a completion — but the resumed text stays available.
+          record.status = failure ? "error" : "completed";
+          if (failure) record.error = failure;
+        }
+        record.result = text;
+        record.completedAt = Date.now();
+      } catch (err) {
+        if (!isExternallyStopped()) {
+          record.status = "error";
+          record.error = err instanceof Error ? err.message : String(err);
+        }
+        record.completedAt = Date.now();
+      } finally {
+        detachCallerSignal?.();
+      }
+      return "";
+    })();
+    await record.promise;
 
     // Same contract as the spawn settle paths: children spawned during the
     // resumed turn must not outlive it — nothing else can see or reach them.
@@ -1415,6 +1475,10 @@ export class AgentManager {
       this.dequeue(q => q.id === id);
       record.status = "stopped";
       record.completedAt = Date.now();
+      // A steer can never land here — the tool refuses non-running agents —
+      // but drop the queue anyway so a late session creation cannot flush
+      // guidance into an agent that was stopped before it started.
+      record.pendingSteers = undefined;
       return true;
     }
 
@@ -1422,12 +1486,22 @@ export class AgentManager {
     record.abortController?.abort();
     record.status = "stopped";
     record.completedAt = Date.now();
+    // Same guard as above, for the wider window: steering a stopped agent is
+    // meaningless, and without this a session created after the stop would
+    // still flush queued steers into it via onSessionCreated.
+    record.pendingSteers = undefined;
     return true;
   }
 
   /** Dispose a record's session and remove it from the map. */
   private removeRecord(id: string, record: AgentRecord): void {
     this.tombstone(record);
+    // Last chance to finalize the output transcript: eviction skips every
+    // settle path, and without this the file handle pins until process end.
+    if (record.outputCleanup) {
+      try { record.outputCleanup(); } catch { /* ignore */ }
+      record.outputCleanup = undefined;
+    }
     const session = record.session;
     // Detached before the shutdown starts, so the record leaves the map at once and
     // nothing can observe a session that is half torn down.

--- a/src/agent-runner.ts
+++ b/src/agent-runner.ts
@@ -593,9 +593,20 @@ function finalTurnError(session: AgentSession, startIndex = 0): string | undefin
  * Wire an AbortSignal to abort a session.
  * Returns a cleanup function to remove the listener.
  */
+function tryAbortSession(session: AgentSession): void {
+  // A torn-down session can throw here; swallowing keeps abort() total — the
+  // worst case is a run that keeps going with status "stopped", which every
+  // settle guard already handles.
+  try { session.abort(); } catch { /* teardown already in progress */ }
+}
+
 function forwardAbortSignal(session: AgentSession, signal?: AbortSignal): () => void {
   if (!signal) return () => {};
-  const onAbort = () => session.abort();
+  // A stop that landed before the session was wired would otherwise attach a
+  // listener to an already-aborted signal that never fires, and the run would
+  // execute in full despite status "stopped".
+  if (signal.aborted) { tryAbortSession(session); return () => {}; }
+  const onAbort = () => tryAbortSession(session);
   signal.addEventListener("abort", onAbort, { once: true });
   return () => signal.removeEventListener("abort", onAbort);
 }

--- a/src/index.ts
+++ b/src/index.ts
@@ -2017,6 +2017,16 @@ Terse command-style prompts produce shallow, generic work.
           );
         }
 
+        // Same guard as the background path above: the manager refuses to
+        // resume a live run (it would corrupt the abort controller), so say
+        // why here instead of a generic failure.
+        if (existing.status === "running" || existing.status === "queued") {
+          return textResult(
+            `Agent "${params.resume}" is still ${existing.status} — it can only be resumed once its current run finishes.\n` +
+            `Use steer_subagent to send it a message mid-run, or get_subagent_result to wait for it.`,
+          );
+        }
+
         const record = await manager.resume(params.resume, params.prompt, signal);
         if (!record) {
           return textResult(`Failed to resume agent "${params.resume}".`);
@@ -2027,7 +2037,7 @@ Terse command-style prompts produce shallow, generic work.
           return textResult(`Agent failed: ${record.error}${partialOutputSuffix(record)}`, buildDetails(detailBaseFor(record), record));
         }
         return textResult(
-          record.result?.trim() || "No output.",
+          `${record.result?.trim() || "No output."}${getForegroundOutcomeNote(record.status)}`,
           buildDetails(detailBaseFor(record), record),
         );
       }

--- a/test/agent-manager.test.ts
+++ b/test/agent-manager.test.ts
@@ -1339,6 +1339,188 @@ describe("AgentManager — abort() state machine", () => {
     expect(receivedSignal?.aborted).toBe(true);
   });
 
+  it("abort drops queued steers so a late session cannot flush them", async () => {
+    manager = new AgentManager();
+    vi.mocked(runAgent).mockImplementation(() => new Promise(() => {}));
+    const id = manager.spawn(mockPi, mockCtx, "X", "p", { description: "x", isBackground: true });
+    // No session yet — the steer parks on the record.
+    expect(manager.steer(id, "change course")).toBe(true);
+    expect(manager.getRecord(id)!.pendingSteers).toEqual(["change course"]);
+
+    expect(manager.abort(id)).toBe(true);
+    expect(manager.getRecord(id)!.pendingSteers).toBeUndefined();
+  });
+
+  it("refuses a foreground resume while the previous run is still in flight", async () => {
+    manager = new AgentManager();
+    vi.mocked(runAgent).mockImplementation(() => new Promise(() => {}));
+    const id = manager.spawn(mockPi, mockCtx, "X", "p", { description: "x", isBackground: true });
+    const record = manager.getRecord(id)!;
+    expect(record.status).toBe("running");
+    record.session = mockSession();
+
+    // A second foreground resume over a live run is refused, not interleaved:
+    // interleaving would overwrite the abort controller and race on result.
+    await expect(manager.resume(id, "again")).resolves.toBeUndefined();
+    expect(manager.getRecord(id)!.status).toBe("running");
+  });
+
+  it("foreground resume replaces the previous run's settled promise", async () => {
+    manager = new AgentManager();
+    resolvedRun();
+    const id = manager.spawn(mockPi, mockCtx, "X", "p", { description: "x", isBackground: true });
+    const record = manager.getRecord(id)!;
+    await record.promise;
+    const settledPromise = record.promise;
+    record.session = mockSession();
+
+    let releaseResume!: (v: { text: string }) => void;
+    vi.mocked(resumeAgent).mockImplementationOnce(() => new Promise((res) => { releaseResume = res as any; }));
+    const resumePromise = manager.resume(id, "more");
+    // Waiters must observe the live run, not the settled one.
+    expect(record.promise).toBeDefined();
+    expect(record.promise).not.toBe(settledPromise);
+    let settled = false;
+    void record.promise!.then(() => { settled = true; });
+    await Promise.resolve();
+    expect(settled).toBe(false);
+
+    releaseResume({ text: "more" });
+    await resumePromise;
+    expect(settled).toBe(true);
+  });
+
+  it("a stop during the worktree copy survives the copy failing", async () => {
+    const { createWorktree } = await import("../src/worktree.js");
+    let rejectCopy!: (err: Error) => void;
+    vi.mocked(createWorktree).mockImplementationOnce(
+      () => new Promise((_, reject) => { rejectCopy = reject; }),
+    );
+    const completed: AgentRecord[] = [];
+    manager = new AgentManager((r) => { completed.push(r); });
+
+    const id = manager.spawn(mockPi, mockCtx, "general-purpose", "test", {
+      description: "test",
+      isBackground: true,
+      isolation: "worktree",
+    });
+    const record = manager.getRecord(id)!;
+    expect(record.status).toBe("running");
+
+    // Stop lands while the repo copy is still in flight.
+    expect(manager.abort(id)).toBe(true);
+
+    // The copy then fails: the stopped record must not be relabeled "error",
+    // deleted, or completed a second time. (The stopped event itself is
+    // pinned by the onStop tests — this one covers only the record outcome.)
+    rejectCopy(new Error("git worktree add failed"));
+    await manager.awaitStartup(id).catch(() => {});
+    expect(record.status).toBe("stopped");
+    expect(manager.getRecord(id)).toBe(record);
+    expect(completed).toEqual([]);
+  });
+
+  it("spawn with a pre-aborted caller signal stops without enqueueing", async () => {
+    manager = new AgentManager(undefined, 1);
+    vi.mocked(runAgent).mockImplementation(() => new Promise(() => {}));
+    manager.spawn(mockPi, mockCtx, "X", "blocker", { description: "b", isBackground: true });
+
+    const caller = new AbortController();
+    caller.abort();
+    const id = manager.spawn(mockPi, mockCtx, "Y", "q", {
+      description: "q",
+      isBackground: true,
+      signal: caller.signal,
+    });
+    const record = manager.getRecord(id)!;
+    expect(record.status).toBe("stopped");
+    expect(record.completedAt).toBeGreaterThan(0);
+    expect(record.pendingSteers).toBeUndefined();
+    // The slot was never taken: the next spawn still queues behind the blocker.
+    const next = manager.spawn(mockPi, mockCtx, "Z", "n", { description: "n", isBackground: true });
+    expect(manager.getRecord(next)?.status).toBe("queued");
+  });
+
+  it("a rejection after a mid-resume stop stays stopped", async () => {
+    manager = new AgentManager();
+    resolvedRun();
+    const id = manager.spawn(mockPi, mockCtx, "X", "p", { description: "x", isBackground: true });
+    await manager.getRecord(id)!.promise;
+    manager.getRecord(id)!.session = mockSession();
+
+    let rejectResume!: (err: Error) => void;
+    vi.mocked(resumeAgent).mockImplementationOnce(
+      () => new Promise((_, reject) => { rejectResume = reject as (err: Error) => void; }),
+    );
+    const resumePromise = manager.resume(id, "more");
+    expect(manager.abort(id)).toBe(true);
+
+    rejectResume(new Error("provider died"));
+    const record = await resumePromise;
+    expect(record!.status).toBe("stopped");
+    expect(record!.error).toBeUndefined();
+    expect(record!.completedAt).toBeGreaterThan(0);
+  });
+
+  it("a pre-aborted caller signal stops the resume instead of running it clean", async () => {
+    manager = new AgentManager();
+    resolvedRun();
+    const id = manager.spawn(mockPi, mockCtx, "X", "p", { description: "x", isBackground: true });
+    await manager.getRecord(id)!.promise;
+    manager.getRecord(id)!.session = mockSession();
+
+    const caller = new AbortController();
+    caller.abort();
+    const steer = vi.mocked(resumeAgent).mockImplementationOnce(async () => ({ text: "late" }) as any);
+    const record = await manager.resume(id, "more", caller.signal);
+    // The pre-aborted entry marks the run stopped; the settle guard keeps it
+    // there even though the session still ran (mirrors the spawn path).
+    expect(record!.status).toBe("stopped");
+    expect(steer).toHaveBeenCalled();
+  });
+
+  it("detaches the caller signal once the resume settles", async () => {
+    manager = new AgentManager();
+    resolvedRun();
+    const id = manager.spawn(mockPi, mockCtx, "X", "p", { description: "x", isBackground: true });
+    await manager.getRecord(id)!.promise;
+    manager.getRecord(id)!.session = mockSession();
+
+    const caller = new AbortController();
+    const removeSpy = vi.spyOn(caller.signal, "removeEventListener");
+    vi.mocked(resumeAgent).mockImplementationOnce(async () => ({ text: "done" }) as any);
+    await manager.resume(id, "more", caller.signal);
+    expect(removeSpy).toHaveBeenCalledWith("abort", expect.any(Function));
+    // A later abort of the caller must not touch the settled record.
+    caller.abort();
+    expect(manager.getRecord(id)!.status).toBe("completed");
+  });
+
+  it("refuses a resume while a previous resume is still queued", async () => {
+    manager = new AgentManager(undefined, 1);
+    vi.mocked(runAgent).mockImplementation(() => new Promise(() => {}));
+    // A finished, session-backed agent plus a full pool: its background
+    // resume queues instead of starting.
+    vi.mocked(runAgent).mockResolvedValueOnce({
+      responseText: "done",
+      session: mockSession(),
+      aborted: false,
+      steered: false,
+    });
+    const a = manager.spawn(mockPi, mockCtx, "X", "p", { description: "x", isBackground: true });
+    await manager.getRecord(a)!.promise;
+    manager.getRecord(a)!.session = mockSession();
+    manager.spawn(mockPi, mockCtx, "Y", "blocker", { description: "b", isBackground: true });
+
+    const bg = await manager.resume(a, "bg", undefined, { isBackground: true });
+    expect(bg?.status).toBe("queued");
+    const resumeCalls = vi.mocked(resumeAgent).mock.calls.length;
+    const fg = await manager.resume(a, "fg");
+    expect(fg).toBeUndefined();
+    expect(manager.getRecord(a)!.status).toBe("queued");
+    expect(vi.mocked(resumeAgent).mock.calls.length).toBe(resumeCalls);
+  });
+
   it("returns false (and does not change status) for an already-completed agent", async () => {
     manager = new AgentManager();
     resolvedRun();
@@ -1496,6 +1678,32 @@ describe("AgentManager — abortAll", () => {
     expect(manager.getRecord(running)?.status).toBe("stopped");
     expect(manager.getRecord(queued)?.status).toBe("stopped");
     expect(manager.hasRunning()).toBe(false);
+  });
+
+  it("spawnAndWait renders a record stopped mid-startup instead of throwing", async () => {
+    // Companion to the launch-guard test above: the same interleaving through
+    // the blocking path. Without the stopped-guard in spawnAndWait, the
+    // startup rejection would escape as a throw even though the stop already
+    // reported and owned the record.
+    const { createWorktree } = await import("../src/worktree.js");
+    let rejectCopy!: (err: Error) => void;
+    vi.mocked(createWorktree).mockImplementationOnce(
+      () => new Promise((_, reject) => { rejectCopy = reject; }),
+    );
+    manager = new AgentManager();
+
+    const pending = manager.spawnAndWait(mockPi, mockCtx, "general-purpose", "test", {
+      description: "test",
+      isolation: "worktree",
+    });
+    const id = manager.listAgents()[0].id;
+    expect(manager.getRecord(id)?.status).toBe("running");
+    expect(manager.abort(id)).toBe(true);
+
+    rejectCopy(new Error("git worktree add failed"));
+    const { record } = await pending;
+    expect(record.status).toBe("stopped");
+    expect(manager.getRecord(id)).toBe(record);
   });
 
   it("returns 0 when there are no running or queued agents", () => {

--- a/test/agent-runner.test.ts
+++ b/test/agent-runner.test.ts
@@ -355,6 +355,18 @@ describe("agent-runner final output capture", () => {
     expect(result.failure).toBeUndefined();
   });
 
+  it("resumeAgent aborts up front on a pre-aborted signal", async () => {
+    // A stop that landed before the session was wired must reach it
+    // immediately, not hang a listener on a signal that never fires again.
+    const { session } = createSession("ABORTED");
+    const controller = new AbortController();
+    controller.abort();
+
+    await resumeAgent(session as any, "Continue", { signal: controller.signal });
+
+    expect(session.abort).toHaveBeenCalled();
+  });
+
   it("sets the agent name as session name before binding extensions", async () => {
     const { session } = createSession("NAMED");
     createAgentSession.mockResolvedValue({ session });


### PR DESCRIPTION
Foreground resume could not be stopped (stale abort controller), raced on re-entry, and left waiters on a settled promise; stops during async startup were relabeled or lost. All reachable today via viewer-x, Esc, or RPC stop — no new tools.

- Foreground resume installs a fresh abort controller, refuses a live re-entry, tracks the live promise, guards settle against overwrite, and frames stopped results like the spawn path
- launch() and spawnAndWait() preserve records stopped mid-startup
- abort() and armQueuedAbort() drop parked steers; eviction finalizes the output transcript
- forwardAbortSignal honors pre-aborted signals and tolerates torn-down sessions