### PR TITLE
fix(workflow): preserve running workflows on reload and open fleet inspectors

### DIFF
--- a/README.md
+++ b/README.md
@@ -127,6 +127,20 @@ The token field is annotated with two optional signals inside parens:
 
 ### FleetView
 
+When workflows are present, `↓` or `←` at an empty prompt selects the first
+workflow immediately. `Enter` at an empty prompt opens that workflow directly;
+otherwise `Enter` opens the selected row. A nonempty draft keeps its normal
+Enter behavior. In Pi's regular terminal mode, clicking a workflow row also
+opens its inspector. Hold Shift for native terminal text selection. Fullscreen
+mode retains its own mouse handling; use the keyboard there.
+
+Running workflows and agents survive `/reload` in the same Pi process. The
+replacement runtime reattaches their UI and completion notifications without
+restarting their work. Quit and session changes still stop them. If the plugin
+is removed or cannot reattach within 30 seconds, its retained runs are stopped.
+An active runtime retains its executing code until work settles; reload while
+idle (or start a new session) to apply plugin code updates.
+
 While subagents are running, a Claude Code-style navigable list renders **below** the editor:
 
 ```

--- a/docs/workflows.md
+++ b/docs/workflows.md
@@ -364,6 +364,19 @@ See [`compose.js`](../examples/workflows/compose.js).
 
 ## Troubleshooting
 
+**The running workflow is visible but I cannot open it.**
+At an empty prompt, press `Enter` to open the first workflow, or `↓`/`←` to
+select it and then `Enter`. Mouse clicks on workflow rows open the inspector in
+Pi's regular terminal mode; fullscreen mode uses keyboard navigation. Other
+dialogs keep their own input, and Enter in a nonempty prompt still submits it.
+
+**What happens to a running workflow during `/reload`?**
+The same-process runtime preserves the worker and child agents, restores
+FleetView, and routes completion to the replacement host. It does not rerun the
+script or its completed steps. Quit, switching sessions, and process restart
+still stop runs. If reload removes the plugin or fails to reattach it within
+30 seconds, the retained runs are stopped rather than left orphaned.
+
 **The run failed with `… is unavailable in workflow scripts (breaks resume)`.**
 The script called `Date.now()`, `new Date()` or `Math.random()`. A script that varies run to run cannot be replayed from its journal, so these throw. Use the loop index for ids, pass timestamps in through `args`, or stamp them after the workflow returns. This most often bites pasted-in helper code, and it throws at the line that calls it — *after* you have already paid for the preceding agents.
 

--- a/src/index.ts
+++ b/src/index.ts
@@ -32,6 +32,7 @@ import { describeModel, type ModelRegistry, resolveModel } from "./model-resolve
 import { checkModelScope, isScopeModelsEnabled, setScopeModelsEnabled } from "./model-scope.js";
 import { getMaxSubagentDepth, setMaxSubagentDepth } from "./nested-tools.js";
 import { createOutputFilePath, ensureOutputFile, getOutputTranscriptDefault, sessionTaskDir, setOutputTranscriptDefault, streamToOutputFile, writeInitialEntry } from "./output-file.js";
+import { registerReloadable } from "./reload-runtime.js";
 import { SubagentScheduler } from "./schedule.js";
 import { resolveStorePath, ScheduleStore } from "./schedule-store.js";
 import { applyAndEmitLoaded, loadSettings, type SubagentsSettings, saveAndEmitChanged, type ToolDescriptionMode } from "./settings.js";
@@ -303,6 +304,11 @@ export default function (pi: ExtensionAPI) {
   // would create another manager and leak handlers. Nested orchestration is
   // injected as scoped custom tools by the existing manager instead.
   if (inChildSessionContext()) return;
+
+  registerReloadable(pi, activateSubagents);
+}
+
+function activateSubagents(pi: ExtensionAPI) {
 
   // ---- Register custom notification renderer ----
   pi.registerMessageRenderer<NotificationDetails>(
@@ -786,13 +792,19 @@ export default function (pi: ExtensionAPI) {
   // Capture ctx from session_start for RPC spawn handler + start the scheduler.
   // This also wires the RPC handlers and broadcasts readiness — on the first
   // bound session_start, so a filtered-out activation never advertises (#142).
-  pi.on("session_start", async (_event, ctx) => {
+  pi.on("session_start", async (event, ctx) => {
+    if (event.reason === "reload") applyPersistedSettings(ctx.cwd);
     currentCtx = ctx;
     if (ctx.hasUI) {
       widget.setUICtx(ctx.ui);
       fleet.setUICtx(ctx.ui as any);
     }
-    manager.clearCompleted(true);
+    if (event.reason !== "reload") manager.clearCompleted(true);
+    else {
+      widget.update();
+      if (manager.hasRunning()) widget.ensureTimer();
+      fleet.update();
+    }
     // Guard mirrors the `!scheduler.isActive()` pattern below: session_start
     // fires once per activation, but a double-bind must not leak listeners.
     if (!rpcHandle) {
@@ -1094,13 +1106,18 @@ export default function (pi: ExtensionAPI) {
 
   // On shutdown, abort all agents immediately and clean up.
   // If the session is going down, there's nothing left to consume agent results.
-  pi.on("session_shutdown", async () => {
+  pi.on("session_shutdown", async (event) => {
     rpcHandle?.unsubSpawn();
     rpcHandle?.unsubStop();
     rpcHandle?.unsubPing();
     rpcHandle?.unsubConsume();
     rpcHandle = undefined;
     currentCtx = undefined;
+    scheduler.stop();
+    fleet.dispose();
+    widget.dispose();
+    mentionProviderRegistered = false;
+    if (event?.reason === "reload") return;
     // Only release the global slot if this activation claimed it — a child
     // session's shutdown must not delete the root session's registry entry.
     if (ownsManagerRegistry && (globalThis as any)[MANAGER_KEY] === registryEntry) {
@@ -1112,9 +1129,10 @@ export default function (pi: ExtensionAPI) {
     for (const task of workflowTasks.values()) task.abortController.abort();
     workflowTasks.clear();
     manager.abortAll();
+    groupJoin.dispose();
+    if (batchFinalizeTimer) clearTimeout(batchFinalizeTimer);
     for (const timer of pendingNudges.values()) clearTimeout(timer);
     pendingNudges.clear();
-    fleet.dispose();
     // Awaited: it emits `session_shutdown` into every retained child session so
     // extensions bound there can release what they armed in `session_start` (#242).
     // pi awaits this handler, and the process exits right after — unawaited, those
@@ -1400,7 +1418,8 @@ export default function (pi: ExtensionAPI) {
   // Apply persisted settings on startup and emit `subagents:settings_loaded`.
   // Global + project merged; missing → defaults; corrupt file emits a warning
   // to stderr and falls back to defaults.
-  applyAndEmitLoaded(
+  function applyPersistedSettings(cwd = process.cwd()): void {
+    applyAndEmitLoaded(
     {
       setMaxConcurrent: (n) => manager.setMaxConcurrent(n),
       setMaxConcurrentForeground: (n) => manager.setMaxConcurrentForeground(n),
@@ -1428,7 +1447,10 @@ export default function (pi: ExtensionAPI) {
       setViewerMarkdown,
     },
     (event, payload) => pi.events.emit(event, payload),
+    cwd,
   );
+  }
+  applyPersistedSettings();
 
   // ---- Agent tool ----
 
@@ -3985,4 +4007,6 @@ Write the file using the write tool. Only write the file, nothing else.`;
   };
 
   fleet.setWorkflowSource(fleetWorkflows, id => openWorkflowFromFleet(id, workflowMenuDeps));
