### PR TITLE
feat(rpc): add subagents:rpc:steer for cross-extension callers

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -7,6 +7,10 @@ and this project adheres to [Semantic Versioning](https://semver.org/spec/v2.0.0
 
 ## [Unreleased]
 
+### Added
+
+- **`subagents:rpc:steer` — a cross-extension caller can deliver a message to an agent it spawned.** An extension that spawns over the bus and then learns something the agent needs mid-run (a second CI failure on the head it is already fixing, a review that landed while it works) had to choose between spawning a duplicate agent for the same work and dropping the fact. The new channel is the bus-side half of `steer_subagent`: id only, the same top-level ownership guard as stop, `Agent is not running` once the record has settled, and a message sent before the session exists is flushed when it is created. Outside the `ping` handshake like `consume`; older builds simply do not answer.
+
 ### Fixed
 - **The workflow stand-down now recognises a lowercase `workflow` tool** ([#283](https://github.com/tintinweb/pi-subagents/issues/283) — thanks [@zampierilucas](https://github.com/zampierilucas)). The match is exact on purpose, and the set held `Workflow` and `SubagentWorkflow` only, so `@quintinshaw/pi-dynamic-workflows` — which registers lowercase `workflow` — never tripped it: with `workflowsEnabled` unset, both orchestrators reached the model and nothing warned. Adding the third name is the whole fix; exactness is kept, so a `list_workflows` still cannot take the feature down.
 

--- a/README.md
+++ b/README.md
@@ -33,7 +33,7 @@ https://github.com/user-attachments/assets/8685261b-9338-4fea-8dfe-1c590d5df543
 - **Tool denylist** — block specific tools via `disallowed_tools` frontmatter
 - **Styled completion notifications** — background agent results render as themed, compact notification boxes (icon, stats, result preview) instead of raw XML. Expandable to show full output. Group completions render each agent individually
 - **Event bus** — lifecycle events (`subagents:created`, `started`, `completed`, `failed`, `steered`, `compacted`) emitted via `pi.events`, enabling other extensions to react to sub-agent activity
-- **Cross-extension RPC** — other pi extensions can spawn, stop, and join subagents via the `pi.events` event bus (`subagents:rpc:ping`, `subagents:rpc:spawn`, `subagents:rpc:stop`, `subagents:rpc:consume`). Standardized reply envelopes with protocol versioning. Emits `subagents:ready` on session start. **[Full reference](https://github.com/tintinweb/pi-subagents/blob/master/docs/rpc.md)**
+- **Cross-extension RPC** — other pi extensions can spawn, stop, and join subagents via the `pi.events` event bus (`subagents:rpc:ping`, `subagents:rpc:spawn`, `subagents:rpc:stop`, `subagents:rpc:consume`, `subagents:rpc:steer`). Standardized reply envelopes with protocol versioning. Emits `subagents:ready` on session start. **[Full reference](https://github.com/tintinweb/pi-subagents/blob/master/docs/rpc.md)**
 - **Schedule subagents** — pass `schedule` to the `Agent` tool to fire on cron / interval / one-shot. Session-scoped jobs with PID-locked persistence; results land via the same `subagent-notification` followUp path as manual background completions; manage via `/agents → Scheduled jobs`
 - **Model scope enforcement** — opt-in validation that subagent model choices stay within your pi `enabledModels` allowlist (sourced from `/scoped-models`, with both global and project-local pi settings honored). Caller-supplied out-of-scope → hard error to orchestrator; frontmatter-pinned out-of-scope → warning + runs anyway (frontmatter authoritative). Toggle via `/agents → Settings → Scope models`
 
@@ -824,6 +824,16 @@ Say that an agent's result has been shown to the model, so its completion notifi
 ```typescript
 pi.events.emit("subagents:rpc:consume", { requestId: crypto.randomUUID(), agentId: "agent-id-here" });
 ```
+
+### Steer
+
+Deliver a message to a running agent you spawned, when something it needs arrives mid-run (the bus-side half of `steer_subagent`):
+
+```typescript
+pi.events.emit("subagents:rpc:steer", { requestId: crypto.randomUUID(), agentId: "agent-id-here", message: "A second check failed on the same head; include it before you push." });
+```
+
+Same ownership guard as stop; `Agent is not running` once the agent has settled.
 
 This is the bus-side half of what `get_subagent_result` does when it returns a result. A caller that joins an agent on `subagents:completed` and reports the result itself should consume it — otherwise the notification lands after the parent has already answered, costing a turn to dismiss. Fire-and-forget is the intended use: the reply carries nothing to act on, and the channel is outside the `subagents:rpc:ping` version handshake, so a caller can send it unconditionally and an older extension that has no handler simply keeps notifying. Consuming a running or unknown agent is refused (`success: false`) and changes nothing — a running agent has no result to have been read, and its notification is still the caller's only signal that it finished.
 

--- a/docs/rpc.md
+++ b/docs/rpc.md
@@ -1,6 +1,6 @@
 # Driving subagents from another extension
 
-Another pi extension can spawn a subagent, listen for subagent completion, read the result and stop the run — all over the `pi.events` bus, without importing this package directly. Four request/reply channels (`subagents:rpc:ping`, `subagents:rpc:spawn`, `subagents:rpc:stop`, `subagents:rpc:consume`), eleven lifecycle events, and one in-process registry at `Symbol.for("pi-subagents:manager")`.
+Another pi extension can spawn a subagent, listen for subagent completion, read the result and stop the run — all over the `pi.events` bus, without importing this package directly. Five request/reply channels (`subagents:rpc:ping`, `subagents:rpc:spawn`, `subagents:rpc:stop`, `subagents:rpc:consume`, `subagents:rpc:steer`), eleven lifecycle events, and one in-process registry at `Symbol.for("pi-subagents:manager")`.
 
 The thing worth understanding up front is that **the bus is in-process.** Every "RPC" call here is a synchronous `pi.events.emit` into the same event loop, and every reply comes back the same way. That single fact explains most of what follows: why `signal` and the `on*` callbacks work on a spawn payload at all, why a `consume` fired inside a `subagents:completed` handler lands *before* the notification decision has been made, and why none of this survives a real process boundary.
 
@@ -89,6 +89,8 @@ Every failure reaches the caller as `{ success: false, error }`, where `error` i
 | `Agent is owned by another agent or workflow` | stop — `:178` |
 | `Agent is not running` | stop — `:182`. The record exists, so it has already settled |
 | `Agent not found or still running` | consume — `:193` |
+| `Steer message must be a non-empty string` | steer — the payload's `message` was missing, not a string, or whitespace |
+| `Agent not found` / `Agent is owned by another agent or workflow` / `Agent is not running` | steer — same lookup, ownership guard and settled check as stop |
 
 Three things the table cannot show:
 
@@ -129,6 +131,12 @@ Consumption is not terminal. An `@handle` steer un-consumes the record (`src/ind
 
 One related thing that lives nowhere else: on every top-level settle, pi-subagents writes a session entry — not an event — via `pi.appendEntry("subagents:record", …)` (`src/index.ts:585`), carrying `id`, `type`, `description`, `status`, `result`, `error`, `startedAt` and `completedAt`. It exists for cross-extension history reconstruction. It is append-only history, not something to react to.
 
+## Steering a running agent
+
+`subagents:rpc:steer` `{ requestId, agentId, message }` delivers `message` into a running or queued agent's conversation, the bus-side half of the `steer_subagent` tool. It exists for the caller that spawned an agent over the bus and then learns something that agent needs mid-run — a second CI failure on the head it is already fixing, a review that landed while it works — and would otherwise have to choose between spawning a duplicate agent for the same work and dropping the fact.
+
+It takes an id only, enforces the same top-level ownership guard as stop, and answers `Agent is not running` for a record that has settled. A message queued before the agent's session exists is flushed when the session is created, exactly as the tool's steer is. Like `consume`, it is outside the `ping` version handshake: an older build has no handler and the request times out on your side, so give it a timeout and treat expiry as "not available here".
+
 ## The manager registry
 
 `globalThis[Symbol.for("pi-subagents:manager")]` (`src/index.ts:649-659`) is a second integration surface — the standard Node cross-package singleton pattern, no bus involved:
@@ -148,7 +156,7 @@ Prefer the bus. The registry has no reply envelope, no version, and no availabil
 
 `subagents:rpc:ping` replies `{ version: PROTOCOL_VERSION }`, currently `2` (`src/cross-extension-rpc.ts:33`). The constant was introduced already equal to `2` in 0.5.0; "v1" is a retroactive name for the pre-envelope contract, where spawn replied with a bare `{ id }` or `{ error }`, stop replied `{ success: boolean }` with no message, and each handler caught its own errors.
 
-Everything added since shipped **without a bump**, because all of it is additive: stop's ownership refusal, string-`model` resolution ([#59](https://github.com/tintinweb/pi-subagents/pull/59)/[#60](https://github.com/tintinweb/pi-subagents/issues/60)), `scopeModels` enforcement ([#240](https://github.com/tintinweb/pi-subagents/issues/240)), and the whole `consume` channel.
+Everything added since shipped **without a bump**, because all of it is additive: stop's ownership refusal, string-`model` resolution ([#59](https://github.com/tintinweb/pi-subagents/pull/59)/[#60](https://github.com/tintinweb/pi-subagents/issues/60)), `scopeModels` enforcement ([#240](https://github.com/tintinweb/pi-subagents/issues/240)), and the whole `consume` and `steer` channels.
 
 > A `ping` that answers `2` does not tell you whether `consume` exists, whether model scope is enforced, or whether stop checks ownership.
 
@@ -168,7 +176,7 @@ This document has no test of its own, so it is worth knowing which claims are ac
 
 | Test | Level | Pins |
 |---|---|---|
-| `test/cross-extension-rpc.test.ts` | Mocked `SpawnCapable` | Envelope shape, per-channel error strings, model resolution and scope enforcement |
+| `test/cross-extension-rpc.test.ts` | Mocked `SpawnCapable` | Envelope shape, per-channel error strings (including steer's), model resolution and scope enforcement |
 | `test/rpc-lifecycle-gating.test.ts` | Real extension factory | Nothing wired at factory time, everything once at `session_start`, and live widget activity for RPC spawns ([#142](https://github.com/tintinweb/pi-subagents/issues/142)/[#181](https://github.com/tintinweb/pi-subagents/pull/181)) |
 | `test/rpc-result-consumption.test.ts` | Real delivery path | The notification firing, and not firing, around `consume` |
 

--- a/src/cross-extension-rpc.ts
+++ b/src/cross-extension-rpc.ts
@@ -50,6 +50,11 @@ export interface SpawnCapable {
    * one. False when there is no such agent, or it has not settled yet.
    */
   consumeResult(id: string): boolean;
+  /**
+   * Deliver a message to a running or queued agent's conversation — what
+   * `steer_subagent` does. False when the agent is unknown or has settled.
+   */
+  steer(id: string, message: string): boolean;
 }
 
 export interface RpcDeps {
@@ -64,6 +69,7 @@ export interface RpcHandle {
   unsubSpawn: () => void;
   unsubStop: () => void;
   unsubConsume: () => void;
+  unsubSteer: () => void;
 }
 
 /**
@@ -194,5 +200,21 @@ export function registerRpcHandlers(deps: RpcDeps): RpcHandle {
     },
   );
 
-  return { unsubPing, unsubSpawn, unsubStop, unsubConsume };
+  // An extension that spawned an agent over the bus and then learns something
+  // that agent needs — a second CI failure on the head it is already fixing, a
+  // review that landed mid-run — can hand it over instead of spawning a second
+  // agent for the same work or dropping the fact. Same ownership guard as stop:
+  // an agent something else is waiting on is not this caller's to redirect.
+  // Outside the ping version handshake, like consume: additive and best-effort.
+  const unsubSteer = handleRpc<{ requestId: string; agentId: string; message: unknown }>(
+    events, "subagents:rpc:steer", ({ agentId, message }) => {
+      if (typeof message !== "string" || message.trim().length === 0) throw new Error("Steer message must be a non-empty string");
+      const record = manager.getRecord(agentId);
+      if (!record) throw new Error("Agent not found");
+      if (!isTopLevelAgent(record)) throw new Error("Agent is owned by another agent or workflow");
+      if (!manager.steer(agentId, message)) throw new Error("Agent is not running");
+    },
+  );
+
+  return { unsubPing, unsubSpawn, unsubStop, unsubConsume, unsubSteer };
 }

--- a/src/index.ts
+++ b/src/index.ts
@@ -819,6 +819,7 @@ export default function (pi: ExtensionAPI) {
             cancelNudge(record.id);
             return true;
           },
+          steer: (id, message) => manager.steer(id, message),
         },
       });
       // Broadcast readiness so extensions loaded alongside us can discover us.
@@ -1099,6 +1100,7 @@ export default function (pi: ExtensionAPI) {
     rpcHandle?.unsubStop();
     rpcHandle?.unsubPing();
     rpcHandle?.unsubConsume();
+    rpcHandle?.unsubSteer();
     rpcHandle = undefined;
     currentCtx = undefined;
     // Only release the global slot if this activation claimed it — a child

--- a/test/cross-extension-rpc.test.ts
+++ b/test/cross-extension-rpc.test.ts
@@ -34,6 +34,7 @@ describe("cross-extension RPC", () => {
       abort: vi.fn().mockReturnValue(true),
       getRecord: vi.fn().mockReturnValue({}),
       consumeResult: vi.fn().mockReturnValue(true),
+      steer: vi.fn().mockReturnValue(true),
     };
     ctx = { session: true };
     deps = { events, pi: { events }, getCtx: () => ctx, manager };
@@ -326,6 +327,81 @@ describe("cross-extension RPC", () => {
       await new Promise((r) => setTimeout(r, 20));
       expect(reply).not.toHaveBeenCalled();
       expect(manager.consumeResult).not.toHaveBeenCalled();
+    });
+  });
+
+  // --- steer ---
+
+  describe("steer RPC", () => {
+    it("delivers a message to a running top-level agent", async () => {
+      registerRpcHandlers(deps);
+      const reply = vi.fn();
+      events.on("subagents:rpc:steer:reply:req-m1", reply);
+      events.emit("subagents:rpc:steer", { requestId: "req-m1", agentId: "agent-42", message: "also failing: check_suite on 839ab295" });
+
+      await vi.waitFor(() => expect(reply).toHaveBeenCalled());
+      expect(reply).toHaveBeenCalledWith({ success: true });
+      expect(manager.steer).toHaveBeenCalledWith("agent-42", "also failing: check_suite on 839ab295");
+    });
+
+    it("returns error when the agent is unknown to the manager", async () => {
+      (manager.getRecord as ReturnType<typeof vi.fn>).mockReturnValue(undefined);
+      registerRpcHandlers(deps);
+      const reply = vi.fn();
+      events.on("subagents:rpc:steer:reply:req-m2", reply);
+      events.emit("subagents:rpc:steer", { requestId: "req-m2", agentId: "nonexistent", message: "x" });
+
+      await vi.waitFor(() => expect(reply).toHaveBeenCalled());
+      expect(reply).toHaveBeenCalledWith({ success: false, error: "Agent not found" });
+      expect(manager.steer).not.toHaveBeenCalled();
+    });
+
+    // Same ownership stance as stop: an agent another agent or a workflow is
+    // waiting on is not this RPC's to redirect.
+    it("refuses to steer another agent's nested child or a workflow's agent", async () => {
+      (manager.getRecord as ReturnType<typeof vi.fn>).mockReturnValue({ workflowId: "wf-1" });
+      registerRpcHandlers(deps);
+      const reply = vi.fn();
+      events.on("subagents:rpc:steer:reply:req-m3", reply);
+      events.emit("subagents:rpc:steer", { requestId: "req-m3", agentId: "agent-42", message: "x" });
+
+      await vi.waitFor(() => expect(reply).toHaveBeenCalled());
+      expect(reply).toHaveBeenCalledWith({ success: false, error: "Agent is owned by another agent or workflow" });
+      expect(manager.steer).not.toHaveBeenCalled();
+    });
+
+    it("says so when the agent has already finished", async () => {
+      (manager.steer as ReturnType<typeof vi.fn>).mockReturnValue(false);
+      registerRpcHandlers(deps);
+      const reply = vi.fn();
+      events.on("subagents:rpc:steer:reply:req-m4", reply);
+      events.emit("subagents:rpc:steer", { requestId: "req-m4", agentId: "agent-42", message: "x" });
+
+      await vi.waitFor(() => expect(reply).toHaveBeenCalled());
+      expect(reply).toHaveBeenCalledWith({ success: false, error: "Agent is not running" });
+    });
+
+    it("rejects an empty or non-string message before touching the manager", async () => {
+      registerRpcHandlers(deps);
+      const reply = vi.fn();
+      events.on("subagents:rpc:steer:reply:req-m5", reply);
+      events.emit("subagents:rpc:steer", { requestId: "req-m5", agentId: "agent-42", message: "   " });
+
+      await vi.waitFor(() => expect(reply).toHaveBeenCalled());
+      expect(reply).toHaveBeenCalledWith({ success: false, error: "Steer message must be a non-empty string" });
+      expect(manager.steer).not.toHaveBeenCalled();
+    });
+
+    it("unsub stops responding to steer requests", async () => {
+      const { unsubSteer } = registerRpcHandlers(deps);
+      unsubSteer();
+
+      const reply = vi.fn();
+      events.on("subagents:rpc:steer:reply:req-m6", reply);
+      events.emit("subagents:rpc:steer", { requestId: "req-m6", agentId: "agent-42", message: "x" });
+
+      await new Promise((r) => setTimeout(r, 20));
+      expect(reply).not.toHaveBeenCalled();
     });
   });
 


### PR DESCRIPTION
Adds a fifth RPC channel so a cross-extension caller can steer an agent it spawned. Nothing existing changes. States as of opening.

## Summary

An extension that spawns an agent through `subagents:rpc:spawn` and then learns something that agent needs while it is running has no bus-side way to pass it on. Two failure modes result:

1. It spawns a second agent for the same work. In pi-shipyard's case a second CI check failed on the same head a remediator was already fixing; a second remediator would race the first on one worktree, so the event was refused instead.
2. It drops the fact. The running agent finishes without knowing about the later failure, pushes, and CI fails again on the thing it was never told about.

`steer_subagent` exists for exactly this, but it is a tool the parent model calls. There was no equivalent for an extension.

## What changed

One new request/reply channel, `subagents:rpc:steer` `{ requestId, agentId, message }`, handled in `src/cross-extension-rpc.ts` beside `stop` and `consume`. It validates `message` is a non-empty string, looks the record up, applies the same `isTopLevelAgent` guard as stop, and calls `manager.steer`, which already queues a message for a session that does not exist yet and returns false for a settled record. `SpawnCapable` gains `steer`; `RpcHandle` gains `unsubSteer`, torn down on `session_shutdown` with the others. `src/index.ts` wires `steer` to the real manager.

Deliberately outside the `ping` version handshake, like `consume`: additive, and an older build simply never answers.

## Related work

| Number | Title | State | Relation |
|---|---|---|---|
| — | `subagents:rpc:consume` (0.19.0) | shipped | Same pattern: additive channel outside the handshake, same section of the handler file |

## Behavior and compatibility

No changes to existing channels, envelopes, events, or `PROTOCOL_VERSION`. Callers that do not send `steer` see nothing new. Ownership stance matches stop: nested and workflow-owned agents are refused with `Agent is owned by another agent or workflow`. Handles are not resolved (id only), the same asymmetry stop has today.

## Performance

No measurable change: one additional `events.on` subscription at `session_start`; nothing on any hot path.

## Testing

```
npm run check
  biome: Checked 170 files. No fixes applied.
  tsc: clean
  vitest: Test Files 105 passed (105), Tests 2135 passed | 7 skipped (2142)
```

New coverage in `test/cross-extension-rpc.test.ts` (six cases): success path with the exact message forwarded, unknown agent, ownership refusal, settled agent, empty/non-string message rejected before the manager is touched, and `unsubSteer` silencing the channel.

Mutation check: removing the ownership guard and the message validation from the handler failed the two corresponding tests; restoring the source passed all 36 in the file.

Not covered: no real-extension-factory test for steer (the equivalent of `test/rpc-lifecycle-gating.test.ts`), and no test that a steer queued before session creation is flushed; that behavior belongs to `AgentManager.steer` and is unchanged here.