+  return () => manager.hasRunning() || pendingNudges.size > 0
+    || [...workflowTasks.values()].some(task => task.status === "running" || task.status === "paused");
 }

--- a/src/reload-runtime.ts
+++ b/src/reload-runtime.ts
@@ -1,0 +1,163 @@
+import type { ExtensionAPI, ExtensionContext } from "@earendil-works/pi-coding-agent";
+
+type Callback = (...args: unknown[]) => unknown;
+type Deferred = { run(): void; cancel(): void };
+type Runtime = {
+  api: ExtensionAPI;
+  context?: ExtensionContext;
+  proxy?: ExtensionContext;
+  callbacks: Map<string, Callback>;
+  pending: Deferred[];
+  detached: boolean;
+  closed: boolean;
+  expiry?: ReturnType<typeof setTimeout>;
+  keepAlive?: () => boolean;
+};
+
+// The loader reimports modules on reload. A module-local map would disappear
+// at exactly the moment it is needed. Session identity prevents another root
+// session (or a child) from claiming an unrelated manager and workflow table.
+const KEY = Symbol.for("pi-subagents:reload-runtime:v1");
+const globals = globalThis as unknown as Record<symbol, Map<string, Runtime> | undefined>;
+const retained = globals[KEY] ?? new Map<string, Runtime>();
+globals[KEY] = retained;
+const REATTACH_TIMEOUT_MS = 30_000;
+
+/** Keep the running closure, but replace its host API and UI on /reload. */
+export function registerReloadable(pi: ExtensionAPI, setup: (api: ExtensionAPI) => () => boolean): void {
+  const created: Runtime = { api: pi, callbacks: new Map(), pending: [], detached: false, closed: false };
+  let current = created;
+  let sessionKey: string | undefined;
+
+  const context = new Proxy({} as ExtensionContext, {
+    get: (_target, key) => {
+      const value: unknown = Reflect.get(created.context ?? {}, key);
+      return typeof value === "function"
+        ? (...args: unknown[]) => Reflect.apply(Reflect.get(created.context ?? {}, key), created.context, args)
+        : value;
+    },
+  });
+  created.proxy = context;
+
+  const send = (method: PropertyKey, args: unknown[], bus = false): unknown => {
+    const invoke = () => {
+      const target = bus ? created.api.events : created.api;
+      return Reflect.apply(Reflect.get(target, method), target, args);
+    };
+    if (created.closed) {
+      if (method === "exec") return Promise.reject(new Error("Subagents runtime closed"));
+      return;
+    }
+    if (!created.detached) return invoke();
+    if (method === "exec") {
+      return new Promise((resolve, reject) => created.pending.push({
+        run: () => { try { resolve(invoke()); } catch (error) { reject(error); } },
+        cancel: () => reject(new Error("Subagents reload was not reattached")),
+      }));
+    }
+    if (bus || method === "sendMessage" || method === "sendUserMessage" || method === "appendEntry") {
+      created.pending.push({ run: () => { invoke(); }, cancel() {} });
+      return;
+    }
+    // Registration and configuration reads run at activation, not in a worker.
+    return invoke();
+  };
+
+  const dispose = async (runtime: Runtime) => {
+    runtime.closed = true;
+    if (runtime.expiry) clearTimeout(runtime.expiry);
+    for (const pending of runtime.pending.splice(0)) pending.cancel();
+    await runtime.callbacks.get("on:session_shutdown")?.({ type: "session_shutdown", reason: "quit" }, runtime.context);
+  };
+
+  const wrap = (key: string, callback: Callback): Callback => {
+    created.callbacks.set(key, callback);
+    return (...incoming: unknown[]) => {
+      const lifecycle = key.startsWith("on:");
+      const ctxIndex = lifecycle ? 1 : key.endsWith(":execute") ? 4 : key.endsWith(":handler") ? 1 : -1;
+      const ctx = ctxIndex >= 0 ? incoming[ctxIndex] as ExtensionContext | undefined : undefined;
+      if (ctx && ctx !== current.proxy) current.context = ctx;
+      const event = incoming[0] as { reason?: string } | undefined;
+      if (key === "on:session_start" && ctx) {
+        return (async () => {
+          sessionKey = JSON.stringify([ctx.cwd, ctx.sessionManager.getSessionId()]);
+          const previous = event?.reason === "reload" ? retained.get(sessionKey) : undefined;
+          if (previous && previous !== current) {
+            await dispose(created);
+            retained.delete(sessionKey);
+            current = previous;
+            current.api = pi;
+            current.context = ctx;
+            current.detached = false;
+            if (current.expiry) clearTimeout(current.expiry);
+          }
+          // The saved callbacks captured their own stable context proxy.
+          const result = await current.callbacks.get(key)?.(incoming[0], current.proxy);
+          for (const pending of current.pending.splice(0)) pending.run();
+          return result;
+        })();
+      }
+      if (key === "on:session_shutdown" && event?.reason === "reload" && sessionKey && ctx) {
+        return (async () => {
+          if (!current.keepAlive?.()) {
+            await dispose(current);
+            return;
+          }
+          // Snapshot guarded getters while the old runner is still valid. The
+          // worker can finish a child/start another during the reload gap.
+          const systemPrompt = ctx.getSystemPrompt();
+          const snapshot = { ...ctx, hasUI: false, getSystemPrompt: () => systemPrompt };
+          await current.callbacks.get(key)?.(...incoming);
+          current.context = snapshot;
+          current.detached = true;
+          retained.set(sessionKey!, current);
+          const saved = current;
+          saved.expiry = setTimeout(() => {
+            if (retained.get(sessionKey!) !== saved) return;
+            retained.delete(sessionKey!);
+            void dispose(saved).catch(() => {});
+          }, REATTACH_TIMEOUT_MS);
+          saved.expiry.unref();
+        })();
+      }
+      if (key === "on:session_shutdown" && event?.reason !== "reload") {
+        if (sessionKey && retained.get(sessionKey) === current) retained.delete(sessionKey);
+        if (current.expiry) clearTimeout(current.expiry);
+      }
+      const args = [...incoming];
+      if (ctx) args[ctxIndex] = current.proxy;
+      return current.callbacks.get(key)?.(...args);
+    };
+  };
+
+  const facade = new Proxy(pi, {
+    get: (_target, method) => {
+      if (method === "events") return {
+        emit: (...args: unknown[]) => send("emit", args, true),
+        on: (...args: unknown[]) => send("on", args, true),
+      };
+      if (method === "on") return (event: string, handler: Callback) =>
+        Reflect.apply(pi.on, pi, [event, wrap(`on:${event}`, handler)]);
+      if (typeof method === "string" && method.startsWith("register") && method !== "registerFlag") {
+        return (...args: unknown[]) => {
+          const first = args[0];
+          const name = typeof first === "string" ? first : (first as { name: string }).name;
+          const wrapped = args.map(value => {
+            if (typeof value === "function") return wrap(`${method}:${name}`, value as Callback);
+            if (value && typeof value === "object") {
+              const wrappedObject = Object.fromEntries(Object.entries(value).map(([field, item]) => [field,
+                typeof item === "function" ? wrap(`${method}:${name}:${field}`, item as Callback) : item]));
+              // Mention dispatch passes the registered Agent definition directly.
+              return method === "registerTool" ? Object.assign(value, wrappedObject) : wrappedObject;
+            }
+            return value;
+          });
+          return Reflect.apply(Reflect.get(created.api, method), created.api, wrapped);
+        };
+      }
+      const value: unknown = Reflect.get(created.api, method);
+      return typeof value === "function" ? (...args: unknown[]) => send(method, args) : value;
+    },
+  });
+  created.keepAlive = setup(facade);
+}

--- a/src/ui/agent-widget.ts
+++ b/src/ui/agent-widget.ts
@@ -655,5 +655,6 @@ export class AgentWidget {
     this.widgetRegistered = false;
     this.tui = undefined;
     this.lastStatusText = undefined;
+    this.uiCtx = undefined;
   }
 }

--- a/src/ui/fleet-list.ts
+++ b/src/ui/fleet-list.ts
@@ -18,6 +18,7 @@ import type { AgentRecord, ViewerMarkdownMode } from "../types.js";
 import { getLifetimeCost, getLifetimeTotal } from "../usage.js";
 import { type AgentActivity, formatCost, type Theme } from "./agent-widget.js";
 import { ConversationViewer, VIEWPORT_HEIGHT_PCT } from "./conversation-viewer.js";
+import { FleetMouse } from "./fleet-mouse.js";
 
 /** Widget key for the below-editor fleet list. */
 const FLEET_KEY = "fleet";
@@ -122,6 +123,13 @@ export class FleetList {
    * minus the close handle, because that overlay belongs to the extension.
    */
   private viewingWorkflowId: string | undefined;
+  private mouse = new FleetMouse(id => {
+    const index = this.roster().findIndex(entry => entry.kind === "workflow" && entry.workflow.id === id);
+    if (index < 0 || !this.editorHasFocus() || this.viewerClose || this.viewingWorkflowId) return;
+    this.active = true;
+    this.selectedIndex = index;
+    this.openSelected();
+  });
 
   constructor(
     private manager: AgentManager,
@@ -158,6 +166,7 @@ export class FleetList {
   /** Capture the UI context and (re)register the global input handler. */
   setUICtx(ui: FleetUICtx): void {
     if (ui === this.ui) return;
+    this.mouse.dispose();
     this.inputUnsub?.();
     this.ui = ui;
     this.widgetRegistered = false;
@@ -179,6 +188,7 @@ export class FleetList {
   }
 
   dispose(): void {
+    this.mouse.dispose();
     if (this.timer) { clearInterval(this.timer); this.timer = undefined; }
     this.inputUnsub?.();
     this.inputUnsub = undefined;
@@ -205,6 +215,7 @@ export class FleetList {
     const hasRows = this.enabled && this.roster().length > 1;
 
     if (!hasRows) {
+      this.mouse.dispose();
       if (this.widgetRegistered) {
         this.ui.setWidget(FLEET_KEY, undefined);
         this.widgetRegistered = false;
@@ -222,6 +233,7 @@ export class FleetList {
     if (!this.widgetRegistered) {
       this.ui.setWidget(FLEET_KEY, (tui, theme) => {
         this.tui = tui;
+        this.mouse.attach(tui);
         return {
           render: (w: number) => this.renderBar(w, theme),
           invalidate: () => { this.widgetRegistered = false; this.tui = undefined; },
@@ -307,6 +319,8 @@ export class FleetList {
   /** Returns `{consume:true}` to swallow a key, or undefined to let it through. */
   handleKey(data: string): { consume?: boolean; data?: string } | undefined {
     if (!this.enabled || !this.ui) return undefined;
+    const mouse = this.mouse.handleInput(data);
+    if (mouse) return mouse;
     // Input listeners receive BOTH key-press and key-release (the kitty protocol
     // emits both, and matchesKey matches either) — act on press only, or every
     // tap would move/fire twice. Repeats still pass through for held-key nav.
@@ -326,14 +340,17 @@ export class FleetList {
 
     if (!this.active) {
       // Activate: ↓ or ← at an empty prompt moves focus into the list.
-      const isActivator = matchesKey(data, "down") || matchesKey(data, "left");
+      const workflowIndex = this.roster().findIndex(entry => entry.kind === "workflow");
+      const enterWorkflow = workflowIndex >= 0 && matchesKey(data, Key.enter);
+      const isActivator = matchesKey(data, "down") || matchesKey(data, "left") || enterWorkflow;
       // Gated on the roster, not the agents: a session whose only row is a
       // workflow run still has somewhere to go, and requiring an agent would
       // render the row but refuse to move into it.
       if (isActivator && this.roster().length > 1 && this.ui.getEditorText() === "") {
         this.active = true;
-        this.selectedIndex = 0;
+        this.selectedIndex = workflowIndex >= 0 ? workflowIndex : 0;
         this.update();
+        if (enterWorkflow) this.openSelected();
         return { consume: true };
       }
       return undefined;
@@ -391,10 +408,13 @@ export class FleetList {
       // `viewerClose` to hold — but the list still has to know one is up, and
       // still has to put the cursor back on the run when it comes down.
       this.viewingWorkflowId = entry.workflow.id;
-      void Promise.resolve(this.openWorkflow?.(entry.workflow.id)).then(
-        () => this.clearViewer(),
-        () => this.clearViewer(),
-      );
+      const failed = (error: unknown) => {
+        this.ui?.notify(`Could not open workflow: ${error instanceof Error ? error.message : String(error)}`, "warning");
+        this.clearViewer();
+      };
+      try {
+        void Promise.resolve(this.openWorkflow?.(entry.workflow.id)).then(() => this.clearViewer(), failed);
+      } catch (error) { failed(error); }
       return;
     }
     const record = entry.record;
@@ -466,8 +486,10 @@ export class FleetList {
 
     const hint = this.active
       ? "↑↓ select · enter view · esc back"
+      : this.workflows().length > 0 ? "click / enter workflow · ↓ to manage · esc to interrupt"
       : "esc to interrupt · ← for agents · ↓ to manage";
     const lines: string[] = [];
+    const clickTargets = new Map<number, string>();
     lines.push(truncateToWidth("  " + theme.fg("dim", hint), width));
     lines.push("");
     lines.push(truncateToWidth(`  ${this.bullet(0, sel, theme)} main`, width));
@@ -481,6 +503,7 @@ export class FleetList {
     if (start > 0) lines.push(rightAlign("", theme.fg("dim", `↑ ${start} more`), width));
     for (let a = start; a < start + visible; a++) {
       const row = rows[a];
+      if (row.kind === "workflow") clickTargets.set(lines.length, row.workflow.id);
       lines.push(
         row.kind === "workflow" ?
           this.renderWorkflowRow(a + 1, sel, row.workflow, width, theme)
@@ -489,6 +512,7 @@ export class FleetList {
     }
     if (hiddenBelow > 0) lines.push(rightAlign("", theme.fg("dim", `↓ ${hiddenBelow} more`), width));
 
+    this.mouse.rendered(lines, clickTargets);
     return lines;
   }
 

--- a/src/ui/fleet-mouse.ts
+++ b/src/ui/fleet-mouse.ts
@@ -1,0 +1,82 @@
+import { stripVTControlCharacters } from "node:util";
+
+type RenderState = { previousLines: string[]; hardwareCursorRow: number; previousWidth: number };
+export type FleetMouseTui = {
+  mode?: string;
+  terminal: { columns: number; write(data: string): void };
+  captureRenderState?(): RenderState;
+  hasOverlay?(): boolean;
+};
+
+/** Mouse hit testing against the main-screen renderer's last painted frame. */
+export class FleetMouse {
+  private tui?: FleetMouseTui;
+  private lines: string[] = [];
+  private targets = new Map<number, string>();
+  private pending?: { y: number; cursor: number; start: number; targets: Map<number, string> };
+  private timeout?: ReturnType<typeof setTimeout>;
+
+  constructor(private open: (id: string) => void) {}
+
+  attach(tui: FleetMouseTui): void {
+    if (this.tui === tui) return;
+    this.dispose();
+    // Fullscreen owns mouse input before extension listeners run. Do not alter
+    // its selection/scrolling modes; keyboard navigation remains available.
+    if (!tui.captureRenderState || !tui.terminal?.write || tui.mode === "fullscreen") return;
+    this.tui = tui;
+    tui.terminal.write("\x1b[?1000;1006s\x1b[?1000;1006h");
+  }
+
+  rendered(lines: string[], targets: Map<number, string>): void {
+    this.lines = lines.map(line => stripVTControlCharacters(line).trimEnd());
+    this.targets = new Map(targets);
+  }
+
+  handleInput(data: string): { consume: true } | undefined {
+    const position = /^\x1b\[(\d+);(\d+)R$/.exec(data);
+    if (position && this.pending) {
+      const pending = this.pending;
+      this.pending = undefined;
+      clearTimeout(this.timeout);
+      // CPR gives the actual screen cursor row. The logical cursor is from
+      // the same paint, so this also works when Pi started below a shell prompt
+      // or content has scrolled above the viewport.
+      const row = pending.y - Number(position[1]) + pending.cursor - pending.start;
+      const id = pending.targets.get(row);
+      if (id !== undefined && !this.tui?.hasOverlay?.()) this.open(id);
+      return { consume: true };
+    }
+    const mouse = /^\x1b\[<(\d+);(\d+);(\d+)([Mm])$/.exec(data);
+    if (!mouse || !this.tui) return;
+    if (this.tui.hasOverlay?.()) return;
+    // Only an unmodified primary press opens a row. Never open on release,
+    // motion, wheel, right click, or a modifier used for native selection.
+    if (mouse[1] !== "0" || mouse[4] !== "M") return { consume: true };
+    if (this.pending) return { consume: true };
+    const state = this.tui.captureRenderState!();
+    if (state.previousWidth !== this.tui.terminal.columns || this.lines.length === 0) return { consume: true };
+    if (Number(mouse[2]) < 1 || Number(mouse[2]) > state.previousWidth) return { consume: true };
+    const painted = state.previousLines.map(line => stripVTControlCharacters(line).trimEnd());
+    let start = -1;
+    for (let i = painted.length - this.lines.length; i >= 0; i--) {
+      if (this.lines.every((line, offset) => painted[i + offset] === line)) { start = i; break; }
+    }
+    if (start < 0) return { consume: true }; // stale/unpainted frame: no guessed target
+    this.pending = { y: Number(mouse[3]), cursor: state.hardwareCursorRow, start, targets: new Map(this.targets) };
+    clearTimeout(this.timeout);
+    this.timeout = setTimeout(() => { this.pending = undefined; }, 500);
+    this.timeout.unref();
+    this.tui.terminal.write("\x1b[6n");
+    return { consume: true };
+  }
+
+  dispose(): void {
+    clearTimeout(this.timeout);
+    this.pending = undefined;
+    this.tui?.terminal.write("\x1b[?1000;1006r");
+    this.tui = undefined;
+    this.lines = [];
+    this.targets.clear();
+  }
+}

--- a/test/fleet-list.test.ts
+++ b/test/fleet-list.test.ts
@@ -618,6 +618,44 @@ describe("FleetList cost display", () => {
  * ------------------------------------------------------------------------- */
 
 describe("FleetList workflow rows", () => {
+  it("opens the painted workflow row on a mouse click while preserving a draft", () => {
+    const h = harness([]);
+    h.setWorkflows([makeWorkflow({ id: "wf_click" })]);
+    h.setEditorText("unfinished prompt");
+    const state = { previousLines: [] as string[], hardwareCursorRow: 0, previousWidth: 120 };
+    const write = vi.fn();
+    Object.assign(h.widgetTui, { captureRenderState: () => state,
+      terminal: { columns: 120, rows: 40, write } });
+    const rows = h.render();
+    state.previousLines = ["before", ...rows, "footer"];
+    expect(h.press("\x1b[<0;8;6M")?.consume).toBe(true);
+    expect(write).toHaveBeenLastCalledWith("\x1b[6n");
+    h.press("\x1b[2;1R");
+    expect(h.openedWorkflows()).toEqual(["wf_click"]);
+    expect(h.ui.getEditorText()).toBe("unfinished prompt");
+    h.fleet.dispose();
+    expect(write).toHaveBeenLastCalledWith("\x1b[?1000;1006r");
+  });
+
+  it("opens the first running workflow directly with Enter at an empty prompt", () => {
+    const h = harness([]);
+    h.setWorkflows([makeWorkflow({ id: "wf_enter" })]);
+    expect(h.press(ENTER)?.consume).toBe(true);
+    expect(h.openedWorkflows()).toEqual(["wf_enter"]);
+  });
+
+  it("does not take Enter from a nonempty draft or another focused component", () => {
+    const h = harness([]);
+    h.setWorkflows([makeWorkflow()]);
+    h.setEditorText("keep this draft");
+    expect(h.press(ENTER)?.consume).toBeFalsy();
+    h.setEditorText("");
+    h.widgetTui.focusedComponent = { kind: "selector" };
+    h.render();
+    expect(h.press(ENTER)?.consume).toBeFalsy();
+    expect(h.openedWorkflows()).toEqual([]);
+  });
+
   it("renders identically with no workflow source and an empty one", () => {
     // The contract: a session without workflows behaves exactly as it did
     // before they existed. Asserted as an equality rather than an absence, so
@@ -699,10 +737,8 @@ describe("FleetList workflow rows", () => {
     const h = harness([]);
     h.setWorkflows([makeWorkflow({ id: "wf_only" })]);
 
-    // The first ↓ moves focus into the list and lands on `main`, as it always
-    // has; the second reaches the only other row.
+    // A workflow is selected immediately, instead of landing on `main`.
     expect(h.press(DOWN)?.consume, "↓ at an empty prompt has somewhere to go").toBe(true);
-    h.press(DOWN);
     h.press(ENTER);
 
     expect(h.openedWorkflows()).toEqual(["wf_only"]);
@@ -718,7 +754,6 @@ describe("FleetList workflow rows", () => {
     h.setWorkflows([makeWorkflow({ id: "wf_pick" })]);
 
     h.press(LEFT);
-    h.press(DOWN);
     h.press(ENTER);
 
     expect(h.openedWorkflows()).toEqual(["wf_pick"]);
@@ -737,7 +772,6 @@ describe("FleetList workflow rows", () => {
     ]);
     h.render();
     h.press(LEFT);
-    h.press(DOWN);
     h.press(DOWN);
     expect(h.openedWorkflows()).toEqual([]);
     h.press(ENTER);
@@ -780,7 +814,6 @@ describe("FleetList workflow rows", () => {
     h.setWorkflows([makeWorkflow()]);
 
     h.press(LEFT);
-    h.press(DOWN);
     h.press(DOWN);
     h.press(ENTER);
 

--- a/test/fleet-mouse.test.ts
+++ b/test/fleet-mouse.test.ts
@@ -1,0 +1,67 @@
+import { afterEach, describe, expect, it, vi } from "vitest";
+import { FleetMouse } from "../src/ui/fleet-mouse.js";
+
+const leases: FleetMouse[] = [];
+afterEach(() => { for (const mouse of leases.splice(0)) mouse.dispose(); });
+
+function harness(prefix = 7) {
+  const open = vi.fn();
+  const write = vi.fn();
+  const rows = ["hint", "", "main", "workflow one", "workflow two"];
+  const state = { previousLines: [...Array<string>(prefix).fill("transcript"), ...rows, "footer"], hardwareCursorRow: prefix - 1, previousWidth: 100 };
+  const tui = { mode: "regular", terminal: { columns: 100, write }, captureRenderState: () => state, hasOverlay: () => false };
+  const mouse = new FleetMouse(open); leases.push(mouse);
+  mouse.attach(tui); mouse.rendered(rows, new Map([[3, "one"], [4, "two"]]));
+  return { mouse, open, write, state, tui };
+}
+
+describe("FleetView mouse hit testing", () => {
+  it.each([0, 7, 70])("uses a painted workflow row with %i preceding rows", prefix => {
+    const h = harness(prefix);
+    // Cursor is one row above the list, at screen row 10. Second workflow is 5 rows below it.
+    h.mouse.handleInput("\x1b[<0;8;15M");
+    expect(h.write).toHaveBeenLastCalledWith("\x1b[6n");
+    h.mouse.handleInput("\x1b[10;1R");
+    expect(h.open).toHaveBeenCalledExactlyOnceWith("two");
+    h.mouse.handleInput("\x1b[<0;8;15m");
+    expect(h.open).toHaveBeenCalledTimes(1);
+  });
+
+  it("does not guess when the visible frame changed or the terminal resized", () => {
+    const h = harness();
+    h.state.previousWidth = 90;
+    h.mouse.handleInput("\x1b[<0;8;15M");
+    expect(h.write).not.toHaveBeenCalledWith("\x1b[6n");
+    h.state.previousWidth = 100; h.state.previousLines = ["another view"];
+    h.mouse.handleInput("\x1b[<0;8;15M");
+    h.mouse.handleInput("\x1b[10;1R");
+    expect(h.open).not.toHaveBeenCalled();
+  });
+
+  it("ignores non-row clicks, modifiers, wheels, and overlays", () => {
+    const h = harness();
+    h.mouse.handleInput("\x1b[<0;8;10M"); h.mouse.handleInput("\x1b[10;1R");
+    for (const button of [2, 4, 8, 16, 32, 64, 65]) h.mouse.handleInput(`\x1b[<${button};8;15M`);
+    h.tui.hasOverlay = () => true;
+    h.mouse.handleInput("\x1b[<0;8;15M"); h.mouse.handleInput("\x1b[10;1R");
+    expect(h.open).not.toHaveBeenCalled();
+  });
+
+  it("restores terminal mouse modes and forgets a pending click on dispose", () => {
+    const h = harness();
+    h.mouse.attach(h.tui);
+    expect(h.write).toHaveBeenCalledTimes(1);
+    h.mouse.handleInput("\x1b[<0;8;15M");
+    h.mouse.dispose();
+    expect(h.write).toHaveBeenLastCalledWith("\x1b[?1000;1006r");
+    h.mouse.handleInput("\x1b[10;1R");
+    expect(h.open).not.toHaveBeenCalled();
+  });
+
+  it("leaves the fullscreen host's mouse ownership alone", () => {
+    const h = harness(); h.mouse.dispose(); h.write.mockClear();
+    h.mouse.attach({ ...h.tui, mode: "fullscreen" });
+    h.mouse.handleInput("\x1b[<0;8;15M");
+    expect(h.write).not.toHaveBeenCalled();
+  });
+});

--- a/test/reload-runs.test.ts
+++ b/test/reload-runs.test.ts
@@ -1,0 +1,85 @@
+import { mkdirSync, mkdtempSync, rmSync, writeFileSync } from "node:fs";
+import { tmpdir } from "node:os";
+import { join } from "node:path";
+import type { ExtensionAPI, ExtensionContext, ToolDefinition } from "@earendil-works/pi-coding-agent";
+import { afterEach, describe, expect, it, vi } from "vitest";
+import subagents from "../src/index.js";
+import { runWorkflow } from "../src/workflow/runtime.js";
+
+vi.mock("../src/workflow/runtime.js", () => ({ runWorkflow: vi.fn() }));
+type Handler = (event: { type: string; reason?: string }, ctx: ExtensionContext) => unknown;
+
+function host(cwd: string, sessionId = "reload-test") {
+  const handlers = new Map<string, Handler[]>();
+  const tools = new Map<string, ToolDefinition>();
+  const inputUnsub = vi.fn();
+  const pi = {
+    on: (event: string, handler: Handler) => handlers.set(event, [...(handlers.get(event) ?? []), handler]),
+    registerTool: (tool: ToolDefinition) => tools.set(tool.name, tool),
+    registerCommand: vi.fn(), registerFlag: vi.fn(), getFlag: vi.fn(),
+    registerMessageRenderer: vi.fn(), registerEntryRenderer: vi.fn(),
+    events: { emit: vi.fn(), on: vi.fn(() => vi.fn()) },
+    sendMessage: vi.fn(), appendEntry: vi.fn(),
+    getAllTools: () => [], getActiveTools: () => [],
+  };
+  const ctx = {
+    cwd, hasUI: true, mode: "rpc", model: undefined,
+    modelRegistry: { find: vi.fn(), getAvailable: () => [] },
+    sessionManager: { getSessionId: () => sessionId, getBranch: () => [] },
+    getSystemPrompt: () => "parent",
+    ui: { setStatus: vi.fn(), setWidget: vi.fn(), notify: vi.fn(),
+      onTerminalInput: vi.fn(() => inputUnsub), getEditorText: () => "", custom: vi.fn() },
+  };
+  return { pi, ctx, tools, inputUnsub,
+    async emit(type: string, reason: string) {
+      for (const handler of handlers.get(type) ?? []) await handler({ type, reason }, ctx as unknown as ExtensionContext);
+    },
+  };
+}
+const active: ReturnType<typeof host>[] = [];
+const dirs: string[] = [];
+afterEach(async () => {
+  for (const h of active.splice(0)) await h.emit("session_shutdown", "quit");
+  for (const dir of dirs.splice(0)) rmSync(dir, { recursive: true, force: true });
+  vi.restoreAllMocks();
+});
+
+describe("workflow reload handoff", () => {
+  it.each([false, true])("keeps a workflow alive and restores delivery (completion during reload: %s)", async (duringReload) => {
+    vi.mocked(runWorkflow).mockReset();
+    const cwd = mkdtempSync(join(tmpdir(), "pi-reload-")); dirs.push(cwd);
+    mkdirSync(join(cwd, ".pi"));
+    writeFileSync(join(cwd, ".pi/subagents.json"), JSON.stringify({ schedulingEnabled: false }));
+    let resolveRun!: (value: Awaited<ReturnType<typeof runWorkflow>>) => void;
+    vi.mocked(runWorkflow).mockImplementation(() => new Promise(resolve => { resolveRun = resolve; }));
+    const first = host(cwd); active.push(first);
+    subagents(first.pi as unknown as ExtensionAPI);
+    await first.emit("session_start", "startup");
+    const tool = first.tools.get("SubagentWorkflow")!;
+    const result = await tool.execute("test-call", { script: 'export const meta = { name: "Reload proof", description: "reload test" }; return "ok";' }, undefined, undefined, first.ctx as unknown as ExtensionContext);
+    expect(result.details, JSON.stringify(result.content)).toBeDefined();
+    const runOptions = vi.mocked(runWorkflow).mock.calls[0][0];
+    expect(first.ctx.ui.setWidget).toHaveBeenCalledWith("fleet", expect.any(Function), { placement: "belowEditor" });
+    const oldMessageCount = first.pi.sendMessage.mock.calls.length;
+    await first.emit("session_shutdown", "reload");
+    active.splice(active.indexOf(first), 1);
+    expect(runOptions.signal?.aborted).toBe(false);
+    const complete = () => resolveRun({ status: "completed", value: "ok", meta: { name: "Reload proof", description: "reload test" }, agentCount: 0, replayedCount: 0 } as Awaited<ReturnType<typeof runWorkflow>>);
+    if (duringReload) {
+      complete();
+      await new Promise(resolve => setTimeout(resolve, 250));
+      expect(first.pi.sendMessage).toHaveBeenCalledTimes(oldMessageCount);
+    }
+
+    const second = host(cwd); active.push(second);
+    subagents(second.pi as unknown as ExtensionAPI);
+    await second.emit("session_start", "reload");
+    expect(second.ctx.ui.setWidget).toHaveBeenCalledWith("fleet", expect.any(Function), { placement: "belowEditor" });
+    expect(runWorkflow).toHaveBeenCalledTimes(1);
+    if (!duringReload) complete();
+    await vi.waitFor(() => expect(second.pi.sendMessage).toHaveBeenCalled());
+    expect(first.pi.sendMessage).toHaveBeenCalledTimes(oldMessageCount);
+    await second.emit("session_shutdown", "quit");
+    expect(runOptions.signal?.aborted).toBe(true);
+  });
+});

--- a/test/reload-session.test.ts
+++ b/test/reload-session.test.ts
@@ -1,0 +1,54 @@
+import { mkdtempSync, rmSync } from "node:fs";
+import { tmpdir } from "node:os";
+import { join } from "node:path";
+import { createAgentSession, DefaultResourceLoader, SessionManager, SettingsManager } from "@earendil-works/pi-coding-agent";
+import { expect, it, vi } from "vitest";
+import subagents from "../src/index.js";
+import { runWorkflow } from "../src/workflow/runtime.js";
+import { fauxModelBackend } from "./helpers/faux-model-backend.js";
+import { registerFauxProvider } from "./helpers/pi-ai.js";
+
+vi.mock("../src/workflow/runtime.js", () => ({ runWorkflow: vi.fn() }));
+
+it("crosses real AgentSession.reload twice without stale context/API calls", async () => {
+  const dir = mkdtempSync(join(tmpdir(), "pi-reload-host-"));
+  const faux = registerFauxProvider({ provider: "faux", models: [{ id: "faux-1", contextWindow: 200_000 }] });
+  const model = faux.getModel();
+  const loader = new DefaultResourceLoader({ cwd: dir, agentDir: dir, noExtensions: true,
+    noSkills: true, noPromptTemplates: true, noThemes: true, noContextFiles: true,
+    extensionFactories: [subagents] });
+  await loader.reload();
+  const { session } = await createAgentSession({ cwd: dir, agentDir: dir, model,
+    ...fauxModelBackend(model), resourceLoader: loader, sessionManager: SessionManager.inMemory(dir),
+    settingsManager: SettingsManager.inMemory({ compaction: { enabled: false }, retry: { enabled: false } }) });
+  let release!: (value: Awaited<ReturnType<typeof runWorkflow>>) => void;
+  vi.mocked(runWorkflow).mockImplementation(() => new Promise(resolve => { release = resolve; }));
+  const errors: string[] = [];
+  try {
+    await session.bindExtensions({ onError: error => errors.push(error.message) });
+    const ctx = session.extensionRunner!.createContext();
+    const tool = loader.getExtensions().extensions.flatMap(extension => [...extension.tools.values()])
+      .find(tool => tool.definition.name === "SubagentWorkflow")!.definition;
+    await tool.execute("call", { script: 'export const meta = {name: "test", description: "test"}; return 1;' }, undefined, undefined, ctx);
+    const options = vi.mocked(runWorkflow).mock.calls[0][0];
+    await session.reload();
+    expect(options.signal?.aborted).toBe(false);
+    expect(() => ctx.cwd).toThrow(); // This is a real stale host context.
+    // A gate launched after reload reads the workflow's captured context and
+    // calls the extension API. Both must now resolve to the new host runtime.
+    const gate = await options.host.runGate?.("printf reload-ok", {});
+    expect(gate).toMatchObject({ ok: true, output: "reload-ok" });
+    await session.reload();
+    const secondGate = await options.host.runGate?.("printf twice-ok", {});
+    expect(secondGate).toMatchObject({ ok: true, output: "twice-ok" });
+    expect(options.signal?.aborted).toBe(false);
+    release({ status: "completed", value: "ok", meta: { name: "test", description: "test" }, agentCount: 0, replayedCount: 0 } as Awaited<ReturnType<typeof runWorkflow>>);
+    await vi.waitFor(() => expect(session.state.messages.some(message => message.role === "custom" && message.customType === "subagent-notification")).toBe(true));
+    expect(errors).toEqual([]);
+  } finally {
+    await session.extensionRunner?.emit({ type: "session_shutdown", reason: "quit" });
+    session.dispose();
+    faux.unregister();
+    rmSync(dir, { recursive: true, force: true });
+  }
+}, 15_000);


### PR DESCRIPTION
Preserve access to a running workflow across same-process reload and make its FleetView inspector directly reachable. Closes #294. Draft for design review.

## Summary

- `/reload` currently aborts workflows and drops the FleetView roster because shutdown handles reload like quit.
- Enter at an empty prompt does not open a workflow; initial arrow navigation selects `main`. Workflow rows have no mouse activation.

## What changed

- Retain the active extension closure by cwd/session identity during reload. Rebind its API, context, lifecycle handlers and tool callbacks to the replacement host; queue completion messages and commands while detached. Idle reload creates a fresh runtime.
- Detach UI/input listeners during reload, then rebuild FleetView and the agent widget. Quit/session replacement retain teardown behavior. A missing replacement is disposed after 30 seconds.
- Enter at an empty prompt opens the first workflow; arrow activation selects it. Regular-terminal primary clicks resolve a workflow ID from the painted frame and a cursor-position response, then open the existing inspector. Failed opens notify rather than silently disappearing.
- Document the behavior and add lifecycle, real SDK reload, keyboard, mouse-target and input-ownership regression coverage.

## Related work

States as of opening.

| Item | State | Relation |
| --- | --- | --- |
| #256 — session_shutdown leaves widget and group timers active | Open | Same cleanup area. This adds teardown on quit and UI detachment on reload, but deliberately retains task-owned timers for a reload handoff; does not close the broader issue. |
| #290 — fix: harden abort and resume lifecycle paths | Open | Related stop/resume work in the manager/runner and `src/index.ts`; not superseded. |

## Behavior and compatibility

No tool schema or RPC channel change. Enter on a nonempty draft still submits normally; other focused dialogs retain input. Regular-terminal mouse reporting is saved/enabled while FleetView is present and restored on disposal; Shift retains native terminal selection. Fullscreen keeps host-owned mouse behavior and uses keyboard activation.

This is in-process continuity, not crash/restart persistence. Executing code is retained while work is active; reload while idle or start a new session to replace that code. If the plugin is removed or fails to reattach within 30 seconds, retained work is stopped. The 30-second policy and mouse interaction are included for maintainer review.

## Performance

Not benchmarked. The handoff retains one runtime per cwd/session while awaiting reattachment. Mouse hit testing scans the last painted frame on primary clicks, not on each render tick. No measured performance claim.

## Testing

- `npm run check`: lint and typecheck passed; 108 test files passed, 2142 tests passed, 7 skipped.
- `npm run build`: passed.
- `npm run test:e2e`: 15 test files passed, 68 tests passed, 7 skipped; scripted/faux tests, no live model calls.
- Four targeted mutations caught: removing the reload abort guard, retaining the stale host API, disabling direct Enter activation, and disabling mouse row targeting. Sources restored.
- Local real Pi 0.85.0 PTY probe: Enter and SGR primary-click events opened the running workflow inspector; `/reload` preserved the worker and reopened inspector. This used a terminal emulator responding to cursor queries, not a physical mouse.

Not covered by the local PTY probe: fullscreen mouse activation (unsupported), Windows/remote terminal combinations, or persistence across process restart. Remote CI results are separate from these local results.
